### PR TITLE
Fix parallel test flakiness: remove unsound global buffer clearing

### DIFF
--- a/ir/src/test/unit/uop.rs
+++ b/ir/src/test/unit/uop.rs
@@ -9,11 +9,6 @@ use morok_dtype::DeviceSpec;
 
 use crate::{AxisId, ConstValue, Op, UOp}; // ConstValue kept for DType::Index
 
-// Mutex to serialize tests that clear the global UOp cache.
-// Without this, parallel test execution causes races where one test clears
-// the cache while another test is creating UOps.
-static CACHE_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 #[test]
 fn test_const_creation() {
     let c1 = UOp::native_const(1.0f32);
@@ -52,9 +47,6 @@ fn test_hash_consing_with_src() {
 fn test_cross_thread_hash_consing() {
     use std::sync::Barrier;
 
-    // Serialize tests that manipulate cache to prevent races with parallel test execution
-    let _lock = CACHE_TEST_MUTEX.lock().unwrap();
-
     let num_threads = 10;
     let barrier = Arc::new(Barrier::new(num_threads));
 
@@ -90,9 +82,6 @@ fn test_cross_thread_hash_consing() {
 #[test]
 fn test_cross_thread_hash_consing_complex() {
     use std::sync::Barrier;
-
-    // Serialize tests that manipulate cache to prevent races with parallel test execution
-    let _lock = CACHE_TEST_MUTEX.lock().unwrap();
 
     let num_threads = 8;
     let barrier = Arc::new(Barrier::new(num_threads));

--- a/tensor/src/test/unit/realize_binary.rs
+++ b/tensor/src/test/unit/realize_binary.rs
@@ -15,7 +15,7 @@ use crate::{
 #[test]
 // #[tracing_test::traced_test]
 fn test_add_f32_simple() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([4.0f32, 5.0, 6.0]);
     let c = &a + &b;
@@ -40,7 +40,7 @@ fn test_add_f32_simple() {
 
 #[test]
 fn test_add_f32_negative() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([-1.0f32, -2.0, -3.0]);
     let b = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let c = &a + &b;
@@ -53,7 +53,7 @@ fn test_add_f32_negative() {
 
 #[test]
 fn test_add_f32_zero() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([0.0f32, 0.0, 0.0]);
     let c = &a + &b;
@@ -66,7 +66,7 @@ fn test_add_f32_zero() {
 
 #[test]
 fn test_add_f32_large_values() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1e6f32, 2e6, 3e6]);
     let b = Tensor::from_slice([4e6f32, 5e6, 6e6]);
     let c = &a + &b;
@@ -83,7 +83,7 @@ fn test_add_f32_large_values() {
 
 #[test]
 fn test_sub_f32_simple() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([5.0f32, 6.0, 7.0]);
     let b = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let c = &a - &b;
@@ -96,7 +96,7 @@ fn test_sub_f32_simple() {
 
 #[test]
 fn test_sub_f32_negative_result() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([5.0f32, 6.0, 7.0]);
     let c = &a - &b;
@@ -109,7 +109,7 @@ fn test_sub_f32_negative_result() {
 
 #[test]
 fn test_sub_f32_zero() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let c = &a - &b;
@@ -126,7 +126,7 @@ fn test_sub_f32_zero() {
 
 #[test]
 fn test_mul_f32_simple() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([2.0f32, 3.0, 4.0]);
     let b = Tensor::from_slice([5.0f32, 6.0, 7.0]);
     let c = &a * &b;
@@ -139,7 +139,7 @@ fn test_mul_f32_simple() {
 
 #[test]
 fn test_mul_f32_by_zero() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([0.0f32, 0.0, 0.0]);
     let c = &a * &b;
@@ -152,7 +152,7 @@ fn test_mul_f32_by_zero() {
 
 #[test]
 fn test_mul_f32_negative() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([2.0f32, -3.0, 4.0]);
     let b = Tensor::from_slice([-5.0f32, 6.0, -7.0]);
     let c = &a * &b;
@@ -165,7 +165,7 @@ fn test_mul_f32_negative() {
 
 #[test]
 fn test_mul_f32_fractional() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([0.5f32, 0.25, 0.125]);
     let b = Tensor::from_slice([2.0f32, 4.0, 8.0]);
     let c = &a * &b;
@@ -182,7 +182,7 @@ fn test_mul_f32_fractional() {
 
 #[test]
 fn test_div_f32_simple() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([10.0f32, 20.0, 30.0]);
     let b = Tensor::from_slice([2.0f32, 4.0, 5.0]);
     let c = &a / &b;
@@ -195,7 +195,7 @@ fn test_div_f32_simple() {
 
 #[test]
 fn test_div_f32_by_one() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([1.0f32, 1.0, 1.0]);
     let c = &a / &b;
@@ -208,7 +208,7 @@ fn test_div_f32_by_one() {
 
 #[test]
 fn test_div_f32_fractional() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([1.0f32, 1.0, 1.0]);
     let b = Tensor::from_slice([2.0f32, 4.0, 8.0]);
     let c = &a / &b;
@@ -221,7 +221,7 @@ fn test_div_f32_fractional() {
 
 #[test]
 fn test_div_f32_negative() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([10.0f32, -20.0, 30.0]);
     let b = Tensor::from_slice([-2.0f32, 4.0, -5.0]);
     let c = &a / &b;
@@ -238,7 +238,7 @@ fn test_div_f32_negative() {
 
 #[test]
 fn test_pow_f32_simple() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([2.0f32, 3.0, 4.0]);
     let b = Tensor::from_slice([2.0f32, 2.0, 2.0]);
     let c = a.try_pow(&b).unwrap();
@@ -252,7 +252,7 @@ fn test_pow_f32_simple() {
 
 #[test]
 fn test_pow_f32_zero_exponent() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([2.0f32, 3.0, 4.0]);
     let b = Tensor::from_slice([0.0f32, 0.0, 0.0]);
     let c = a.try_pow(&b).unwrap();
@@ -266,7 +266,7 @@ fn test_pow_f32_zero_exponent() {
 
 #[test]
 fn test_pow_f32_one_exponent() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([2.0f32, 3.0, 4.0]);
     let b = Tensor::from_slice([1.0f32, 1.0, 1.0]);
     let c = a.try_pow(&b).unwrap();
@@ -280,7 +280,7 @@ fn test_pow_f32_one_exponent() {
 
 #[test]
 fn test_pow_f32_fractional_exponent() {
-    let _guard = test_setup();
+    test_setup();
     let a = Tensor::from_slice([4.0f32, 9.0, 16.0]);
     let b = Tensor::from_slice([0.5f32, 0.5, 0.5]);
     let c = a.try_pow(&b).unwrap();
@@ -294,7 +294,7 @@ fn test_pow_f32_fractional_exponent() {
 
 #[test]
 fn test_pow_f32_negative_base() {
-    let _guard = test_setup();
+    test_setup();
     // Note: (-x)^y is complex for non-integer y, but for integer y it works
     let a = Tensor::from_slice([-2.0f32, -3.0, -4.0]);
     let b = Tensor::from_slice([2.0f32, 2.0, 2.0]);
@@ -313,7 +313,7 @@ fn test_pow_f32_negative_base() {
 
 #[test]
 fn test_chained_add_mul() {
-    let _guard = test_setup();
+    test_setup();
     // (a + b) * c
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
     let b = Tensor::from_slice([4.0f32, 5.0, 6.0]);
@@ -330,7 +330,7 @@ fn test_chained_add_mul() {
 
 #[test]
 fn test_chained_mul_add() {
-    let _guard = test_setup();
+    test_setup();
     // a * b + c
     let a = Tensor::from_slice([2.0f32, 3.0, 4.0]);
     let b = Tensor::from_slice([5.0f32, 6.0, 7.0]);
@@ -347,7 +347,7 @@ fn test_chained_mul_add() {
 
 #[test]
 fn test_chained_sub_div() {
-    let _guard = test_setup();
+    test_setup();
     // (a - b) / c
     let a = Tensor::from_slice([10.0f32, 20.0, 30.0]);
     let b = Tensor::from_slice([2.0f32, 4.0, 6.0]);
@@ -364,7 +364,7 @@ fn test_chained_sub_div() {
 
 #[test]
 fn test_complex_expression() {
-    let _guard = test_setup();
+    test_setup();
     // ((a + b) * c - d) / e
     let a = Tensor::from_slice([1.0f32, 2.0]);
     let b = Tensor::from_slice([3.0f32, 4.0]);

--- a/tensor/src/test/unit/reduce.rs
+++ b/tensor/src/test/unit/reduce.rs
@@ -295,7 +295,7 @@ fn test_argmax_all_equal() {
 
 #[test]
 fn test_sum_1d_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0]);
     let result = realize_f32(t.sum(()).unwrap());
     assert_close_f32(&result, &[10.0], 1e-6);
@@ -303,7 +303,7 @@ fn test_sum_1d_value() {
 
 #[test]
 fn test_sum_2d_full_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.sum(()).unwrap());
     assert_close_f32(&result, &[21.0], 1e-6);
@@ -311,7 +311,7 @@ fn test_sum_2d_full_value() {
 
 #[test]
 fn test_sum_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.sum(0).unwrap());
     // [[1, 2, 3], [4, 5, 6]] -> [1+4, 2+5, 3+6] = [5, 7, 9]
@@ -321,7 +321,7 @@ fn test_sum_axis0_value() {
 #[test]
 #[tracing_test::traced_test]
 fn test_sum_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.sum(1).unwrap());
     // [[1, 2, 3], [4, 5, 6]] -> [1+2+3, 4+5+6] = [6, 15]
@@ -331,7 +331,7 @@ fn test_sum_axis1_value() {
 #[test]
 #[tracing_test::traced_test]
 fn test_sum_keepdim_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0]).try_reshape(&[2, 2]).unwrap();
     let result = t.sum_with().axes(1).keepdim(true).call().unwrap();
     let arr = realize_f32(result);
@@ -342,7 +342,7 @@ fn test_sum_keepdim_value() {
 
 #[test]
 fn test_sum_single_element_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([42.0f32]);
     let result = realize_f32(t.sum(()).unwrap());
     assert_close_f32(&result, &[42.0], 1e-6);
@@ -350,7 +350,7 @@ fn test_sum_single_element_value() {
 
 #[test]
 fn test_sum_negative_values() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([-1.0f32, -2.0, 3.0, 4.0]);
     let result = realize_f32(t.sum(()).unwrap());
     assert_close_f32(&result, &[4.0], 1e-6);
@@ -360,7 +360,7 @@ fn test_sum_negative_values() {
 
 #[test]
 fn test_max_1d_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 5.0, 3.0, 2.0]);
     let result = realize_f32(t.max(()).unwrap());
     assert_close_f32(&result, &[5.0], 1e-6);
@@ -368,7 +368,7 @@ fn test_max_1d_value() {
 
 #[test]
 fn test_max_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 5.0, 3.0, 2.0, 8.0, 4.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.max(1).unwrap());
     // [[1, 5, 3], [2, 8, 4]] -> [5, 8]
@@ -377,7 +377,7 @@ fn test_max_2d_axis1_value() {
 
 #[test]
 fn test_max_2d_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 5.0, 3.0, 2.0, 8.0, 4.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.max(0).unwrap());
     // [[1, 5, 3], [2, 8, 4]] -> [2, 8, 4]
@@ -386,7 +386,7 @@ fn test_max_2d_axis0_value() {
 
 #[test]
 fn test_max_negative_values() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([-5.0f32, -1.0, -3.0, -2.0]);
     let result = realize_f32(t.max(()).unwrap());
     assert_close_f32(&result, &[-1.0], 1e-6);
@@ -396,7 +396,7 @@ fn test_max_negative_values() {
 
 #[test]
 fn test_min_1d_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([5.0f32, 1.0, 3.0, 2.0]);
     let result = realize_f32(t.min(()).unwrap());
     assert_close_f32(&result, &[1.0], 1e-6);
@@ -404,7 +404,7 @@ fn test_min_1d_value() {
 
 #[test]
 fn test_min_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 5.0, 3.0, 2.0, 8.0, 4.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.min(1).unwrap());
     // [[1, 5, 3], [2, 8, 4]] -> [1, 2]
@@ -413,7 +413,7 @@ fn test_min_2d_axis1_value() {
 
 #[test]
 fn test_min_negative_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([-1.0f32, -5.0, -3.0]);
     let result = realize_f32(t.min(()).unwrap());
     assert_close_f32(&result, &[-5.0], 1e-6);
@@ -424,7 +424,7 @@ fn test_min_negative_value() {
 #[test]
 #[tracing_test::traced_test]
 fn test_argmax_debug_steps() {
-    let _guard = test_setup();
+    test_setup();
 
     // Simplest test: compare two tensors
     let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
@@ -475,7 +475,7 @@ fn test_argmax_debug_steps() {
 #[test]
 
 fn test_argmax_full_steps() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 5.0, 4.0]);
 
     // Step 1: max value along axis 0
@@ -529,7 +529,7 @@ fn test_argmax_full_steps() {
 
 #[test]
 fn test_argmax_value_1d() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 5.0, 4.0]);
     let result = realize_i32(t.argmax(Some(0)).unwrap());
     // Max 5.0 at index 3
@@ -538,7 +538,7 @@ fn test_argmax_value_1d() {
 
 #[test]
 fn test_argmax_ties_first_value() {
-    let _guard = test_setup();
+    test_setup();
     // Tinygrad test: [2, 2] -> should return 0 (first occurrence)
     let t = Tensor::from_slice([2.0f32, 2.0]);
     let result = realize_i32(t.argmax(Some(0)).unwrap());
@@ -547,7 +547,7 @@ fn test_argmax_ties_first_value() {
 
 #[test]
 fn test_argmax_2d_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 4.0, 2.0, 5.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_i32(t.argmax(Some(0)).unwrap());
     // [[1, 3, 2], [4, 2, 5]]
@@ -557,7 +557,7 @@ fn test_argmax_2d_axis0_value() {
 
 #[test]
 fn test_argmax_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 4.0, 2.0, 5.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_i32(t.argmax(Some(1)).unwrap());
     // [[1, 3, 2], [4, 2, 5]]
@@ -567,7 +567,7 @@ fn test_argmax_2d_axis1_value() {
 
 #[test]
 fn test_argmax_flatten_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 4.0, 2.0, 5.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_i32(t.argmax(None).unwrap());
     // Flattened: [1, 3, 2, 4, 2, 5], max 5.0 at index 5
@@ -579,7 +579,7 @@ fn test_argmax_flatten_value() {
 #[test]
 
 fn test_argmin_value_1d() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([5.0f32, 3.0, 1.0, 4.0, 2.0]);
     let result = realize_i32(t.argmin(Some(0)).unwrap());
     // Min 1.0 at index 2
@@ -588,7 +588,7 @@ fn test_argmin_value_1d() {
 
 #[test]
 fn test_argmin_negative_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.5f32, -2.3, 0.5, 1.0]);
     let result = realize_i32(t.argmin(Some(0)).unwrap());
     // Min -2.3 at index 1
@@ -597,7 +597,7 @@ fn test_argmin_negative_value() {
 
 #[test]
 fn test_argmin_2d_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 4.0, 2.0, 5.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_i32(t.argmin(Some(0)).unwrap());
     // [[1, 3, 2], [4, 2, 5]]
@@ -608,7 +608,7 @@ fn test_argmin_2d_axis0_value() {
 #[test]
 
 fn test_argmin_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 3.0, 2.0, 4.0, 2.0, 5.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_i32(t.argmin(Some(1)).unwrap());
     // [[1, 3, 2], [4, 2, 5]]
@@ -620,7 +620,7 @@ fn test_argmin_2d_axis1_value() {
 
 #[test]
 fn test_mean_1d_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0]);
     let result = realize_f32(t.mean(()).unwrap());
     assert_close_f32(&result, &[2.5], 1e-6);
@@ -628,7 +628,7 @@ fn test_mean_1d_value() {
 
 #[test]
 fn test_mean_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.mean(1).unwrap());
     // [[1, 2, 3], [4, 5, 6]] -> [mean(1,2,3), mean(4,5,6)] = [2, 5]
@@ -637,7 +637,7 @@ fn test_mean_2d_axis1_value() {
 
 #[test]
 fn test_mean_2d_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]).try_reshape(&[2, 3]).unwrap();
     let result = realize_f32(t.mean(0).unwrap());
     // [[1, 2, 3], [4, 5, 6]] -> [mean(1,4), mean(2,5), mean(3,6)] = [2.5, 3.5, 4.5]
@@ -648,7 +648,7 @@ fn test_mean_2d_axis0_value() {
 
 #[test]
 fn test_any_value_all_true() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, true, true]);
     let result = t.any(()).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     assert!(result[[]]);
@@ -656,7 +656,7 @@ fn test_any_value_all_true() {
 
 #[test]
 fn test_any_value_one_true() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([false, true, false]);
     let result = t.any(()).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     assert!(result[[]]);
@@ -664,7 +664,7 @@ fn test_any_value_one_true() {
 
 #[test]
 fn test_any_value_all_false() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([false, false, false]);
     let result = t.any(()).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     assert!(!result[[]]);
@@ -672,7 +672,7 @@ fn test_any_value_all_false() {
 
 #[test]
 fn test_any_2d_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, false, false, true]).try_reshape(&[2, 2]).unwrap();
     let result = t.any(0).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     // [[true, false], [false, true]] -> any along axis 0 -> [true, true]
@@ -681,7 +681,7 @@ fn test_any_2d_axis0_value() {
 
 #[test]
 fn test_any_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, false, false, false]).try_reshape(&[2, 2]).unwrap();
     let result = t.any(1).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     // [[true, false], [false, false]] -> any along axis 1 -> [true, false]
@@ -692,7 +692,7 @@ fn test_any_2d_axis1_value() {
 
 #[test]
 fn test_all_value_all_true() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, true, true]);
     let result = t.all(()).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     assert!(result[[]]);
@@ -700,7 +700,7 @@ fn test_all_value_all_true() {
 
 #[test]
 fn test_all_value_one_false() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, false, true]);
     let result = t.all(()).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     assert!(!result[[]]);
@@ -708,7 +708,7 @@ fn test_all_value_one_false() {
 
 #[test]
 fn test_all_value_all_false() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([false, false, false]);
     let result = t.all(()).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     assert!(!result[[]]);
@@ -717,7 +717,7 @@ fn test_all_value_all_false() {
 #[test]
 // #[tracing_test::traced_test]
 fn test_all_2d_axis0_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, true, false, true]).try_reshape(&[2, 2]).unwrap();
     let result = t.all(0).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     // [[true, true], [false, true]] -> all along axis 0 -> [false, true]
@@ -727,7 +727,7 @@ fn test_all_2d_axis0_value() {
 #[test]
 
 fn test_all_2d_axis1_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([true, true, true, false]).try_reshape(&[2, 2]).unwrap();
     let result = t.all(1).unwrap().realize().unwrap().to_ndarray::<bool>().unwrap();
     // [[true, true], [true, false]] -> all along axis 1 -> [true, false]
@@ -738,7 +738,7 @@ fn test_all_2d_axis1_value() {
 
 #[test]
 fn test_argmax_single_element_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([42.0f32]);
     let result = realize_i32(t.argmax(Some(0)).unwrap());
     // Only element, index should be 0
@@ -747,7 +747,7 @@ fn test_argmax_single_element_value() {
 
 #[test]
 fn test_argmax_all_equal_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([5.0f32, 5.0, 5.0, 5.0]);
     let result = realize_i32(t.argmax(Some(0)).unwrap());
     // All equal, should return first index (0)
@@ -756,7 +756,7 @@ fn test_argmax_all_equal_value() {
 
 #[test]
 fn test_argmin_single_element_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([42.0f32]);
     let result = realize_i32(t.argmin(Some(0)).unwrap());
     // Only element, index should be 0
@@ -765,7 +765,7 @@ fn test_argmin_single_element_value() {
 
 #[test]
 fn test_max_single_element_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([42.0f32]);
     let result = realize_f32(t.max(()).unwrap());
     assert_close_f32(&result, &[42.0], 1e-6);
@@ -773,7 +773,7 @@ fn test_max_single_element_value() {
 
 #[test]
 fn test_min_single_element_value() {
-    let _guard = test_setup();
+    test_setup();
     let t = Tensor::from_slice([42.0f32]);
     let result = realize_f32(t.min(()).unwrap());
     assert_close_f32(&result, &[42.0], 1e-6);
@@ -781,7 +781,7 @@ fn test_min_single_element_value() {
 
 #[test]
 fn test_debug_argmin_intermediate() {
-    let _guard = test_setup();
+    test_setup();
     let values = Tensor::from_slice([5.0f32, 3.0, 1.0, 4.0, 2.0]);
 
     // Test neg first - does it produce correct values?
@@ -809,7 +809,7 @@ fn test_debug_argmin_intermediate() {
 #[test]
 
 fn test_debug_lazy_neg_max() {
-    let _guard = test_setup();
+    test_setup();
     let values = Tensor::from_slice([5.0f32, 3.0, 1.0, 4.0, 2.0]);
 
     // Test max of lazy negated values
@@ -824,7 +824,7 @@ fn test_debug_lazy_neg_max() {
 #[test]
 
 fn test_debug_lazy_neg_argmax() {
-    let _guard = test_setup();
+    test_setup();
     let values = Tensor::from_slice([5.0f32, 3.0, 1.0, 4.0, 2.0]);
 
     // Chain neg and argmax LAZILY (like argmin does internally)
@@ -840,7 +840,7 @@ fn test_indices_cast_bug() {
     use crate::Tensor;
     use morok_dtype::DType;
 
-    let _guard = crate::test::helpers::test_setup();
+    crate::test::helpers::test_setup();
 
     // Create indices tensor [5, 4, 3, 2, 1]
     let indices = Tensor::arange(5, Some(0), Some(-1)).unwrap();

--- a/tensor/src/test/unit/shared_subgraph.rs
+++ b/tensor/src/test/unit/shared_subgraph.rs
@@ -22,7 +22,7 @@ use test_case::test_case;
 #[test_case(2 ; "N=2")]
 #[test_case(4 ; "N=4")]
 fn test_realized_matrix_matmul(n: usize) {
-    let _guard = test_setup();
+    test_setup();
 
     let data: Vec<f32> = (0..n * n).map(|i| i as f32 * 0.1).collect();
     let matrix = Tensor::from_slice(&data).try_reshape(&[n as isize, n as isize]).unwrap();
@@ -41,7 +41,7 @@ fn test_realized_matrix_matmul(n: usize) {
 #[test_case(2 ; "N=2")]
 #[test_case(4 ; "N=4")]
 fn test_unary_on_buffer_rooted_matmul(n: usize) {
-    let _guard = test_setup();
+    test_setup();
 
     let data: Vec<f32> = (0..n * n).map(|i| i as f32 * 0.1).collect();
     let matrix = Tensor::from_slice(&data).try_reshape(&[n as isize, n as isize]).unwrap().cos().unwrap();
@@ -58,7 +58,7 @@ fn test_unary_on_buffer_rooted_matmul(n: usize) {
 /// Element-wise diamond (no matmul): cos(t) + sin(t). Always works.
 #[test]
 fn test_diamond_elementwise_no_matmul() {
-    let _guard = test_setup();
+    test_setup();
 
     let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0]).try_reshape(&[2, 2]).unwrap();
 
@@ -80,7 +80,7 @@ fn test_diamond_elementwise_no_matmul() {
 #[test_case(2 ; "N=2")]
 #[test_case(4 ; "N=4")]
 fn test_lazy_outer_product_matmul(n: usize) {
-    let _guard = test_setup();
+    test_setup();
 
     let indices = Tensor::arange(n as i64, None, None).unwrap().cast(DType::Float32).unwrap();
     let k = indices.try_reshape(&[n as isize, 1]).unwrap();
@@ -100,7 +100,7 @@ fn test_lazy_outer_product_matmul(n: usize) {
 #[test_case(2 ; "N=2")]
 #[test_case(4 ; "N=4")]
 fn test_lazy_outer_product_unary_matmul(n: usize) {
-    let _guard = test_setup();
+    test_setup();
 
     let indices = Tensor::arange(n as i64, None, None).unwrap().cast(DType::Float32).unwrap();
     let k = indices.try_reshape(&[n as isize, 1]).unwrap();
@@ -121,7 +121,7 @@ fn test_lazy_outer_product_unary_matmul(n: usize) {
 #[test_case(2 ; "N=2")]
 #[test_case(4 ; "N=4")]
 fn test_dft_pattern(n: usize) {
-    let _guard = test_setup();
+    test_setup();
 
     let indices = Tensor::arange(n as i64, None, None).unwrap().cast(DType::Float32).unwrap();
     let k = indices.try_reshape(&[n as isize, 1]).unwrap();


### PR DESCRIPTION
## Summary
- Remove `clear_buffer_index()` from `test_setup()` — it wiped the global BUFFERS map mid-`realize()` in concurrent tests
- Remove dead code: `UOP_TO_TENSOR` secondary index, `clear_all()`, `remove_tensor()`, `CACHE_TEST_MUTEX`
- Simplify `test_setup()` to only clear kernel cache (the sole non-RAII global state)

Buffer UOp IDs are globally unique (`Op::Unique` monotonic counter), so entries never collide across tests. Stale entries cleaned by `gc_dead_refs()`.

## Test plan
- [x] `cargo t -p morok-tensor` — 295 passed, 1 pre-existing failure (`test_beam_search_matmul`)
- [x] `cargo t -p morok-tensor -- --test-threads=1` — same results
- [x] `cargo t -p morok-ir` — 412 passed
- [x] `cargo clippy` / `cargo fmt` — clean