### PR TITLE
Fix PTRCAT broadcast grouping, auto-dtype, and LOAD guard

### DIFF
--- a/ir/src/uop/constructors/hardware.rs
+++ b/ir/src/uop/constructors/hardware.rs
@@ -250,7 +250,13 @@ impl UOp {
         assert!(!sources.is_empty(), "PTRCAT requires at least one source");
         let dtype = dtype.unwrap_or_else(|| {
             // Compute vcount from total source pointer vcount, matching CAT's approach.
-            let total_vcount: usize = sources.iter().map(|s| s.dtype().vcount()).sum();
+            let total_vcount: usize = sources
+                .iter()
+                .map(|s| match s.dtype() {
+                    DType::Ptr { base, .. } => base.vcount(),
+                    other => other.vcount(),
+                })
+                .sum();
             let base = &sources[0].dtype;
             match base {
                 DType::Ptr { base, addrspace, size, .. } => {


### PR DESCRIPTION
## Summary
- Fix broadcast grouping bug: lanes reading the same address now produce scalar PTRCAT + GEP broadcast instead of incorrect contiguous vector load
- Fix PTRCAT auto-dtype to use `base.vcount()` for Ptr types
- Add `alt: None` guard to `distribute_ptrcat_load`
- Add broadcast tests (pure, partial, mixed)