### PR TITLE
Auto-generate introduction.md from README, add example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let a = Tensor::from_ndarray(&array![[1.0f32, 2.0], [3.0, 4.0]]);
 let b = Tensor::from_ndarray(&array![[5.0f32, 6.0], [7.0, 8.0]]);
 
 // Lazy — nothing executes yet
-let c = (&a + &b)?;
+let c = &a + &b;
 
 // Compile, execute, extract as ndarray
 let result = c.to_ndarray::<f32>()?;
@@ -64,8 +64,8 @@ let optimizer = patterns! {
 
     // Constant folding
     for op in binary [Add, Mul, Sub] {
-        op(a @const(av), b @const(bv))
-          => eval_binary_op(op, av, bv).map(|r| UOp::const_(a.dtype(), r)),
+        op(a @const(av), _b @const(bv))
+          => |a, av, bv| eval_binary_op(op, av, bv).map(|r| UOp::const_(a.dtype(), r)),
     },
 };
 ```

--- a/tensor/src/test/unit/mod.rs
+++ b/tensor/src/test/unit/mod.rs
@@ -12,6 +12,7 @@ pub mod indexing;
 pub mod math;
 pub mod matmul;
 pub mod nn;
+pub mod readme_examples;
 pub mod realize_binary;
 pub mod reduce;
 pub mod shape_ops;

--- a/tensor/src/test/unit/readme_examples.rs
+++ b/tensor/src/test/unit/readme_examples.rs
@@ -1,0 +1,17 @@
+use ndarray::array;
+
+use crate::Tensor;
+
+/// Tests that mirror README.md Quick Example exactly.
+/// If these tests break, the README examples are wrong.
+
+#[test]
+fn test_readme_quick_example() {
+    let a = Tensor::from_ndarray(&array![[1.0f32, 2.0], [3.0, 4.0]]);
+    let b = Tensor::from_ndarray(&array![[5.0f32, 6.0], [7.0, 8.0]]);
+    let c = &a + &b;
+    let result = c.to_ndarray::<f32>().unwrap();
+    assert_eq!(result, array![[6.0, 8.0], [10.0, 12.0]].into_dyn());
+    let flat = c.to_vec::<f32>().unwrap();
+    assert_eq!(flat, vec![6.0, 8.0, 10.0, 12.0]);
+}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -8,6 +8,9 @@
 .docusaurus
 .cache-loader
 
+# Auto-generated from root README.md by readme-intro plugin
+docs/introduction.md
+
 # Misc
 .DS_Store
 .env.local

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -4,9 +4,9 @@ sidebar_label: Introduction
 
 # Morok
 
-> ⚠️ **Pre-alpha software.** APIs are unstable and may change without notice. Not recommended for production use. 🚧💀
+> **Alpha software.** Core functionality is tested, but APIs are unstable and may change without notice.
 
-Morok is a Rust-based ML compiler inspired by [Tinygrad](https://github.com/tinygrad/tinygrad). It features lazy tensor evaluation with UOp-based IR, pattern-driven optimization, and multi-backend code generation.
+A Rust-based ML compiler inspired by [Tinygrad](https://github.com/tinygrad/tinygrad). Lazy tensor evaluation with UOp-based IR, pattern-driven optimization, and multi-backend code generation.
 
 ## Highlights
 
@@ -14,25 +14,100 @@ Morok is a Rust-based ML compiler inspired by [Tinygrad](https://github.com/tiny
 |---------|-------------|
 | **Declarative Optimization** | `patterns!` DSL for graph rewrites with Z3-verified correctness |
 | **Lazy Evaluation** | Tensors build computation graphs, compiled only at `realize()` |
-| **CUDA Support** | Unified memory, D2D copy, LRU buffer caching |
 | **Provenance Tracking** | `#[track_caller]` traces every UOp to source location |
 | **80+ IR Operations** | Arithmetic, memory, control flow, WMMA tensor cores |
 | **20+ Optimizations** | Constant folding, tensor cores, vectorization, loop unrolling |
+
+For architecture details, see the [documentation site](https://npatsakula.github.io/morok/).
+
+## Workspace
+
+| Crate | Description |
+|-------|-------------|
+| [dtype](https://github.com/npatsakula/morok/tree/main/dtype/) | Type system: scalars, vectors, pointers, images |
+| [macros](https://github.com/npatsakula/morok/tree/main/macros/) | Procedural macros (`patterns!` DSL) |
+| [ir](https://github.com/npatsakula/morok/tree/main/ir/) | UOp graph IR: 80+ ops, symbolic integers, provenance |
+| [device](https://github.com/npatsakula/morok/tree/main/device/) | Buffer management: lazy alloc, zero-copy views, LRU caching |
+| [schedule](https://github.com/npatsakula/morok/tree/main/schedule/) | Optimization engine: 20+ passes, RANGEIFY, Z3 verification |
+| [codegen](https://github.com/npatsakula/morok/tree/main/codegen/) | Code generation: Clang (default), LLVM JIT, MLIR |
+| [runtime](https://github.com/npatsakula/morok/tree/main/runtime/) | JIT compilation and kernel execution |
+| [tensor](https://github.com/npatsakula/morok/tree/main/tensor/) | High-level lazy tensor API |
+| [onnx](https://github.com/npatsakula/morok/tree/main/onnx/) | ONNX model importer |
 
 ## Quick Example
 
 ```rust
 use morok_tensor::Tensor;
+use ndarray::array;
 
-// Build lazy computation graph
-let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
-let b = Tensor::from_slice([4.0f32, 5.0, 6.0]);
-let c = (&a + &b).sum();
+// Zero-copy from ndarray (C-contiguous fast path)
+let a = Tensor::from_ndarray(&array![[1.0f32, 2.0], [3.0, 4.0]]);
+let b = Tensor::from_ndarray(&array![[5.0f32, 6.0], [7.0, 8.0]]);
 
-// Compile and execute
-let result = c.realize()?;
+// Lazy — nothing executes yet
+let c = &a + &b;
+
+// Compile, execute, extract as ndarray
+let result = c.to_ndarray::<f32>()?;
+assert_eq!(result, array![[6.0, 8.0], [10.0, 12.0]].into_dyn());
+
+// Or extract as flat Vec
+let flat = c.to_vec::<f32>()?;
+assert_eq!(flat, vec![6.0, 8.0, 10.0, 12.0]);
 ```
 
-## License
+## Pattern DSL Example
 
-MIT
+```rust
+use morok_schedule::patterns;
+
+let optimizer = patterns! {
+    // Identity folding (commutative)
+    Add[x, @zero] ~> x,
+    Mul[x, @one] ~> x,
+
+    // Constant folding
+    for op in binary [Add, Mul, Sub] {
+        op(a @const(av), _b @const(bv))
+          => |a, av, bv| eval_binary_op(op, av, bv).map(|r| UOp::const_(a.dtype(), r)),
+    },
+};
+```
+
+## Development
+
+### Environment setup
+
+#### Nix
+
+This project contains a pre-defined Nix development environment
+with all dependencies and compilers included. The same infrastructure
+is used for CI/CD, so it's the preferred way to develop and test.
+
+```bash
+nix develop # Open development shell
+nix flake check # Run CI tests
+nix fmt # Format source files
+```
+
+#### Bare metal
+
+| Dependency | Version | Required | Description |
+|------------|---------|----------|-------------|
+| Rust | 1.85+ | yes | Edition 2024 |
+| LLVM | 21.x | yes | CPU code generation backend |
+| Clang | - | yes | C compiler for LLVM builds |
+| pkgconf | - | yes | Build configuration tool |
+| protobuf | - | yes | ONNX proto compilation |
+| zlib | >=1.3 | yes | Compression library |
+| libffi | >=3.4 | yes | Foreign function interface |
+| libxml2 | >=2.13 | yes | XML parsing |
+| Z3 | >=4.15 | no | SMT solver for optimization verification |
+
+## Test
+
+```bash
+cargo test
+cargo test --features z3,proptest  # With Z3 verification and PB generated tests
+cargo test --features cuda   # With CUDA tests
+```

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -41,6 +41,10 @@ const config: Config = {
     },
   },
 
+  plugins: [
+    './plugins/readme-intro.mjs',
+  ],
+
   presets: [
     [
       "classic",

--- a/website/i18n/hi/docusaurus-plugin-content-docs/current/introduction.md
+++ b/website/i18n/hi/docusaurus-plugin-content-docs/current/introduction.md
@@ -4,7 +4,7 @@ sidebar_label: परिचय
 
 # Morok
 
-> **प्री-अल्फ़ा सॉफ़्टवेयर।** APIs अस्थिर हैं और बिना नोटिस के बदल सकते हैं। प्रोडक्शन उपयोग के लिए अनुशंसित नहीं है।
+> **अल्फ़ा सॉफ़्टवेयर।** कोर फ़ंक्शनैलिटी टेस्टेड है, लेकिन APIs अस्थिर हैं और बिना नोटिस के बदल सकते हैं।
 
 Morok एक Rust-आधारित ML कम्पाइलर है जो [Tinygrad](https://github.com/tinygrad/tinygrad) से प्रेरित है। इसमें UOp-आधारित IR के साथ lazy tensor इवैल्यूएशन, पैटर्न-ड्रिवन ऑप्टिमाइज़ेशन, और मल्टी-बैकएंड कोड जनरेशन शामिल है।
 
@@ -14,25 +14,98 @@ Morok एक Rust-आधारित ML कम्पाइलर है जो [
 |---------|-------|
 | **डिक्लेरेटिव ऑप्टिमाइज़ेशन** | Z3-सत्यापित शुद्धता के साथ ग्राफ़ रीराइट्स के लिए `patterns!` DSL |
 | **Lazy इवैल्यूएशन** | Tensor कम्प्यूटेशन ग्राफ़ बनाते हैं, कम्पाइल केवल `realize()` पर होता है |
-| **CUDA सपोर्ट** | यूनिफ़ाइड मेमोरी, D2D कॉपी, LRU बफ़र कैशिंग |
 | **प्रोवेनेंस ट्रैकिंग** | `#[track_caller]` हर UOp को सोर्स लोकेशन तक ट्रेस करता है |
 | **80+ IR ऑपरेशन** | अरिथमेटिक, मेमोरी, कंट्रोल फ़्लो, WMMA tensor cores |
 | **20+ ऑप्टिमाइज़ेशन** | कॉन्स्टेंट फ़ोल्डिंग, tensor cores, वेक्टराइज़ेशन, लूप अनरोलिंग |
+
+आर्किटेक्चर की डिटेल्स के लिए [डॉक्यूमेंटेशन साइट](https://npatsakula.github.io/morok/) देखें।
+
+## वर्कस्पेस
+
+| Crate | विवरण |
+|-------|-------|
+| [dtype](https://github.com/npatsakula/morok/tree/main/dtype/) | टाइप सिस्टम: scalars, vectors, pointers, images |
+| [macros](https://github.com/npatsakula/morok/tree/main/macros/) | प्रोसीज़रल मैक्रोज़ (`patterns!` DSL) |
+| [ir](https://github.com/npatsakula/morok/tree/main/ir/) | UOp ग्राफ़ IR: 80+ ops, symbolic integers, प्रोवेनेंस |
+| [device](https://github.com/npatsakula/morok/tree/main/device/) | बफ़र मैनेजमेंट: lazy alloc, zero-copy views, LRU कैशिंग |
+| [schedule](https://github.com/npatsakula/morok/tree/main/schedule/) | ऑप्टिमाइज़ेशन इंजन: 20+ पासेज़, RANGEIFY, Z3 वेरिफ़िकेशन |
+| [codegen](https://github.com/npatsakula/morok/tree/main/codegen/) | कोड जनरेशन: Clang (डिफ़ॉल्ट), LLVM JIT, MLIR |
+| [runtime](https://github.com/npatsakula/morok/tree/main/runtime/) | JIT कम्पाइलेशन और कर्नेल एक्ज़ीक्यूशन |
+| [tensor](https://github.com/npatsakula/morok/tree/main/tensor/) | हाई-लेवल lazy tensor API |
+| [onnx](https://github.com/npatsakula/morok/tree/main/onnx/) | ONNX मॉडल इम्पोर्टर |
 
 ## त्वरित उदाहरण
 
 ```rust
 use morok_tensor::Tensor;
+use ndarray::array;
 
-// Build lazy computation graph
-let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
-let b = Tensor::from_slice([4.0f32, 5.0, 6.0]);
-let c = (&a + &b).sum();
+// Zero-copy from ndarray (C-contiguous fast path)
+let a = Tensor::from_ndarray(&array![[1.0f32, 2.0], [3.0, 4.0]]);
+let b = Tensor::from_ndarray(&array![[5.0f32, 6.0], [7.0, 8.0]]);
 
-// Compile and execute
-let result = c.realize()?;
+// Lazy — nothing executes yet
+let c = &a + &b;
+
+// Compile, execute, extract as ndarray
+let result = c.to_ndarray::<f32>()?;
+assert_eq!(result, array![[6.0, 8.0], [10.0, 12.0]].into_dyn());
+
+// Or extract as flat Vec
+let flat = c.to_vec::<f32>()?;
+assert_eq!(flat, vec![6.0, 8.0, 10.0, 12.0]);
 ```
 
-## लाइसेंस
+## Pattern DSL उदाहरण
 
-MIT
+```rust
+use morok_schedule::patterns;
+
+let optimizer = patterns! {
+    // Identity folding (commutative)
+    Add[x, @zero] ~> x,
+    Mul[x, @one] ~> x,
+
+    // Constant folding
+    for op in binary [Add, Mul, Sub] {
+        op(a @const(av), _b @const(bv))
+          => |a, av, bv| eval_binary_op(op, av, bv).map(|r| UOp::const_(a.dtype(), r)),
+    },
+};
+```
+
+## डेवलपमेंट
+
+### एनवायरनमेंट सेटअप
+
+#### Nix
+
+इस प्रोजेक्ट में सभी डिपेंडेंसीज़ और कम्पाइलर्स के साथ एक प्री-डिफ़ाइंड Nix डेवलपमेंट एनवायरनमेंट है। वही इंफ़्रास्ट्रक्चर CI/CD के लिए इस्तेमाल होता है, इसलिए यह डेवलप और टेस्ट करने का प्रिफ़र्ड तरीका है।
+
+```bash
+nix develop # Open development shell
+nix flake check # Run CI tests
+nix fmt # Format source files
+```
+
+#### बेयर मेटल
+
+| डिपेंडेंसी | वर्शन | ज़रूरी | विवरण |
+|------------|--------|--------|-------|
+| Rust | 1.85+ | हाँ | Edition 2024 |
+| LLVM | 21.x | हाँ | CPU कोड जनरेशन बैकएंड |
+| Clang | - | हाँ | LLVM बिल्ड्स के लिए C कम्पाइलर |
+| pkgconf | - | हाँ | बिल्ड कॉन्फ़िगरेशन टूल |
+| protobuf | - | हाँ | ONNX proto कम्पाइलेशन |
+| zlib | >=1.3 | हाँ | कम्प्रेशन लाइब्रेरी |
+| libffi | >=3.4 | हाँ | फ़ॉरेन फ़ंक्शन इंटरफ़ेस |
+| libxml2 | >=2.13 | हाँ | XML पार्सिंग |
+| Z3 | >=4.15 | नहीं | ऑप्टिमाइज़ेशन वेरिफ़िकेशन के लिए SMT सॉल्वर |
+
+## टेस्ट
+
+```bash
+cargo test
+cargo test --features z3,proptest  # With Z3 verification and PB generated tests
+cargo test --features cuda   # With CUDA tests
+```

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/introduction.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/introduction.md
@@ -4,9 +4,9 @@ sidebar_label: Введение
 
 # Morok
 
-> **Пре-альфа.** API нестабильный и может измениться без предупреждения. Не рекомендуется для продакшна.
+> **Альфа-версия.** Основная функциональность протестирована, но API нестабильны и могут измениться без предупреждения.
 
-Morok — ML-компилятор на Rust, вдохновлённый [Tinygrad](https://github.com/tinygrad/tinygrad). Ленивые тензорные вычисления на основе UOp IR, паттерн-ориентированные оптимизации и кодогенерация под несколько бэкендов.
+ML-компилятор на Rust, вдохновлённый [Tinygrad](https://github.com/tinygrad/tinygrad). Ленивые тензорные вычисления на основе UOp IR, паттерн-ориентированные оптимизации и кодогенерация под несколько бэкендов.
 
 ## Основные возможности
 
@@ -14,25 +14,100 @@ Morok — ML-компилятор на Rust, вдохновлённый [Tinygra
 |-------------|----------|
 | **Декларативные оптимизации** | DSL `patterns!` для перезаписи графов с Z3-верифицированной корректностью |
 | **Ленивые вычисления** | Тензоры строят граф вычислений, компиляция происходит только при `realize()` |
-| **Поддержка CUDA** | Unified memory, D2D copy, LRU-кэширование буферов |
 | **Трассировка происхождения** | `#[track_caller]` привязывает каждый UOp к месту в исходном коде |
 | **80+ IR-операций** | Арифметика, память, control flow, WMMA tensor cores |
 | **20+ оптимизаций** | Свёртка констант, tensor cores, векторизация, развёртка циклов |
+
+Подробнее об архитектуре — на [сайте документации](https://npatsakula.github.io/morok/).
+
+## Структура проекта
+
+| Крейт | Описание |
+|-------|----------|
+| [dtype](https://github.com/npatsakula/morok/tree/main/dtype/) | Система типов: скаляры, векторы, указатели, изображения |
+| [macros](https://github.com/npatsakula/morok/tree/main/macros/) | Процедурные макросы (DSL `patterns!`) |
+| [ir](https://github.com/npatsakula/morok/tree/main/ir/) | UOp-граф IR: 80+ операций, символьные целые, трассировка происхождения |
+| [device](https://github.com/npatsakula/morok/tree/main/device/) | Управление буферами: ленивое выделение, zero-copy view, LRU-кэширование |
+| [schedule](https://github.com/npatsakula/morok/tree/main/schedule/) | Движок оптимизаций: 20+ проходов, RANGEIFY, Z3-верификация |
+| [codegen](https://github.com/npatsakula/morok/tree/main/codegen/) | Кодогенерация: Clang (по умолчанию), LLVM JIT, MLIR |
+| [runtime](https://github.com/npatsakula/morok/tree/main/runtime/) | JIT-компиляция и выполнение ядер |
+| [tensor](https://github.com/npatsakula/morok/tree/main/tensor/) | Высокоуровневый API ленивых тензоров |
+| [onnx](https://github.com/npatsakula/morok/tree/main/onnx/) | Импортер ONNX-моделей |
 
 ## Быстрый пример
 
 ```rust
 use morok_tensor::Tensor;
+use ndarray::array;
 
-// Build lazy computation graph
-let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
-let b = Tensor::from_slice([4.0f32, 5.0, 6.0]);
-let c = (&a + &b).sum();
+// Zero-copy from ndarray (C-contiguous fast path)
+let a = Tensor::from_ndarray(&array![[1.0f32, 2.0], [3.0, 4.0]]);
+let b = Tensor::from_ndarray(&array![[5.0f32, 6.0], [7.0, 8.0]]);
 
-// Compile and execute
-let result = c.realize()?;
+// Lazy — nothing executes yet
+let c = &a + &b;
+
+// Compile, execute, extract as ndarray
+let result = c.to_ndarray::<f32>()?;
+assert_eq!(result, array![[6.0, 8.0], [10.0, 12.0]].into_dyn());
+
+// Or extract as flat Vec
+let flat = c.to_vec::<f32>()?;
+assert_eq!(flat, vec![6.0, 8.0, 10.0, 12.0]);
 ```
 
-## Лицензия
+## Пример DSL паттернов
 
-MIT
+```rust
+use morok_schedule::patterns;
+
+let optimizer = patterns! {
+    // Identity folding (commutative)
+    Add[x, @zero] ~> x,
+    Mul[x, @one] ~> x,
+
+    // Constant folding
+    for op in binary [Add, Mul, Sub] {
+        op(a @const(av), _b @const(bv))
+          => |a, av, bv| eval_binary_op(op, av, bv).map(|r| UOp::const_(a.dtype(), r)),
+    },
+};
+```
+
+## Разработка
+
+### Настройка окружения
+
+#### Nix
+
+Проект содержит предварительно настроенное Nix-окружение для разработки
+со всеми зависимостями и компиляторами. Та же инфраструктура
+используется для CI/CD, поэтому это предпочтительный способ разработки и тестирования.
+
+```bash
+nix develop # Open development shell
+nix flake check # Run CI tests
+nix fmt # Format source files
+```
+
+#### Установка вручную
+
+| Зависимость | Версия | Обязательна | Описание |
+|-------------|--------|-------------|----------|
+| Rust | 1.85+ | да | Edition 2024 |
+| LLVM | 21.x | да | Backend кодогенерации для CPU |
+| Clang | - | да | C-компилятор для сборки LLVM |
+| pkgconf | - | да | Инструмент конфигурации сборки |
+| protobuf | - | да | Компиляция ONNX proto |
+| zlib | >=1.3 | да | Библиотека сжатия |
+| libffi | >=3.4 | да | Foreign function interface |
+| libxml2 | >=2.13 | да | Парсинг XML |
+| Z3 | >=4.15 | нет | SMT-решатель для верификации оптимизаций |
+
+## Тестирование
+
+```bash
+cargo test
+cargo test --features z3,proptest  # With Z3 verification and PB generated tests
+cargo test --features cuda   # With CUDA tests
+```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/introduction.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/introduction.md
@@ -4,7 +4,7 @@ sidebar_label: 简介
 
 # Morok
 
-> ⚠️ **Pre-alpha 阶段软件。** API 尚不稳定，可能随时更改。不建议用于生产环境。 🚧💀
+> **Alpha 阶段软件。** 核心功能已测试，但 API 尚不稳定，可能随时更改。
 
 Morok 是一个基于 Rust 的 ML 编译器，灵感来自 [Tinygrad](https://github.com/tinygrad/tinygrad)。它具有基于 UOp 的 IR 惰性张量求值、模式驱动优化和多后端代码生成。
 
@@ -14,25 +14,98 @@ Morok 是一个基于 Rust 的 ML 编译器，灵感来自 [Tinygrad](https://gi
 |---------|-------------|
 | **声明式优化** | `patterns!` DSL 实现图重写，通过 Z3 验证正确性 |
 | **惰性求值** | Tensor 构建计算图，仅在 `realize()` 时编译执行 |
-| **CUDA 支持** | 统一内存、D2D 拷贝、LRU 缓冲区缓存 |
 | **溯源追踪** | `#[track_caller]` 将每个 UOp 追溯到源码位置 |
 | **80+ IR 操作** | 算术、内存、控制流、WMMA tensor core |
 | **20+ 优化** | 常量折叠、tensor core、向量化、循环展开 |
+
+架构详情请参阅[文档站点](https://npatsakula.github.io/morok/)。
+
+## 工作空间
+
+| Crate | 描述 |
+|-------|-------------|
+| [dtype](https://github.com/npatsakula/morok/tree/main/dtype/) | 类型系统：标量、向量、指针、图像 |
+| [macros](https://github.com/npatsakula/morok/tree/main/macros/) | 过程宏（`patterns!` DSL） |
+| [ir](https://github.com/npatsakula/morok/tree/main/ir/) | UOp 图 IR：80+ 操作、符号整数、溯源 |
+| [device](https://github.com/npatsakula/morok/tree/main/device/) | 缓冲区管理：惰性分配、零拷贝视图、LRU 缓存 |
+| [schedule](https://github.com/npatsakula/morok/tree/main/schedule/) | 优化引擎：20+ 趟、RANGEIFY、Z3 验证 |
+| [codegen](https://github.com/npatsakula/morok/tree/main/codegen/) | 代码生成：Clang（默认）、LLVM JIT、MLIR |
+| [runtime](https://github.com/npatsakula/morok/tree/main/runtime/) | JIT 编译与内核执行 |
+| [tensor](https://github.com/npatsakula/morok/tree/main/tensor/) | 高层惰性张量 API |
+| [onnx](https://github.com/npatsakula/morok/tree/main/onnx/) | ONNX 模型导入器 |
 
 ## 快速示例
 
 ```rust
 use morok_tensor::Tensor;
+use ndarray::array;
 
-// Build lazy computation graph
-let a = Tensor::from_slice([1.0f32, 2.0, 3.0]);
-let b = Tensor::from_slice([4.0f32, 5.0, 6.0]);
-let c = (&a + &b).sum();
+// Zero-copy from ndarray (C-contiguous fast path)
+let a = Tensor::from_ndarray(&array![[1.0f32, 2.0], [3.0, 4.0]]);
+let b = Tensor::from_ndarray(&array![[5.0f32, 6.0], [7.0, 8.0]]);
 
-// Compile and execute
-let result = c.realize()?;
+// Lazy — nothing executes yet
+let c = &a + &b;
+
+// Compile, execute, extract as ndarray
+let result = c.to_ndarray::<f32>()?;
+assert_eq!(result, array![[6.0, 8.0], [10.0, 12.0]].into_dyn());
+
+// Or extract as flat Vec
+let flat = c.to_vec::<f32>()?;
+assert_eq!(flat, vec![6.0, 8.0, 10.0, 12.0]);
 ```
 
-## 许可证
+## 模式 DSL 示例
 
-MIT
+```rust
+use morok_schedule::patterns;
+
+let optimizer = patterns! {
+    // Identity folding (commutative)
+    Add[x, @zero] ~> x,
+    Mul[x, @one] ~> x,
+
+    // Constant folding
+    for op in binary [Add, Mul, Sub] {
+        op(a @const(av), _b @const(bv))
+          => |a, av, bv| eval_binary_op(op, av, bv).map(|r| UOp::const_(a.dtype(), r)),
+    },
+};
+```
+
+## 开发
+
+### 环境配置
+
+#### Nix
+
+本项目包含预定义的 Nix 开发环境，已包含所有依赖和编译器。CI/CD 也使用相同的基础设施，因此这是推荐的开发和测试方式。
+
+```bash
+nix develop # Open development shell
+nix flake check # Run CI tests
+nix fmt # Format source files
+```
+
+#### 裸金属
+
+| 依赖 | 版本 | 必需 | 描述 |
+|------------|---------|----------|-------------|
+| Rust | 1.85+ | 是 | Edition 2024 |
+| LLVM | 21.x | 是 | CPU 代码生成后端 |
+| Clang | - | 是 | LLVM 构建所需的 C 编译器 |
+| pkgconf | - | 是 | 构建配置工具 |
+| protobuf | - | 是 | ONNX proto 编译 |
+| zlib | >=1.3 | 是 | 压缩库 |
+| libffi | >=3.4 | 是 | 外部函数接口 |
+| libxml2 | >=2.13 | 是 | XML 解析 |
+| Z3 | >=4.15 | 否 | 用于优化验证的 SMT 求解器 |
+
+## 测试
+
+```bash
+cargo test
+cargo test --features z3,proptest  # With Z3 verification and PB generated tests
+cargo test --features cuda   # With CUDA tests
+```

--- a/website/plugins/readme-intro.mjs
+++ b/website/plugins/readme-intro.mjs
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_URL = 'https://github.com/npatsakula/morok/tree/main';
+
+export default function readmeIntroPlugin(context) {
+  return {
+    name: 'readme-intro',
+    async loadContent() {
+      let readme = fs.readFileSync(
+        path.resolve(context.siteDir, '..', 'README.md'),
+        'utf-8'
+      );
+
+      // Rewrite relative markdown links to absolute GitHub URLs so
+      // Docusaurus doesn't treat them as broken doc references.
+      readme = readme.replace(
+        /\]\((?!https?:\/\/)([^)]+)\)/g,
+        (match, relPath) => `](${REPO_URL}/${relPath})`,
+      );
+
+      const frontmatter = '---\nsidebar_label: Introduction\n---\n\n';
+      const outPath = path.resolve(context.siteDir, 'docs', 'introduction.md');
+      fs.writeFileSync(outPath, frontmatter + readme);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add Docusaurus plugin (`readme-intro.mjs`) that generates `docs/introduction.md` from root `README.md` at build time — no more manual sync
- Fix README Quick Example bug: `(&a + &b)?` → `&a + &b` (Add returns `Tensor`, not `Result`)
- Add `tensor/test/unit/readme_examples.rs` that mirrors the README example to catch future drift
- Update i18n translations (ru, zh-Hans, hi) to match current README content

## Test plan

- [x] `cargo test -p morok-tensor readme_examples` passes
- [x] `npx docusaurus build` passes for all 4 locales (en, ru, zh-Hans, hi)
- [x] Code blocks verified identical across all translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)