### PR TITLE
Comparison with ndarray multiplication. Print trees only by set a env

### DIFF
--- a/tensor/benches/optimization.rs
+++ b/tensor/benches/optimization.rs
@@ -14,7 +14,6 @@ use morok_schedule::{HeuristicsConfig, OptStrategy, OptimizerConfig};
 use morok_tensor::{PrepareConfig, Tensor};
 use ndarray::{Array, Dim};
 use std::env;
-use strum::Display;
 
 /// Create a test matrix of given size with sequential values.
 fn create_matrix(rows: usize, cols: usize) -> Tensor {
@@ -34,35 +33,18 @@ fn matmul_flops(m: usize, k: usize, n: usize) -> u64 {
     2 * (m as u64) * (k as u64) * (n as u64)
 }
 
-#[derive(Display)]
-enum Config {
-    #[strum(to_string = "HEURISTIC")]
-    Heuristic,
-    #[strum(to_string = "BEAM")]
-    Beam,
-}
-
-fn print_tree(config: Config, size: usize, plan: &morok_runtime::ExecutionPlan, result: &Tensor) {
+fn print_tree(config: &str, size: usize, plan: &morok_runtime::ExecutionPlan, result: &Tensor) {
     if env::var(KEY).is_ok() {
         // DEBUG: Print kernel info
-        eprintln!("\n=== {config} (size={size}) ===");
+        eprintln!("\n=== {config:?} (size={size}) ===");
         eprintln!("Kernel count: {}", plan.kernels().count());
 
-        match config {
-            Config::Heuristic => {
+        eprintln!("UOp tree:\n{}", result.uop().tree());
+        for (i, kernel) in plan.prepared_kernels().iter().enumerate() {
+            if env::var(KEY).is_ok() {
                 eprintln!("UOp tree:\n{}", result.uop().tree());
-                for (i, kernel) in plan.prepared_kernels().iter().enumerate() {
-                    if env::var(KEY).is_ok() {
-                        eprintln!("UOp tree:\n{}", result.uop().tree());
-                        eprintln!("  Kernel {}: {}", i, kernel.kernel.entry_point);
-                        eprintln!("{}", kernel.kernel.code);
-                    }
-                }
-            }
-            Config::Beam => {
-                for (i, kernel) in plan.kernels().enumerate() {
-                    eprintln!("  Kernel {}: {}", i, kernel.entry_point);
-                }
+                eprintln!("  Kernel {}: {}", i, kernel.kernel.entry_point);
+                eprintln!("{}", kernel.kernel.code);
             }
         }
     }
@@ -83,8 +65,7 @@ fn bench_matmul(c: &mut Criterion) {
     let beam_config: PrepareConfig =
         OptimizerConfig::builder().strategy(OptStrategy::Beam { width: BEAM_WIDTH }).build().into();
 
-    {
-        let size = 512;
+    for size in [512] {
         let flops = matmul_flops(size, size, size);
         group.throughput(Throughput::Elements(flops));
 
@@ -97,7 +78,7 @@ fn bench_matmul(c: &mut Criterion) {
             let mut result_h = a.matmul(&b).expect("matmul should succeed");
             let plan_h = result_h.prepare_with(&heuristic_config).expect("prepare should succeed");
 
-            print_tree(Config::Heuristic, size, &plan_h, &result_h);
+            print_tree("HEURISTIC", size, &plan_h, &result_h);
 
             group.bench_with_input(BenchmarkId::new("heuristic", size), &plan_h, |bencher, plan_h| {
                 bencher.iter(|| plan_h.execute().expect("execute should succeed"));
@@ -107,7 +88,7 @@ fn bench_matmul(c: &mut Criterion) {
             let mut result_b = a.matmul(&b).expect("matmul should succeed");
             let plan_b = result_b.prepare_with(&beam_config).expect("prepare should succeed");
 
-            print_tree(Config::Beam, size, &plan_b, &result_b);
+            print_tree("BEAM", size, &plan_b, &result_b);
 
             group.bench_with_input(
                 BenchmarkId::new(format!("beam_w{BEAM_WIDTH}"), size),

--- a/tensor/benches/optimization.rs
+++ b/tensor/benches/optimization.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo bench -p morok-tensor`
 //!
-//! If you want to see tree, set env variable TREE.
+//! If you want to see the UOp tree, set the TREE environment variable.
 
 const KEY: &str = "TREE";
 

--- a/tensor/benches/optimization.rs
+++ b/tensor/benches/optimization.rs
@@ -4,10 +4,17 @@
 //! Reports throughput in GFLOPS.
 //!
 //! Run with: `cargo bench -p morok-tensor`
+//!
+//! If you want to see tree, set env variable TREE.
+
+const KEY: &str = "TREE";
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use morok_schedule::{HeuristicsConfig, OptStrategy, OptimizerConfig};
 use morok_tensor::{PrepareConfig, Tensor};
+use ndarray::{Array, Dim};
+use std::env;
+use strum::Display;
 
 /// Create a test matrix of given size with sequential values.
 fn create_matrix(rows: usize, cols: usize) -> Tensor {
@@ -15,10 +22,50 @@ fn create_matrix(rows: usize, cols: usize) -> Tensor {
     Tensor::from_slice(&data).try_reshape([rows as isize, cols as isize]).expect("reshape should succeed")
 }
 
+/// Create a ndarray matrix of given size with sequential values.
+fn create_ndarray(rows: usize, cols: usize) -> ndarray::Array<f32, Dim<[usize; 2]>> {
+    let data: Vec<f32> = (0..rows * cols).map(|i| i as f32 * 0.01).collect();
+    Array::from_shape_vec((rows, cols), data).expect("array from vec should succeed")
+}
+
 /// Calculate FLOPs for matrix multiplication.
 /// For [M, K] @ [K, N] -> [M, N]: 2 * M * N * K (one mul + one add per output element, K times)
 fn matmul_flops(m: usize, k: usize, n: usize) -> u64 {
     2 * (m as u64) * (k as u64) * (n as u64)
+}
+
+#[derive(Display)]
+enum Config {
+    #[strum(to_string = "HEURISTIC")]
+    Heuristic,
+    #[strum(to_string = "BEAM")]
+    Beam,
+}
+
+fn print_tree(config: Config, size: usize, plan: &morok_runtime::ExecutionPlan, result: &Tensor) {
+    if env::var(KEY).is_ok() {
+        // DEBUG: Print kernel info
+        eprintln!("\n=== {config} (size={size}) ===");
+        eprintln!("Kernel count: {}", plan.kernels().count());
+
+        match config {
+            Config::Heuristic => {
+                eprintln!("UOp tree:\n{}", result.uop().tree());
+                for (i, kernel) in plan.prepared_kernels().iter().enumerate() {
+                    if env::var(KEY).is_ok() {
+                        eprintln!("UOp tree:\n{}", result.uop().tree());
+                        eprintln!("  Kernel {}: {}", i, kernel.kernel.entry_point);
+                        eprintln!("{}", kernel.kernel.code);
+                    }
+                }
+            }
+            Config::Beam => {
+                for (i, kernel) in plan.kernels().enumerate() {
+                    eprintln!("  Kernel {}: {}", i, kernel.entry_point);
+                }
+            }
+        }
+    }
 }
 
 fn bench_matmul(c: &mut Criterion) {
@@ -36,7 +83,8 @@ fn bench_matmul(c: &mut Criterion) {
     let beam_config: PrepareConfig =
         OptimizerConfig::builder().strategy(OptStrategy::Beam { width: BEAM_WIDTH }).build().into();
 
-    for size in [512] {
+    {
+        let size = 512;
         let flops = matmul_flops(size, size, size);
         group.throughput(Throughput::Elements(flops));
 
@@ -49,17 +97,9 @@ fn bench_matmul(c: &mut Criterion) {
             let mut result_h = a.matmul(&b).expect("matmul should succeed");
             let plan_h = result_h.prepare_with(&heuristic_config).expect("prepare should succeed");
 
-            // DEBUG: Print kernel info for heuristic
-            eprintln!("\n=== HEURISTIC (size={}) ===", size);
-            eprintln!("Kernel count: {}", plan_h.kernels().count());
-            eprintln!("UOp tree:\n{}", result_h.uop().tree());
-            for (i, kernel) in plan_h.prepared_kernels().iter().enumerate() {
-                eprintln!("UOp tree:\n{}", kernel.ast.tree());
-                eprintln!("  Kernel {}: {}", i, kernel.kernel.entry_point);
-                eprintln!("{}", kernel.kernel.code);
-            }
+            print_tree(Config::Heuristic, size, &plan_h, &result_h);
 
-            group.bench_with_input(BenchmarkId::new("heuristic", size), &size, |bencher, _| {
+            group.bench_with_input(BenchmarkId::new("heuristic", size), &plan_h, |bencher, plan_h| {
                 bencher.iter(|| plan_h.execute().expect("execute should succeed"));
             });
 
@@ -67,16 +107,26 @@ fn bench_matmul(c: &mut Criterion) {
             let mut result_b = a.matmul(&b).expect("matmul should succeed");
             let plan_b = result_b.prepare_with(&beam_config).expect("prepare should succeed");
 
-            // DEBUG: Print kernel info for beam
-            eprintln!("\n=== BEAM (size={}) ===", size);
-            eprintln!("Kernel count: {}", plan_b.kernels().count());
-            for (i, kernel) in plan_b.kernels().enumerate() {
-                eprintln!("  Kernel {}: {}", i, kernel.entry_point);
-            }
+            print_tree(Config::Beam, size, &plan_b, &result_b);
 
-            group.bench_with_input(BenchmarkId::new(format!("beam_w{BEAM_WIDTH}"), size), &size, |bencher, _| {
-                bencher.iter(|| plan_b.execute().expect("execute should succeed"));
-            });
+            group.bench_with_input(
+                BenchmarkId::new(format!("beam_w{BEAM_WIDTH}"), size),
+                &plan_b,
+                |bencher, plan_b| {
+                    bencher.iter(|| plan_b.execute().expect("execute should succeed"));
+                },
+            );
+
+            let a = create_ndarray(size, size);
+            let b = create_ndarray(size, size);
+
+            group.bench_with_input(
+                BenchmarkId::new("ndarray multiplication".to_string(), size),
+                &(a, b),
+                |bencher, (a, b)| {
+                    bencher.iter(|| a.dot(b));
+                },
+            );
         }
     }
 

--- a/tensor/benches/optimization.rs
+++ b/tensor/benches/optimization.rs
@@ -36,16 +36,14 @@ fn matmul_flops(m: usize, k: usize, n: usize) -> u64 {
 fn print_tree(config: &str, size: usize, plan: &morok_runtime::ExecutionPlan, result: &Tensor) {
     if env::var(KEY).is_ok() {
         // DEBUG: Print kernel info
-        eprintln!("\n=== {config:?} (size={size}) ===");
+        eprintln!("\n=== {config} (size={size}) ===");
         eprintln!("Kernel count: {}", plan.kernels().count());
-
         eprintln!("UOp tree:\n{}", result.uop().tree());
+
         for (i, kernel) in plan.prepared_kernels().iter().enumerate() {
-            if env::var(KEY).is_ok() {
-                eprintln!("UOp tree:\n{}", result.uop().tree());
-                eprintln!("  Kernel {}: {}", i, kernel.kernel.entry_point);
-                eprintln!("{}", kernel.kernel.code);
-            }
+            eprintln!("UOp tree:\n{}", kernel.ast.tree());
+            eprintln!("  Kernel {}: {}", i, kernel.kernel.entry_point);
+            eprintln!("{}", kernel.kernel.code);
         }
     }
 }
@@ -65,7 +63,7 @@ fn bench_matmul(c: &mut Criterion) {
     let beam_config: PrepareConfig =
         OptimizerConfig::builder().strategy(OptStrategy::Beam { width: BEAM_WIDTH }).build().into();
 
-    for size in [512] {
+    for size in [256, 512, 1024] {
         let flops = matmul_flops(size, size, size);
         group.throughput(Throughput::Elements(flops));
 


### PR DESCRIPTION
This PR brings ndarray into the matmul benchmark. Now we can directly compare morok's heuristic and beam_w* strategies against a well-known reference implementation (ndarray::Array::dot) across multiple sizes.

 Alongside that, a bit of cleanup:

 - UOp-tree / kernel dumps are now opt-in via TREE=1 — no more stderr spam on every run
 - Merged the two copy-pasted debug blocks into one print_tree helper
 - Sweeping [256, 512, 1024] now, so we get a small/medium/large picture instead of just 512
 - bench_with_input now takes the prepared ExecutionPlan directly, which is what we're actually measuring