### PR TITLE
[*] model/gigaam+silero_vad: move chunk-overshoot trim into the splitter

### DIFF
--- a/arch/src/test/unit/vad/chunker.rs
+++ b/arch/src/test/unit/vad/chunker.rs
@@ -173,6 +173,38 @@ fn test_chunker_align_to_640() {
 }
 
 #[test]
+fn test_chunker_end_sample_can_exceed_waveform_len() {
+    // `chunks_from_probs` sees only `probs`, not the raw `waveform`. When the
+    // waveform's actual length isn't a multiple of `samples_per_prob`, the
+    // last prob's window straddles the waveform end and the emitted chunk's
+    // `end_sample` reflects the full window — overshooting the waveform by
+    // up to `samples_per_prob - 1` samples. This is the contract documented
+    // at `AudioChunk::end_sample`: callers owning the waveform must clamp at
+    // slice time. Pinned here so the documented overshoot is exercised by a
+    // test, not just a comment.
+    let probs = vec![1.0_f32; 4]; // 4 windows × 512 = 2048 samples of coverage
+    let waveform_len = 1800; // real waveform ended mid-window
+    let opts = ChunkerOpts {
+        sample_rate: 16_000,
+        samples_per_prob: 512,
+        threshold: 0.5,
+        min_duration: 0.0,
+        max_duration: 1.0,
+        strict_limit_duration: 1.0,
+        min_speech_probs: 1,
+        min_silence_probs: 1,
+        merge_gap_probs: 1,
+        trough_search_probs: None,
+        trough_threshold: None,
+        pad_samples: 0,
+        align_to: 640, // GigaAM: hop_length * subsampling_factor
+    };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert_eq!(chunks, vec![AudioChunk { start_sample: 0, end_sample: 2048 }]);
+    assert!(chunks[0].end_sample > waveform_len);
+}
+
+#[test]
 fn test_chunker_validates_min_exceeds_max() {
     let opts = ChunkerOpts { min_duration: 30.0, max_duration: 22.0, ..ChunkerOpts::default() };
     match chunks_from_probs(&[], &opts) {

--- a/model/src/audio/mod.rs
+++ b/model/src/audio/mod.rs
@@ -10,4 +10,4 @@ pub(crate) mod mel;
 mod splitter;
 
 pub use mel::{MelConfig, MelSpectrogram};
-pub use splitter::{AudioChunk, EncoderBounds, FixedLengthSplitter, Splitter};
+pub use splitter::{AudioChunk, EncoderBounds, FixedLengthSplitter, Splitter, trim_chunks_to_waveform};

--- a/model/src/audio/splitter.rs
+++ b/model/src/audio/splitter.rs
@@ -68,6 +68,12 @@ impl EncoderBounds {
 /// `end_sample <= waveform.len()` and `end_sample - start_sample <=
 /// bounds.max_samples()`; alignment is a soft preference (floor-division on
 /// `hop_length` tolerates misaligned boundaries).
+///
+/// Splitters that align chunk ends to encoder strides
+/// ([`align_to_samples`](EncoderBounds::align_to_samples)) can round the
+/// trailing chunk past `waveform.len()`. The contract still requires
+/// in-range chunks — use [`trim_chunks_to_waveform`] to clean up the tail
+/// before returning.
 pub trait Splitter {
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -79,6 +85,25 @@ pub trait Splitter {
     /// Default: full encoder capacity.
     fn max_chunk_samples(&self, bounds: &EncoderBounds) -> usize {
         bounds.max_samples()
+    }
+}
+
+/// Trim `chunks` so every entry stays within `0..waveform_len`: drop chunks
+/// starting at or past `waveform_len`, then clamp the trailing chunk's
+/// `end_sample` down to `waveform_len`. Intended for [`Splitter`]
+/// implementations whose stride alignment can push the last chunk past the
+/// waveform end (see the trait docs).
+///
+/// Assumes `chunks` is in increasing `start_sample` order — the
+/// `Splitter::split` contract — so a single pass from the back is enough.
+pub fn trim_chunks_to_waveform(chunks: &mut Vec<AudioChunk>, waveform_len: usize) {
+    while let Some(mut last) = chunks.pop() {
+        if last.start_sample >= waveform_len {
+            continue;
+        }
+        last.end_sample = last.end_sample.min(waveform_len);
+        chunks.push(last);
+        break;
     }
 }
 

--- a/model/src/silero_vad/splitter.rs
+++ b/model/src/silero_vad/splitter.rs
@@ -9,7 +9,7 @@
 use bon::bon;
 use snafu::{ResultExt, Snafu};
 
-use crate::audio::{AudioChunk, EncoderBounds, Splitter};
+use crate::audio::{AudioChunk, EncoderBounds, Splitter, trim_chunks_to_waveform};
 use crate::silero_vad::{NUM_SAMPLES, SileroVad, VadInference};
 
 /// VAD-driven splitter. Construction: [`from_hub`](Self::from_hub) loads the
@@ -102,7 +102,12 @@ impl Splitter for SileroVadSplitter {
             pad_samples: self.pad_samples,
             align_to: bounds.align_to_samples().max(1),
         };
-        morok_arch::vad::chunks_from_probs(&probs, &chunker_opts).context(ChunkSnafu)
+        let mut chunks = morok_arch::vad::chunks_from_probs(&probs, &chunker_opts).context(ChunkSnafu)?;
+        // `align_to` rounds chunk ends up to a stride multiple, which can push
+        // the trailing chunk past `waveform.len()`. The `Splitter` contract
+        // forbids that, so clamp the tail before returning.
+        trim_chunks_to_waveform(&mut chunks, waveform.len());
+        Ok(chunks)
     }
 
     /// Upper bound on chunk length the chunker can emit under this


### PR DESCRIPTION
Fixes #73. `Transcriber::transcribe` was returning `ChunkOutOfRange` on some real-audio lengths because `SileroVadSplitter::split` forwarded `morok_arch::vad::chunks_from_probs` output verbatim, and that output   is documented to overshoot `waveform.len()` by up to `samples_per_prob - 1` samples (last VAD prob covers a window past the wave) plus another `align_to - 1` from stride rounding. The model-layer `Splitter` trait introduced in f4f8dc6 requires in-range chunks; nothing adapted between the two layers.

This PR adds that adapter step at the splitter boundary.

- `model::audio::trim_chunks_to_waveform` (new helper, re-exported from audio): walks `chunks` back-to-front, drops chunks starting at or past `waveform_len`, clamps the trailing chunk's `end_sample` down. Single pass — relies on the existing `Splitter::split` ordering invariant.
- `SileroVadSplitter::split`: calls the helper after `chunks_from_probs`, with a comment naming the two overshoot sources (`samples_per_prob` window rounding + `align_to` stride rounding).
- `audio::Splitter` trait doc: reinforces the `end_sample <= waveform.len()` contract and points stride-aligning impls at the helper. The `FixedLengthSplitter` already clamps inside its loop, so no call needed there.
- `arch::vad::chunks_from_probs` test (`test_chunker_end_sample_can_exceed_waveform_len`): pins the arch-layer overshoot behavior that the `AudioChunk` doc already promised. Asserts `end_sample = 2048 > waveform_len = 1800` for a 4-prob input — the same mechanism that the original real-audio failure (1_616_384 > 1_616_000) hits at scale.