### PR TITLE
model/gigaam: fix RNNT frontend parity

### DIFF
--- a/model/src/audio/mel.rs
+++ b/model/src/audio/mel.rs
@@ -36,10 +36,7 @@ impl MelSpectrogram {
         let mut planner = RealFftPlanner::<f32>::new();
         let r2c = planner.plan_fft_forward(n_fft);
 
-        let mut window = vec![0.0f32; n_fft];
-        for (i, w) in window.iter_mut().enumerate().take(config.win_length) {
-            *w = 0.5 * (1.0 - (2.0 * PI * i as f32 / (config.win_length as f32 - 1.0)).cos());
-        }
+        let window = hann_window(config.n_fft, config.win_length);
 
         let mel_fb = build_mel_filterbank(config.n_mels, n_fft, config.sample_rate as f32);
 
@@ -112,6 +109,17 @@ impl MelSpectrogram {
             }
         }
     }
+}
+
+/// Periodic Hann window, matching `torch.hann_window(periodic=True)`, which is
+/// torchaudio's default in `MelSpectrogram`. `realfft` handles only the FFT;
+/// it does not provide STFT window builders.
+pub(crate) fn hann_window(n_fft: usize, win_length: usize) -> Vec<f32> {
+    let mut window = vec![0.0f32; n_fft];
+    for (i, w) in window.iter_mut().enumerate().take(win_length) {
+        *w = 0.5 * (1.0 - (2.0 * PI * i as f32 / win_length as f32).cos());
+    }
+    window
 }
 
 /// Build HTK mel filterbank matrix of shape `[n_mels, n_fft/2+1]`.

--- a/model/src/gigaam/config.rs
+++ b/model/src/gigaam/config.rs
@@ -94,6 +94,9 @@ impl GigaAmConfig {
     }
 
     fn from_raw(raw: RawModelCfg) -> Result<Self> {
+        validate_preprocessor(&raw.preprocessor)?;
+        validate_encoder(&raw.encoder)?;
+
         // `max_mel_frames` is the pre-subsampling sequence-length bound. Configs that
         // only specify `pos_emb_max_len` (the post-subsampling encoder bound) need it
         // multiplied by `subsampling_factor` so audio approaching the encoder cap
@@ -104,6 +107,18 @@ impl GigaAmConfig {
             .max_mel_frames
             .or(raw.encoder.max_seq_len)
             .unwrap_or(max_encoder_frames * raw.encoder.subsampling_factor);
+        let subs_kernel = match &raw.encoder.subsampling {
+            SubsamplingMode::Conv1d => raw.encoder.subs_kernel_size,
+            SubsamplingMode::Conv2d => 3,
+        };
+        let max_sub_frames = subsampled_len(subs_kernel, max_mel_frames);
+        if max_sub_frames > max_encoder_frames {
+            return Err(Error::DecoderConfig {
+                message: format!(
+                    "max_mel_frames ({max_mel_frames}) subsamples to {max_sub_frames} encoder frames, exceeding pos_emb_max_len ({max_encoder_frames})"
+                ),
+            });
+        }
         // CTC configs put `num_classes` directly on `head`; RNN-T configs nest
         // it under `head.decoder.num_classes` / `head.joint.num_classes`.
         let vocab_size = raw
@@ -166,6 +181,10 @@ struct RawPreprocessor {
     win_length: usize,
     #[serde(default = "default_true")]
     center: bool,
+    #[serde(default)]
+    mel_scale: Option<String>,
+    #[serde(default)]
+    mel_norm: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -176,6 +195,8 @@ struct RawEncoder {
     n_layers: usize,
     conv_kernel_size: usize,
     subsampling_factor: usize,
+    #[serde(default = "default_self_attention_model")]
+    self_attention_model: String,
     #[serde(default = "default_subs_kernel_size")]
     subs_kernel_size: usize,
     #[serde(default = "default_subsampling_mode")]
@@ -232,8 +253,68 @@ fn default_conv_norm_type() -> ConvNormType {
 fn default_pos_emb_max_len() -> usize {
     5000
 }
+fn default_self_attention_model() -> String {
+    "rotary".into()
+}
 fn default_max_batch_size() -> usize {
     32
+}
+
+fn validate_preprocessor(pre: &RawPreprocessor) -> Result<()> {
+    if let Some(scale) = pre.mel_scale.as_deref()
+        && scale != "htk"
+    {
+        return Err(Error::DecoderConfig {
+            message: format!(
+                "unsupported mel_scale {scale:?}; Morok GigaAM currently matches torchaudio's HTK mel frontend"
+            ),
+        });
+    }
+    if let Some(norm) = pre.mel_norm.as_deref() {
+        return Err(Error::DecoderConfig {
+            message: format!(
+                "unsupported mel_norm {norm:?}; Morok GigaAM currently supports only null/no mel normalization"
+            ),
+        });
+    }
+    if pre.n_fft != pre.win_length {
+        return Err(Error::DecoderConfig {
+            message: format!(
+                "unsupported mel frontend n_fft ({}) != win_length ({}); current GigaAM parity path requires equal FFT/window lengths",
+                pre.n_fft, pre.win_length
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_encoder(encoder: &RawEncoder) -> Result<()> {
+    if encoder.self_attention_model != "rotary" {
+        return Err(Error::DecoderConfig {
+            message: format!(
+                "unsupported self_attention_model {:?}; Morok GigaAM currently implements rotary attention only",
+                encoder.self_attention_model
+            ),
+        });
+    }
+    if encoder.subsampling_factor != 4 {
+        return Err(Error::DecoderConfig {
+            message: format!(
+                "unsupported subsampling_factor {}; Morok GigaAM currently implements exactly two stride-2 subsampling layers",
+                encoder.subsampling_factor
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn subsampled_len(kernel_size: usize, mel_frames: usize) -> usize {
+    let pad = (kernel_size - 1) / 2;
+    let mut len = mel_frames;
+    for _ in 0..2 {
+        len = len.saturating_add(2 * pad).saturating_sub(kernel_size) / 2 + 1;
+    }
+    len
 }
 
 // ─── Decoder + transducer dispatch ────────────────────────────────────────

--- a/model/src/gigaam/encoder.rs
+++ b/model/src/gigaam/encoder.rs
@@ -12,15 +12,15 @@ use super::error::{StateSnafu, TensorSnafu};
 use super::{ConvNormType, GigaAmConfig, SubsamplingMode};
 
 /// Precompute RoPE cos/sin cache tensors. Returns `(cos, sin)` each of shape
-/// `[max_encoder_frames, 1, 1, d_k/2]` where `d_k = d_model / n_heads`. GigaAM
-/// uses non-interleaved RoPE (first_half/second_half split), matching
-/// `apply_rotary_emb(..., interleaved=false)`.
+/// `[max_encoder_frames, 1, 1, d_k/2]` where `d_k = d_model / n_heads`. Upstream
+/// GigaAM passes `pos_emb_max_len` as both cache length and RoPE base.
 fn build_rope_cache(config: &GigaAmConfig) -> (Tensor, Tensor) {
     let d_k = config.d_model / config.n_heads;
     let half_d = d_k / 2;
     let max_len = config.max_encoder_frames;
+    let base = config.max_encoder_frames as f32;
 
-    let inv_freq: Vec<f32> = (0..half_d).map(|i| 1.0 / 10000.0f32.powf(2.0 * i as f32 / d_k as f32)).collect();
+    let inv_freq: Vec<f32> = (0..half_d).map(|i| 1.0 / base.powf(2.0 * i as f32 / d_k as f32)).collect();
 
     let mut cos_arr = Array4::<f32>::zeros((max_len, 1, 1, half_d));
     let mut sin_arr = Array4::<f32>::zeros((max_len, 1, 1, half_d));

--- a/model/src/gigaam/remap.rs
+++ b/model/src/gigaam/remap.rs
@@ -39,7 +39,7 @@ fn remap_key(key: &str, config: &GigaAmConfig) -> Option<String> {
     let key = key.strip_prefix("model.").unwrap_or(key);
     let parts: Vec<&str> = key.split('.').collect();
 
-    if parts[..3] == ["encoder", "pre_encode", "conv"] && parts.len() == 5 {
+    if parts.len() == 5 && parts[..3] == ["encoder", "pre_encode", "conv"] {
         let idx = parts[3];
         let param = parts[4];
         let conv_map = match idx {
@@ -50,22 +50,22 @@ fn remap_key(key: &str, config: &GigaAmConfig) -> Option<String> {
         return Some(format!("subsampling.{conv_map}_{param}"));
     }
 
-    if parts[..3] == ["encoder", "pre_encode", "out"] && parts.len() == 4 {
+    if parts.len() == 4 && parts[..3] == ["encoder", "pre_encode", "out"] {
         return Some(format!("subsampling.linear_{}", parts[3]));
     }
 
-    if parts[..2] == ["encoder", "layers"] && parts.len() >= 4 {
+    if parts.len() >= 4 && parts[..2] == ["encoder", "layers"] {
         let i = parts[2];
         let rest = &parts[3..];
         return remap_encoder_layer(i, rest, config);
     }
 
-    if parts[..2] == ["head", "decoder_layers"] && parts.len() >= 4 {
+    if parts.len() >= 4 && parts[..2] == ["head", "decoder_layers"] {
         return Some(format!("head.{}", &parts[3..].join(".")));
     }
 
     // RNN-T predictor: head.decoder.embed.weight, head.decoder.lstm.{w,b}_{ih,hh}_l{N}.
-    if parts[..2] == ["head", "decoder"] && parts.len() >= 3 {
+    if parts.len() >= 3 && parts[..2] == ["head", "decoder"] {
         if parts[2] == "embed" && parts.len() == 4 && parts[3] == "weight" {
             return Some("head.predictor.embed".to_string());
         }
@@ -77,7 +77,7 @@ fn remap_key(key: &str, config: &GigaAmConfig) -> Option<String> {
 
     // RNN-T joint: head.joint.{enc,pred}.{weight,bias},
     // head.joint.joint_net.1.{weight,bias} (joint_net.0 = ReLU, no params).
-    if parts[..2] == ["head", "joint"] && parts.len() >= 4 {
+    if parts.len() >= 4 && parts[..2] == ["head", "joint"] {
         let sub = parts[2];
         let last = parts.last().unwrap();
         if (sub == "enc" || sub == "pred") && parts.len() == 4 {

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -406,23 +406,12 @@ impl<S: Splitter> Transcriber<S> {
             }
         }
 
-        // Plain `ndarray::Array3` (not a Tensor) — `forward_into` is pure
-        // host code, and a per-call `Tensor::full(...).realize()` would
-        // JIT-recompile per `total_mel_frames` value.
         let n_mels = self.mel.n_mels();
-        let total_mel_frames = self.mel.num_frames(waveform.len());
-        if total_mel_frames == 0 || chunks.is_empty() {
+        if chunks.is_empty() {
             return Ok(TranscribeResult { text: String::new(), chunks: Vec::new() });
         }
-        let mut full_mel = ndarray::Array3::<f32>::zeros((1, n_mels, total_mel_frames));
-        {
-            let mut view = full_mel.view_mut().into_dyn();
-            self.mel.forward_into(waveform, &mut view);
-        }
-        let full_mel_data = full_mel.as_slice().expect("contiguous mel buffer");
 
         let sample_rate_hz = self.model.config.sample_rate;
-        let hop_length = self.model.config.hop_length;
         let d_model = self.model.config.d_model;
         let subs_kernel_size = match self.model.config.subsampling_mode {
             SubsamplingMode::Conv1d => self.model.config.subs_kernel_size,
@@ -433,18 +422,17 @@ impl<S: Splitter> Transcriber<S> {
         let max_batch = self.max_batch;
         let want_words = self.opts.word_timestamps;
 
-        // (mel_start, mel_len, start_sec, end_sec) per chunk.
-        let chunks_meta: Vec<(usize, usize, f32, f32)> = chunks
+        // (start_sample, end_sample, mel_len, start_sec, end_sec) per chunk.
+        let chunks_meta: Vec<(usize, usize, usize, f32, f32)> = chunks
             .iter()
             .filter_map(|c| {
-                let mel_start = c.start_sample / hop_length;
-                let mel_end = (c.end_sample / hop_length).min(total_mel_frames);
-                if mel_end <= mel_start {
+                let mel_len = self.mel.num_frames(c.end_sample.saturating_sub(c.start_sample));
+                if mel_len == 0 {
                     return None;
                 }
                 let start_sec = c.start_sample as f32 / sample_rate_hz as f32;
                 let end_sec = c.end_sample as f32 / sample_rate_hz as f32;
-                Some((mel_start, mel_end - mel_start, start_sec, end_sec))
+                Some((c.start_sample, c.end_sample, mel_len, start_sec, end_sec))
             })
             .collect();
         if chunks_meta.is_empty() {
@@ -457,6 +445,18 @@ impl<S: Splitter> Transcriber<S> {
             let b = (num_chunks - chunk_batch_start).min(max_batch);
             let mut chunk_lengths = vec![0usize; b];
 
+            let batch_mels: Vec<Vec<f32>> = (0..b)
+                .map(|bi| {
+                    let &(start_sample, end_sample, valid, _, _) = &chunks_meta[chunk_batch_start + bi];
+                    let mut chunk_mel = ndarray::Array3::<f32>::zeros((1, n_mels, valid));
+                    {
+                        let mut view = chunk_mel.view_mut().into_dyn();
+                        self.mel.forward_into(&waveform[start_sample..end_sample], &mut view);
+                    }
+                    chunk_mel.as_slice().expect("contiguous chunk mel").to_vec()
+                })
+                .collect();
+
             // Pack mel into encoder JIT input buffer.
             {
                 let buf = self.encoder_jit.mel_mut().context(JitSnafu)?;
@@ -464,12 +464,13 @@ impl<S: Splitter> Transcriber<S> {
                 let slice = view.as_slice_mut().expect("contiguous mel buffer");
                 slice.fill(0.0);
                 for (bi, chunk_len) in chunk_lengths.iter_mut().enumerate() {
-                    let &(mel_start, valid, _, _) = &chunks_meta[chunk_batch_start + bi];
+                    let &(_, _, valid, _, _) = &chunks_meta[chunk_batch_start + bi];
                     *chunk_len = valid;
+                    let chunk_mel = &batch_mels[bi];
                     for mel_bin in 0..n_mels {
-                        let src = mel_bin * total_mel_frames + mel_start;
+                        let src = mel_bin * valid;
                         let dst = ((bi * n_mels) + mel_bin) * max_t_mel;
-                        slice[dst..dst + valid].copy_from_slice(&full_mel_data[src..src + valid]);
+                        slice[dst..dst + valid].copy_from_slice(&chunk_mel[src..src + valid]);
                     }
                 }
             }
@@ -519,22 +520,25 @@ impl<S: Splitter> Transcriber<S> {
                     let flat = logits.as_slice().expect("contiguous head logits");
                     for (bi, mel_len) in chunk_lengths.iter().enumerate() {
                         let actual_sub = subs_output_length(subs_kernel_size, *mel_len);
-                        let &(_, valid_mel, start_sec, end_sec) = &chunks_meta[chunk_batch_start + bi];
-                        let chunk_duration_sec = (valid_mel as f32) * hop_length as f32 / sample_rate_hz as f32;
+                        let &(start_sample, end_sample, _, start_sec, end_sec) = &chunks_meta[chunk_batch_start + bi];
+                        let chunk_duration_sec = (end_sample - start_sample) as f32 / sample_rate_hz as f32;
                         let frame_shift = chunk_duration_sec / (actual_sub.max(1) as f32);
 
                         let item_slice = &flat[bi * item_stride..bi * item_stride + item_stride];
 
-                        let (text, words) = if want_words {
+                        let (text, frames) = if want_words {
                             let (text, frames) = decoder
                                 .decode_with_timestamps(item_slice, t_exec_sub, actual_sub)
                                 .context(CtcDecodeSnafu)?;
-                            let words = ctc_frames_to_words(&text, &frames, frame_shift);
-                            (text, Some(words))
+                            (text, Some(frames))
                         } else {
                             let text = decoder.decode(item_slice, t_exec_sub, actual_sub).context(CtcDecodeSnafu)?;
                             (text, None)
                         };
+                        let words = want_words.then(|| {
+                            let frames = frames.as_deref().unwrap_or(&[]);
+                            ctc_frames_to_words(&text, frames, frame_shift)
+                        });
                         chunk_results.push(ChunkResult { start_sec, end_sec, text, words });
                     }
                 }
@@ -545,8 +549,8 @@ impl<S: Splitter> Transcriber<S> {
                     let flat = enc.as_slice().expect("contiguous encoder output");
                     for (bi, mel_len) in chunk_lengths.iter().enumerate() {
                         let actual_sub = subs_output_length(subs_kernel_size, *mel_len);
-                        let &(_, valid_mel, start_sec, end_sec) = &chunks_meta[chunk_batch_start + bi];
-                        let chunk_duration_sec = (valid_mel as f32) * hop_length as f32 / sample_rate_hz as f32;
+                        let &(start_sample, end_sample, _, start_sec, end_sec) = &chunks_meta[chunk_batch_start + bi];
+                        let chunk_duration_sec = (end_sample - start_sample) as f32 / sample_rate_hz as f32;
                         let frame_shift = chunk_duration_sec / (actual_sub.max(1) as f32);
 
                         let item_slice = &flat[bi * item_stride..bi * item_stride + item_stride];
@@ -555,18 +559,18 @@ impl<S: Splitter> Transcriber<S> {
                         let frames = transpose_dt_to_td(item_slice, d_model, t_exec_sub, actual_sub);
 
                         let backend: &mut RnntStepBackend = backend;
-                        let (raw, emissions, want_emissions) = if want_words {
+                        let (raw, emissions) = if want_words {
                             let (s, e) = decoder
                                 .decode_with_timestamps(&frames, actual_sub, actual_sub, d_model, backend)
                                 .map_err(rnnt_decode_err)?;
-                            (s, e, true)
+                            (s, e)
                         } else {
                             let s = decoder
                                 .decode(&frames, actual_sub, actual_sub, d_model, backend)
                                 .map_err(rnnt_decode_err)?;
-                            (s, Vec::new(), false)
+                            (s, Vec::new())
                         };
-                        let words = want_emissions.then(|| decoder.frames_to_words(&emissions, frame_shift));
+                        let words = want_words.then(|| decoder.frames_to_words(&emissions, frame_shift));
                         // SP pieces carry `▁` (U+2581) as word-initial markers;
                         // after concatenation we restore them as spaces.
                         let text = if *sentencepiece { raw.replace('\u{2581}', " ").trim().to_string() } else { raw };

--- a/model/src/test/unit/batch.rs
+++ b/model/src/test/unit/batch.rs
@@ -69,6 +69,24 @@ fn test_rope_cache_uses_encoder_bound() {
 }
 
 #[test]
+fn test_rope_cache_uses_pos_emb_max_len_as_base() {
+    let model = model_with_random_weights();
+    let cfg = test_config();
+    let d_k = cfg.d_model / cfg.n_heads;
+    let half_d = d_k / 2;
+    let pos = 1usize;
+    let freq_idx = 1usize;
+    let angle = pos as f32 / (cfg.max_encoder_frames as f32).powf(2.0 * freq_idx as f32 / d_k as f32);
+    let flat_idx = pos * half_d + freq_idx;
+
+    let cos = model.encoder.cos_cache.as_vec::<f32>().unwrap();
+    let sin = model.encoder.sin_cache.as_vec::<f32>().unwrap();
+
+    assert!((cos[flat_idx] - angle.cos()).abs() < 1e-6);
+    assert!((sin[flat_idx] - angle.sin()).abs() < 1e-6);
+}
+
+#[test]
 fn test_subsampled_max_mel_fits_encoder_bound() {
     let model = model_with_random_weights();
     let cfg = test_config();

--- a/model/src/test/unit/config.rs
+++ b/model/src/test/unit/config.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use morok_arch::ctc::CtcDecoder;
 
@@ -40,4 +41,112 @@ fn test_config_from_json() {
     assert_eq!(config.decoder.total_vocab(), config.vocab_size);
     assert_eq!(config.decoder.vocabulary()[0], " ");
     assert_eq!(config.decoder.vocabulary()[32], "я");
+}
+
+#[test]
+fn test_rnnt_config_from_json() {
+    let config = GigaAmConfig::from_json(Path::new("tests/gigaam/rnnt_config.json")).unwrap();
+    let transducer = config.transducer.as_ref().expect("rnnt transducer config");
+
+    assert_eq!(config.vocab_size, 1025);
+    assert_eq!(transducer.pred_hidden, 320);
+    assert_eq!(transducer.pred_rnn_layers, 1);
+    assert_eq!(transducer.joint_hidden, 320);
+    assert_eq!(transducer.num_classes, 1025);
+    assert_eq!(transducer.max_symbols_per_step, 10);
+    assert!(transducer.vocabulary.is_empty());
+    assert!(transducer.sentencepiece);
+}
+
+#[test]
+fn test_config_rejects_unsupported_attention() {
+    let err = expect_config_err(parse_temp_config(&minimal_config("rel_pos", 4, "htk", "null", 8, 8)));
+    assert!(err.to_string().contains("self_attention_model"));
+}
+
+#[test]
+fn test_config_rejects_unsupported_subsampling_factor() {
+    let err = expect_config_err(parse_temp_config(&minimal_config("rotary", 2, "htk", "null", 8, 8)));
+    assert!(err.to_string().contains("subsampling_factor"));
+}
+
+#[test]
+fn test_config_rejects_unsupported_mel_frontend() {
+    let err = expect_config_err(parse_temp_config(&minimal_config("rotary", 4, "slaney", "null", 8, 8)));
+    assert!(err.to_string().contains("mel_scale"));
+
+    let err = expect_config_err(parse_temp_config(&minimal_config("rotary", 4, "htk", r#""slaney""#, 8, 8)));
+    assert!(err.to_string().contains("mel_norm"));
+
+    let err = expect_config_err(parse_temp_config(&minimal_config("rotary", 4, "htk", "null", 16, 8)));
+    assert!(err.to_string().contains("n_fft"));
+}
+
+#[test]
+fn test_config_rejects_mel_bound_exceeding_rope_cache() {
+    let json = minimal_config("rotary", 4, "htk", "null", 8, 8)
+        .replace(r#""pos_emb_max_len": 8,"#, r#""pos_emb_max_len": 8, "max_mel_frames": 40,"#);
+    let err = expect_config_err(parse_temp_config(&json));
+    assert!(err.to_string().contains("max_mel_frames"));
+}
+
+fn expect_config_err(result: Result<GigaAmConfig, crate::gigaam::Error>) -> crate::gigaam::Error {
+    match result {
+        Ok(_) => panic!("expected config error"),
+        Err(err) => err,
+    }
+}
+
+fn parse_temp_config(json: &str) -> Result<GigaAmConfig, crate::gigaam::Error> {
+    let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let path = std::env::temp_dir().join(format!("morok_gigaam_config_{stamp}.json"));
+    std::fs::write(&path, json).unwrap();
+    let out = GigaAmConfig::from_json(&path);
+    let _ = std::fs::remove_file(path);
+    out
+}
+
+fn minimal_config(
+    self_attention_model: &str,
+    subsampling_factor: usize,
+    mel_scale: &str,
+    mel_norm: &str,
+    n_fft: usize,
+    win_length: usize,
+) -> String {
+    format!(
+        r#"{{
+  "cfg": {{
+    "model": {{
+      "cfg": {{
+        "preprocessor": {{
+          "sample_rate": 16000,
+          "features": 4,
+          "win_length": {win_length},
+          "hop_length": 4,
+          "mel_scale": "{mel_scale}",
+          "n_fft": {n_fft},
+          "mel_norm": {mel_norm},
+          "center": false
+        }},
+        "encoder": {{
+          "d_model": 8,
+          "n_layers": 1,
+          "subsampling": "conv1d",
+          "subs_kernel_size": 5,
+          "subsampling_factor": {subsampling_factor},
+          "ff_expansion_factor": 4,
+          "self_attention_model": "{self_attention_model}",
+          "pos_emb_max_len": 8,
+          "n_heads": 2,
+          "conv_kernel_size": 5,
+          "conv_norm_type": "layer_norm"
+        }},
+        "head": {{ "num_classes": 2 }},
+        "decoding": {{ "_target_": "CTCGreedyDecoding", "vocabulary": ["a"] }}
+      }}
+    }}
+  }}
+}}"#
+    )
 }

--- a/model/src/test/unit/mel.rs
+++ b/model/src/test/unit/mel.rs
@@ -1,3 +1,4 @@
+use crate::audio::mel::hann_window;
 use crate::audio::{MelConfig, MelSpectrogram};
 
 struct MelOutput {
@@ -88,4 +89,14 @@ fn test_mel_spectrogram_sine_wave() {
         lower_avg > upper_avg,
         "Expected lower mel bins to have more energy for 440Hz sine: lower={lower_avg:.2}, upper={upper_avg:.2}"
     );
+}
+
+#[test]
+fn test_hann_window_matches_torch_periodic_default() {
+    let window = hann_window(8, 8);
+    let expected = [0.0, 0.14644662, 0.5, 0.8535534, 1.0, 0.8535533, 0.5, 0.1464465];
+
+    for (got, want) in window.iter().zip(expected) {
+        assert!((got - want).abs() < 1e-6, "got {got}, want {want}");
+    }
 }

--- a/model/src/test/unit/remap.rs
+++ b/model/src/test/unit/remap.rs
@@ -178,3 +178,16 @@ fn test_remap_rnnt_joint() {
     assert!(out.contains_key("head.joint.out_w"));
     assert!(out.contains_key("head.joint.out_b"));
 }
+
+#[test]
+fn test_remap_ignores_short_keys_without_panicking() {
+    let config = make_config(ConvNormType::LayerNorm);
+    let mut sd = StateDict::new();
+    sd.insert("encoder".into(), fake_tensor());
+    sd.insert("head".into(), fake_tensor());
+    sd.insert("head.decoder".into(), fake_tensor());
+    sd.insert("model.encoder".into(), fake_tensor());
+
+    let out = remap_pytorch(sd, &config).unwrap();
+    assert!(out.is_empty());
+}


### PR DESCRIPTION
Fix GigaAM RNNT frontend/model parity issues.

## Changes
- Match torchaudio’s periodic Hann window in mel extraction.
- Use GigaAM `pos_emb_max_len` as the RoPE base.
- Extract mel features per transcription chunk instead of slicing a full-file spectrogram.
- Use actual chunk sample duration for timestamp frame shift.
- Add config validation for unsupported GigaAM variants.
- Harden RNNT checkpoint remapping against short-key panics.
- Add focused tests for mel, RoPE, config validation, remap safety, and RNNT config parsing.