### PR TITLE
model/gigaam+silero_vad: fix RNNT longform chunking

### DIFF
--- a/arch/src/test/unit/vad/chunker.rs
+++ b/arch/src/test/unit/vad/chunker.rs
@@ -4,23 +4,22 @@ use crate::vad::{AudioChunk, ChunkerOpts, Error, chunks_from_probs};
 
 /// Trivial coordinate system: 1 prob = 1 sample = 1 second. Lets us write
 /// assertions in human units. Real ASR uses 31.25 probs/sec via
-/// `(sample_rate, samples_per_prob)`.
+/// `(sample_rate, samples_per_prob)`. Speech gate is disabled (peak ≥ 0
+/// always); individual tests opt in when needed.
 fn fast_opts() -> ChunkerOpts {
     ChunkerOpts {
         sample_rate: 1,
         samples_per_prob: 1,
-        threshold: 0.5,
-        min_duration: 5.0,
-        max_duration: 10.0,
-        cluster_target_duration: None,
-        strict_limit_duration: 15.0,
+        onset: 0.5,
+        offset: 0.5,
         min_speech_probs: 1,
-        min_silence_probs: 2,
+        min_silence_probs: 1,
         merge_gap_probs: 0,
-        trough_search_probs: None,
-        trough_threshold: None,
+        min_chunk_probs: 5,
+        max_chunk_probs: 10,
         pad_samples: 0,
         align_to: 1,
+        min_chunk_max_prob: 0.0,
     }
 }
 
@@ -36,9 +35,11 @@ fn cat(parts: &[Vec<f32>]) -> Vec<f32> {
     parts.iter().flatten().copied().collect()
 }
 
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
 #[test]
 fn test_chunker_single_segment_under_max() {
-    // 7 probs of speech (= 7s, < max=10) bracketed by 3-prob silences.
+    // 7 probs of speech (= 7s, ≤ max=10) bracketed by 3-prob silences.
     let probs = cat(&[silence(3), speech(7), silence(3)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
     assert_eq!(chunks, vec![AudioChunk::new(3, 10)]);
@@ -46,7 +47,7 @@ fn test_chunker_single_segment_under_max() {
 
 #[test]
 fn test_chunker_pack_two_segments_under_max() {
-    // 4s + 4s with 2s silence gap = 10s total → fits one chunk (max=10).
+    // 4s + 4s with 2s silence gap = two runs that pack to 10s ≤ max.
     let probs = cat(&[speech(4), silence(2), speech(4)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
     assert_eq!(chunks, vec![AudioChunk::new(0, 10)]);
@@ -54,94 +55,17 @@ fn test_chunker_pack_two_segments_under_max() {
 
 #[test]
 fn test_chunker_close_at_inter_segment_silence() {
-    // Three 4s segments with 2s gaps: span 16s. min=5, max=10.
-    // - First two pack into [0, 10] (= 10s, exactly max).
-    // - Third doesn't fit (would push to 16 > max), and cur_len=10 ≥ min.
-    //   Close → chunk[0]=[0,10], chunk[1]=[12,16]. Silence [10,12) dropped.
+    // Three 4s runs, 2s gaps each: spans 16s, max=10.
+    // - Pack [0,4]+[6,10] → chunk [0,10] (= max, fits).
+    // - Try +[12,16] → would be 16 > max → close, new chunk [12,16].
     let probs = cat(&[speech(4), silence(2), speech(4), silence(2), speech(4)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
     assert_eq!(chunks, vec![AudioChunk::new(0, 10), AudioChunk::new(12, 16)]);
 }
 
 #[test]
-fn test_chunker_cluster_target_splits_at_internal_gap() {
-    // The coarse packer would keep this as one 20s chunk. With a 8s cluster
-    // target, the second pass splits at the real 4s VAD gap nearest that
-    // target. The next core starts inside the gap, preserving bounded pre-roll
-    // for low-confidence speech that may sit before the next VAD run.
-    let probs = cat(&[speech(8), silence(4), speech(8)]);
-    let opts = ChunkerOpts {
-        max_duration: 30.0,
-        strict_limit_duration: 30.0,
-        cluster_target_duration: Some(8.0),
-        ..fast_opts()
-    };
-    let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert_eq!(chunks, vec![AudioChunk::new(0, 8), AudioChunk::new(10, 20)]);
-}
-
-#[test]
-fn test_chunker_cluster_target_splits_greedy_envelopes_at_midpoint_gaps() {
-    // Mirrors a pause-heavy longform layout: many short speech runs should first
-    // be packed into model-sized envelopes, then each long envelope split near
-    // its midpoint. A global duration-only partition tends to cut after the
-    // largest early gaps and separates short runs that belong together.
-    let speech_lens = [229, 59, 14, 60, 92, 56, 68, 38, 92, 73, 51, 95, 24, 56];
-    let gap_lens = [107, 92, 46, 28, 48, 39, 61, 32, 30, 46, 126, 117, 31];
-    let mut parts = Vec::new();
-    for (i, &speech_len) in speech_lens.iter().enumerate() {
-        parts.push(speech(speech_len));
-        if let Some(&gap_len) = gap_lens.get(i) {
-            parts.push(silence(gap_len));
-        }
-    }
-    let probs = cat(&parts);
-    let opts = ChunkerOpts {
-        sample_rate: 1,
-        samples_per_prob: 1,
-        threshold: 0.5,
-        min_duration: 469.0,
-        max_duration: 638.0,
-        cluster_target_duration: Some(319.0),
-        strict_limit_duration: 638.0,
-        min_speech_probs: 8,
-        min_silence_probs: 4,
-        merge_gap_probs: 8,
-        trough_search_probs: None,
-        trough_threshold: None,
-        pad_samples: 0,
-        align_to: 1,
-    };
-    let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert_eq!(
-        chunks,
-        vec![
-            AudioChunk::new(0, 229),
-            AudioChunk::new(233, 607),
-            AudioChunk::new(611, 938),
-            AudioChunk::new(942, 1264),
-            AudioChunk::new(1268, 1582),
-            AudioChunk::new(1586, 1810),
-        ]
-    );
-}
-
-#[test]
-fn test_chunker_strict_limit_splits_long_run() {
-    // One 30-prob unbroken segment with a deliberate prob trough at index 14
-    // (value 0.4). With strict=15, n=ceil(30/15)=2 ⇒ one split target at 15.
-    // Search radius = min_silence_probs = 2, but index 14 is illegal because
-    // it would leave a 16-prob suffix. The hard limit wins over trough quality.
-    let mut probs = vec![1.0f32; 30];
-    probs[14] = 0.4;
-    let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
-    assert_eq!(chunks, vec![AudioChunk::new(0, 15), AudioChunk::new(15, 30)]);
-}
-
-#[test]
 fn test_chunker_drops_silence_between_chunks() {
-    // Two well-separated 4s segments, each becomes its own chunk; the 8s
-    // silence gap between them is gone from the output.
+    // Two well-separated 4s runs; the 8s silence gap is gone from the output.
     let probs = cat(&[speech(4), silence(8), speech(4)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
     assert_eq!(chunks, vec![AudioChunk::new(0, 4), AudioChunk::new(12, 16)]);
@@ -162,35 +86,70 @@ fn test_chunker_all_silence() {
 
 #[test]
 fn test_chunker_all_speech_no_breaks() {
-    // 50-prob unbroken speech, strict=15. Every chunk ≤ strict_limit; total
-    // coverage equals input length.
+    // 50-prob unbroken run, max=10. min-cut's flat-speech fallback returns
+    // the rightmost legal split (= hi), so chunks land at exactly max.
     let probs = vec![1.0f32; 50];
-    let opts = fast_opts();
+    let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
+    assert_eq!(
+        chunks,
+        vec![
+            AudioChunk::new(0, 10),
+            AudioChunk::new(10, 20),
+            AudioChunk::new(20, 30),
+            AudioChunk::new(30, 40),
+            AudioChunk::new(40, 50),
+        ]
+    );
+}
+
+#[test]
+fn test_chunker_min_cut_lands_on_silence_trough() {
+    // 30-prob run with a single sub-offset trough at index 14. min-cut prefers
+    // the rightmost silence inside the legal window [min, max]; index 14 is
+    // inside [5, 15] (max=15 here), so the first split lands there.
+    let mut probs = vec![1.0f32; 30];
+    probs[14] = 0.4;
+    let opts = ChunkerOpts { max_chunk_probs: 15, min_chunk_probs: 5, ..fast_opts() };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert!(!chunks.is_empty());
+    assert_eq!(chunks.first().unwrap().end_sample, 14);
     for c in &chunks {
-        assert!(c.end_sample - c.start_sample <= 15, "chunk {c:?} exceeds strict_limit");
+        assert!(c.core_len() <= 15, "chunk {c:?} exceeds max_chunk_probs");
     }
     assert_eq!(chunks.first().unwrap().start_sample, 0);
-    assert_eq!(chunks.last().unwrap().end_sample, 50);
+    assert_eq!(chunks.last().unwrap().end_sample, 30);
+}
+
+#[test]
+fn test_chunker_min_cut_argmin_fallback_when_no_silence() {
+    // Flat-speech run; no probs below offset. min-cut's fallback returns
+    // the rightmost legal split (= hi), keeping a ≥ min_chunk tail.
+    let probs = vec![1.0f32; 22];
+    let opts = ChunkerOpts { max_chunk_probs: 10, min_chunk_probs: 5, ..fast_opts() };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert_eq!(chunks.first().unwrap().start_sample, 0);
+    assert_eq!(chunks.last().unwrap().end_sample, 22);
+    for c in &chunks {
+        assert!(c.core_len() <= 10, "chunk {c:?} exceeds max");
+        assert!(c.core_len() >= 1, "empty chunk: {c:?}");
+    }
 }
 
 #[test]
 fn test_chunker_pad_samples() {
+    // Run [10, 20], pad=5 → decode window [5, 25].
     let probs = cat(&[silence(10), speech(10), silence(10)]);
     let opts = ChunkerOpts { pad_samples: 5, ..fast_opts() };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    // Raw chunk would be (10, 20). With pad=5: (5, 25).
     assert_eq!(chunks, vec![AudioChunk::with_decode(10, 20, 5, 25)]);
 }
 
 #[test]
 fn test_chunker_pad_clamps_at_edges() {
-    // Speech right at the start; padding past 0 saturates.
+    // Run at the file start; pad past 0 saturates and pad past end clamps.
     let probs = cat(&[speech(8), silence(10)]);
     let opts = ChunkerOpts { pad_samples: 100, ..fast_opts() };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    let max_sample = probs.len(); // samples_per_prob = 1
+    let max_sample = probs.len();
     assert_eq!(chunks.len(), 1);
     assert_eq!(chunks[0].start_sample, 0);
     assert_eq!(chunks[0].end_sample, 8);
@@ -200,26 +159,25 @@ fn test_chunker_pad_clamps_at_edges() {
 
 #[test]
 fn test_chunker_align_to_640() {
-    // 10 probs, samples_per_prob=512, one speech segment at probs [3..7).
-    // Raw samples: (1536, 3584). With align_to=640:
+    // 10 probs, samples_per_prob=512, speech at probs [3..7). Closure needs
+    // min_silence_probs consecutive sub-offset probs; the trailing 3 zeros
+    // satisfy that. Core samples (1536, 3584). With align_to=640:
     //   start floor: 1536 / 640 = 2.4 → 2 * 640 = 1280.
     //   end ceil:    3584 / 640 = 5.6 → 6 * 640 = 3840.
     let probs = cat(&[silence(3), speech(4), silence(3)]);
     let opts = ChunkerOpts {
-        sample_rate: 16000,
+        sample_rate: 16_000,
         samples_per_prob: 512,
-        threshold: 0.5,
-        min_duration: 0.0,
-        max_duration: 1.0,
-        cluster_target_duration: None,
-        strict_limit_duration: 1.0,
+        onset: 0.5,
+        offset: 0.5,
         min_speech_probs: 1,
         min_silence_probs: 2,
         merge_gap_probs: 0,
-        trough_search_probs: None,
-        trough_threshold: None,
+        min_chunk_probs: 1,
+        max_chunk_probs: 31, // ≈ ceil(1.0 * 16000 / 512)
         pad_samples: 0,
         align_to: 640,
+        min_chunk_max_prob: 0.0,
     };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
     assert_eq!(chunks, vec![AudioChunk::with_decode(1536, 3584, 1280, 3840)]);
@@ -231,31 +189,26 @@ fn test_chunker_align_to_640() {
 
 #[test]
 fn test_chunker_end_sample_can_exceed_waveform_len() {
-    // `chunks_from_probs` sees only `probs`, not the raw `waveform`. When the
-    // waveform's actual length isn't a multiple of `samples_per_prob`, the
-    // last prob's window straddles the waveform end and the emitted chunk's
-    // `decode_end_sample` reflects the full window — overshooting the waveform by
-    // up to `samples_per_prob - 1` samples. This is the contract documented
-    // at `AudioChunk::decode_end_sample`: callers owning the waveform must clamp at
-    // slice time. Pinned here so the documented overshoot is exercised by a
-    // test, not just a comment.
-    let probs = vec![1.0_f32; 4]; // 4 windows × 512 = 2048 samples of coverage
-    let waveform_len = 1800; // real waveform ended mid-window
+    // `chunks_from_probs` sees only `probs`, not the raw waveform. When the
+    // waveform length isn't a multiple of `samples_per_prob`, the last
+    // prob's window straddles the waveform end and the emitted chunk's
+    // decode_end overshoots — callers must clamp at slice time. Pinned
+    // here so the documented overshoot is exercised.
+    let probs = vec![1.0_f32; 4];
+    let waveform_len = 1800;
     let opts = ChunkerOpts {
         sample_rate: 16_000,
         samples_per_prob: 512,
-        threshold: 0.5,
-        min_duration: 0.0,
-        max_duration: 1.0,
-        cluster_target_duration: None,
-        strict_limit_duration: 1.0,
+        onset: 0.5,
+        offset: 0.5,
         min_speech_probs: 1,
         min_silence_probs: 1,
         merge_gap_probs: 1,
-        trough_search_probs: None,
-        trough_threshold: None,
+        min_chunk_probs: 1,
+        max_chunk_probs: 31,
         pad_samples: 0,
-        align_to: 640, // GigaAM: hop_length * subsampling_factor
+        align_to: 640,
+        min_chunk_max_prob: 0.0,
     };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
     assert_eq!(chunks, vec![AudioChunk::new(0, 2048)]);
@@ -263,26 +216,93 @@ fn test_chunker_end_sample_can_exceed_waveform_len() {
 }
 
 #[test]
+fn test_chunker_hysteresis_sustain_band_keeps_run_open() {
+    // onset=0.6, offset=0.3. Mid-run prob 0.4 is in the sustain band and
+    // does not close the run — the whole 6 probs become one chunk.
+    let probs = vec![0.7, 0.7, 0.7, 0.4, 0.7, 0.7];
+    let opts = ChunkerOpts {
+        onset: 0.6,
+        offset: 0.3,
+        min_speech_probs: 1,
+        min_silence_probs: 2,
+        min_chunk_probs: 1,
+        max_chunk_probs: 10,
+        ..fast_opts()
+    };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert_eq!(chunks, vec![AudioChunk::new(0, 6)]);
+}
+
+#[test]
+fn test_chunker_speech_gate_drops_low_peak_chunk() {
+    // Single run whose max prob (0.45) is below the gate (0.5). Build with
+    // onset = offset = 0.4 so hysteresis opens; then set the gate at 0.5.
+    let probs = vec![0.45_f32; 12];
+    let opts = ChunkerOpts {
+        onset: 0.4,
+        offset: 0.4,
+        min_speech_probs: 1,
+        min_silence_probs: 1,
+        min_chunk_probs: 1,
+        max_chunk_probs: 20,
+        min_chunk_max_prob: 0.5,
+        ..fast_opts()
+    };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert!(chunks.is_empty(), "speech gate should drop low-confidence chunk: {chunks:?}");
+}
+
+#[test]
+fn test_chunker_speech_gate_keeps_high_peak_chunk() {
+    let probs = vec![0.9_f32; 12];
+    let opts = ChunkerOpts { min_chunk_max_prob: 0.5, ..fast_opts() };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert!(!chunks.is_empty(), "high-confidence chunk should pass gate");
+}
+
+#[test]
+fn test_chunker_decode_windows_dont_overlap_with_align_one() {
+    // Three 4s runs with 2s gaps, pad=4, align=1. Each side's pad is capped
+    // at half the gap so decode windows tile cleanly with no overlap.
+    let probs = cat(&[speech(4), silence(2), speech(4), silence(2), speech(4)]);
+    let opts = ChunkerOpts { pad_samples: 4, max_chunk_probs: 4, min_chunk_probs: 1, ..fast_opts() };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert!(chunks.len() >= 2, "expected multiple chunks: {chunks:?}");
+    for w in chunks.windows(2) {
+        assert!(w[0].decode_end_sample <= w[1].decode_start_sample, "decode windows overlap: {:?} → {:?}", w[0], w[1]);
+    }
+}
+
+#[test]
 fn test_chunker_validates_min_exceeds_max() {
-    let opts = ChunkerOpts { min_duration: 30.0, max_duration: 22.0, ..ChunkerOpts::default() };
+    let opts = ChunkerOpts { min_chunk_probs: 30, max_chunk_probs: 22, ..ChunkerOpts::default() };
     match chunks_from_probs(&[], &opts) {
         Err(Error::MinExceedsMax { min, max }) => {
-            assert_eq!(min, 30.0);
-            assert_eq!(max, 22.0);
+            assert_eq!(min, 30);
+            assert_eq!(max, 22);
         }
         other => panic!("expected MinExceedsMax, got {other:?}"),
     }
 }
 
 #[test]
-fn test_chunker_validates_max_exceeds_strict() {
-    let opts = ChunkerOpts { max_duration: 40.0, strict_limit_duration: 30.0, ..ChunkerOpts::default() };
+fn test_chunker_validates_zero_max_chunk() {
+    let opts = ChunkerOpts { max_chunk_probs: 0, ..ChunkerOpts::default() };
     match chunks_from_probs(&[], &opts) {
-        Err(Error::MaxExceedsStrict { max, strict }) => {
-            assert_eq!(max, 40.0);
-            assert_eq!(strict, 30.0);
+        Err(Error::ZeroMaxChunk) => {}
+        other => panic!("expected ZeroMaxChunk, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_chunker_validates_offset_exceeds_onset() {
+    let opts = ChunkerOpts { onset: 0.3, offset: 0.5, ..ChunkerOpts::default() };
+    match chunks_from_probs(&[], &opts) {
+        Err(Error::OffsetExceedsOnset { offset, onset }) => {
+            assert!((offset - 0.5).abs() < 1e-6);
+            assert!((onset - 0.3).abs() < 1e-6);
         }
-        other => panic!("expected MaxExceedsStrict, got {other:?}"),
+        other => panic!("expected OffsetExceedsOnset, got {other:?}"),
     }
 }
 
@@ -304,20 +324,17 @@ fn test_chunker_validates_zero_align_to() {
     }
 }
 
-// ─── Proptests ─────────────────────────────────────────────────────────────
+// ─── Proptests ──────────────────────────────────────────────────────────────
 //
-// These exercise the algorithm across a broad parameter sweep and check
-// invariants that hand-rolled unit tests can't easily cover:
+// Invariants checked across a broad parameter sweep:
 //
-// 1. Structural — sorted, non-overlapping, in-bounds, alignment-aligned, and
-//    deterministic across re-runs of the same input/opts.
-// 2. Strict-limit — with `pad=0, align=1`, every output chunk's sample length
-//    is bounded by `strict_limit_probs * samples_per_prob`. Trough search can
-//    move split points only inside legal ranges that preserve that hard cap.
-// 3. Coverage — with all smoothing knobs set to 1 (no smoothing) and
-//    `pad=0, align=1`, every above-threshold prob in the input falls inside
-//    some output chunk's sample range. Catches phantom-coverage regressions
-//    where speech regions are silently dropped.
+// 1. Structural — sorted, non-overlapping cores; in-bounds decode windows;
+//    decode-window alignment; deterministic; adjacent decode windows
+//    never overlap (the new invariant that motivated the redesign).
+// 2. Max-chunk bound — every core respects `max_chunk_probs · samples_per_prob`;
+//    every decode window respects `max_chunk_sample_bound`.
+// 3. Coverage — with the gate disabled and smoothing minimal, every prob
+//    ≥ onset falls inside some output chunk's sample range.
 
 proptest! {
     #![proptest_config(ProptestConfig { cases: 200, ..ProptestConfig::default() })]
@@ -327,157 +344,151 @@ proptest! {
         probs in prop::collection::vec(0.0f32..=1.0f32, 0..400),
         sample_rate in prop::sample::select(vec![8_000u32, 16_000, 22_050, 44_100, 48_000]),
         samples_per_prob in prop::sample::select(vec![64usize, 128, 256, 512, 1024]),
-        threshold in 0.2f32..0.8,
-        min_dur in 0.05f32..=2.0,
-        max_extra in 0.0f32..=4.0,
-        strict_extra in 0.0f32..=8.0,
+        onset in 0.3f32..0.8,
+        offset_extra in 0.0f32..=0.2,
         min_speech in 1usize..=8,
         min_silence in 1usize..=8,
         merge_gap in 0usize..=8,
+        min_chunk in 1usize..=4,
+        max_chunk_extra in 0usize..=400,
         align_to in prop::sample::select(vec![1usize, 64, 256, 512, 640, 1024, 2048]),
         pad_samples in 0usize..=2048,
     ) {
-        let max_dur = min_dur + max_extra;
-        let strict_dur = max_dur + strict_extra;
+        let offset = (onset - offset_extra).max(0.0);
+        let max_chunk = min_chunk + max_chunk_extra;
         let opts = ChunkerOpts {
             sample_rate,
             samples_per_prob,
-            threshold,
-            min_duration: min_dur,
-            max_duration: max_dur,
-            cluster_target_duration: None,
-            strict_limit_duration: strict_dur,
+            onset,
+            offset,
             min_speech_probs: min_speech,
             min_silence_probs: min_silence,
             merge_gap_probs: merge_gap,
-            trough_search_probs: None,
-        trough_threshold: None,
+            min_chunk_probs: min_chunk,
+            max_chunk_probs: max_chunk,
             pad_samples,
             align_to,
+            min_chunk_max_prob: 0.0,
         };
         let chunks = chunks_from_probs(&probs, &opts).unwrap();
         let max_sample = probs.len() * samples_per_prob;
 
-        // Core output ranges are sorted + non-overlapping (touching allowed).
         for w in chunks.windows(2) {
             prop_assert!(
                 w[0].end_sample <= w[1].start_sample,
-                "overlapping chunk cores: {:?} and {:?}", w[0], w[1]
+                "overlapping cores: {:?} and {:?}", w[0], w[1]
+            );
+            // Decode windows may overlap by up to 2·(align_to − 1) samples
+            // when floor/ceil rounding lands on opposite sides of touching
+            // cores. `crop_words_to_core` filters seam duplicates via the
+            // core boundaries, so this is benign.
+            let overlap = w[0].decode_end_sample.saturating_sub(w[1].decode_start_sample);
+            prop_assert!(
+                overlap < 2 * align_to,
+                "decode overlap {overlap} ≥ 2·align_to {}: {:?} and {:?}",
+                2 * align_to, w[0], w[1]
             );
         }
-        // Each core/decode range is non-empty and inside the input extent.
         for c in &chunks {
-            prop_assert!(c.start_sample < c.end_sample, "empty chunk: {c:?}");
+            prop_assert!(c.start_sample < c.end_sample, "empty core: {c:?}");
             prop_assert!(c.end_sample <= max_sample,
-                "chunk core {c:?} exceeds max_sample {max_sample}");
-            prop_assert!(c.decode_start_sample <= c.start_sample, "decode starts after core: {c:?}");
-            prop_assert!(c.end_sample <= c.decode_end_sample, "decode ends before core: {c:?}");
-            prop_assert!(c.decode_start_sample < c.decode_end_sample, "empty decode window: {c:?}");
+                "core {c:?} exceeds max_sample {max_sample}");
+            prop_assert!(c.decode_start_sample <= c.start_sample,
+                "decode starts after core: {c:?}");
+            prop_assert!(c.end_sample <= c.decode_end_sample,
+                "decode ends before core: {c:?}");
+            prop_assert!(c.decode_start_sample < c.decode_end_sample,
+                "empty decode window: {c:?}");
             prop_assert!(c.decode_end_sample <= max_sample,
-                "chunk decode {c:?} exceeds max_sample {max_sample}");
-        }
-        // Decode-window alignment: start always aligned, end aligned OR
-        // clamped to max_sample (the only legitimate non-aligned end).
-        for c in &chunks {
-            prop_assert_eq!(c.decode_start_sample % align_to, 0,
-                "decode start {} not aligned to {}", c.decode_start_sample, align_to);
+                "decode {c:?} exceeds max_sample {max_sample}");
+
             let end_aligned = c.decode_end_sample % align_to == 0;
             let end_at_max = c.decode_end_sample == max_sample;
             prop_assert!(end_aligned || end_at_max,
                 "decode end {} not aligned to {} and not at max_sample {}",
                 c.decode_end_sample, align_to, max_sample);
+            // decode_start is either an align multiple OR pinned to the
+            // previous chunk's decode_end (which is itself either aligned
+            // or at max_sample).
+            let start_aligned = c.decode_start_sample % align_to == 0;
+            prop_assert!(start_aligned || c.decode_start_sample == max_sample,
+                "decode start {} not aligned to {}", c.decode_start_sample, align_to);
         }
-        // Same input, same output.
         let chunks2 = chunks_from_probs(&probs, &opts).unwrap();
         prop_assert_eq!(chunks, chunks2);
     }
 
     #[test]
-    fn prop_chunker_strict_limit_bound(
+    fn prop_chunker_max_chunk_bound(
         probs in prop::collection::vec(0.0f32..=1.0f32, 0..400),
         sample_rate in prop::sample::select(vec![8_000u32, 16_000, 48_000]),
         samples_per_prob in prop::sample::select(vec![128usize, 512, 1024]),
-        threshold in 0.2f32..0.8,
-        min_dur in 0.1f32..=2.0,
-        max_extra in 0.1f32..=5.0,
-        strict_extra in 0.0f32..=10.0,
+        onset in 0.3f32..0.8,
+        offset_extra in 0.0f32..=0.2,
         min_speech in 1usize..=8,
         min_silence in 1usize..=8,
         merge_gap in 0usize..=8,
+        min_chunk in 1usize..=4,
+        max_chunk_extra in 0usize..=400,
     ) {
-        let max_dur = min_dur + max_extra;
-        let strict_dur = max_dur + strict_extra;
+        let offset = (onset - offset_extra).max(0.0);
+        let max_chunk = min_chunk + max_chunk_extra;
         let opts = ChunkerOpts {
             sample_rate,
             samples_per_prob,
-            threshold,
-            min_duration: min_dur,
-            max_duration: max_dur,
-            cluster_target_duration: None,
-            strict_limit_duration: strict_dur,
+            onset,
+            offset,
             min_speech_probs: min_speech,
             min_silence_probs: min_silence,
             merge_gap_probs: merge_gap,
-            trough_search_probs: None,
-        trough_threshold: None,
+            min_chunk_probs: min_chunk,
+            max_chunk_probs: max_chunk,
             pad_samples: 0,
             align_to: 1,
+            min_chunk_max_prob: 0.0,
         };
         let chunks = chunks_from_probs(&probs, &opts).unwrap();
-        let probs_per_sec = sample_rate as f32 / samples_per_prob as f32;
-        let strict_limit_probs = (strict_dur * probs_per_sec).ceil() as usize;
-        let bound_samples = crate::vad::strict_chunk_sample_bound(
-            strict_limit_probs,
-            samples_per_prob,
-            opts.pad_samples,
-            opts.align_to,
-        );
+        let bound = crate::vad::max_chunk_sample_bound(max_chunk, samples_per_prob, 0, 1);
         for c in &chunks {
-            let len = c.end_sample - c.start_sample;
-            prop_assert!(
-                len <= bound_samples,
-                "chunk {c:?} length {len} exceeds bound {bound_samples} \
-                 (strict_probs={strict_limit_probs}, spp={samples_per_prob})"
-            );
+            prop_assert!(c.core_len() <= max_chunk * samples_per_prob,
+                "chunk {c:?} core_len exceeds max_chunk_probs * samples_per_prob");
+            prop_assert!(c.decode_len() <= bound,
+                "chunk {c:?} decode_len exceeds max_chunk_sample_bound {bound}");
         }
     }
 
     #[test]
     fn prop_chunker_unsmoothed_coverage(
         probs in prop::collection::vec(0.0f32..=1.0f32, 1..400),
-        threshold in 0.3f32..=0.7,
+        onset in 0.3f32..=0.7,
     ) {
-        // With min_speech=min_silence=1, merge_gap=0, pad=0, align=1, every
-        // above-threshold prob is its own speech run and must be inside
-        // some output chunk's sample range. If this ever fires, the
-        // chunker is dropping speech.
+        // With min_speech = min_silence = 1, merge_gap = 0, pad = 0,
+        // align = 1, and gate disabled, every prob ≥ onset must be covered
+        // by some output chunk. Catches phantom-coverage regressions.
         let samples_per_prob = 512usize;
         let opts = ChunkerOpts {
             sample_rate: 16_000,
             samples_per_prob,
-            threshold,
-            min_duration: 0.05,
-            max_duration: 0.5,
-            cluster_target_duration: None,
-            strict_limit_duration: 0.5,
+            onset,
+            offset: onset,
             min_speech_probs: 1,
             min_silence_probs: 1,
             merge_gap_probs: 0,
-            trough_search_probs: None,
-        trough_threshold: None,
+            min_chunk_probs: 1,
+            max_chunk_probs: 16,
             pad_samples: 0,
             align_to: 1,
+            min_chunk_max_prob: 0.0,
         };
         let chunks = chunks_from_probs(&probs, &opts).unwrap();
         for (i, &p) in probs.iter().enumerate() {
-            if p >= threshold {
+            if p >= onset {
                 let lo = i * samples_per_prob;
                 let hi = (i + 1) * samples_per_prob;
                 let covered = chunks.iter().any(|c| c.start_sample <= lo && hi <= c.end_sample);
                 prop_assert!(
                     covered,
-                    "above-threshold prob {p:.3} at index {i} (samples {lo}..{hi}) \
-                     not covered by any chunk: {chunks:?}"
+                    "≥-onset prob {p:.3} at index {i} (samples {lo}..{hi}) not covered: {chunks:?}"
                 );
             }
         }
@@ -491,116 +502,27 @@ fn test_chunker_serde_default_roundtrip() {
     let default = ChunkerOpts::default();
     assert_eq!(opts.sample_rate, default.sample_rate);
     assert_eq!(opts.samples_per_prob, default.samples_per_prob);
-    assert!((opts.threshold - default.threshold).abs() < 1e-6);
-    assert!((opts.min_duration - default.min_duration).abs() < 1e-6);
-    assert!((opts.max_duration - default.max_duration).abs() < 1e-6);
-    assert_eq!(opts.cluster_target_duration, default.cluster_target_duration);
-    assert!((opts.strict_limit_duration - default.strict_limit_duration).abs() < 1e-6);
+    assert!((opts.onset - default.onset).abs() < 1e-6);
+    assert!((opts.offset - default.offset).abs() < 1e-6);
     assert_eq!(opts.min_speech_probs, default.min_speech_probs);
     assert_eq!(opts.min_silence_probs, default.min_silence_probs);
     assert_eq!(opts.merge_gap_probs, default.merge_gap_probs);
+    assert_eq!(opts.min_chunk_probs, default.min_chunk_probs);
+    assert_eq!(opts.max_chunk_probs, default.max_chunk_probs);
     assert_eq!(opts.pad_samples, default.pad_samples);
     assert_eq!(opts.align_to, default.align_to);
-}
-
-#[test]
-fn test_chunker_split_long_runs_respects_min_piece_floor() {
-    // 25-prob unbroken speech with a deep trough at index 1 and a wide
-    // search radius. Without the min_piece floor, the first split would
-    // land on probs[1]=0.0, leaving a 1-prob shard. With the floor
-    // (min_piece = 25 / (2 * 3) = 4) the split is held back to ≥ index 4.
-    let mut probs = vec![1.0f32; 25];
-    probs[1] = 0.0;
-    let opts = ChunkerOpts {
-        sample_rate: 1,
-        samples_per_prob: 1,
-        threshold: 0.5,
-        min_duration: 1.0,
-        max_duration: 10.0,
-        cluster_target_duration: None,
-        strict_limit_duration: 10.0,
-        min_speech_probs: 1,
-        min_silence_probs: 100, // suppress smoothing-driven termination
-        merge_gap_probs: 0,
-        trough_search_probs: Some(10),
-        trough_threshold: None,
-        pad_samples: 0,
-        align_to: 1,
-    };
-    let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert!(!chunks.is_empty());
-    let first_len = chunks[0].end_sample - chunks[0].start_sample;
-    assert!(first_len >= 4, "first chunk too small ({first_len} samples): {chunks:?}");
-}
-
-#[test]
-fn test_chunker_split_long_runs_respects_strict_limit_with_wide_search() {
-    // Wide trough search must not pull a split so far toward a low-prob frame
-    // that any produced cluster exceeds the hard model-context limit.
-    let mut probs = vec![1.0f32; 25];
-    probs[18] = 0.0;
-    let opts = ChunkerOpts {
-        sample_rate: 1,
-        samples_per_prob: 1,
-        threshold: 0.5,
-        min_duration: 1.0,
-        max_duration: 10.0,
-        cluster_target_duration: None,
-        strict_limit_duration: 10.0,
-        min_speech_probs: 1,
-        min_silence_probs: 100,
-        merge_gap_probs: 0,
-        trough_search_probs: Some(20),
-        trough_threshold: None,
-        pad_samples: 0,
-        align_to: 1,
-    };
-    let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert!(!chunks.is_empty());
-    for c in &chunks {
-        assert!(c.core_len() <= 10, "chunk exceeds strict limit: {c:?}");
-    }
-    assert_eq!(chunks.first().unwrap().start_sample, 0);
-    assert_eq!(chunks.last().unwrap().end_sample, 25);
-}
-
-#[test]
-fn test_chunker_decoupled_trough_search_radius() {
-    // With min_silence=2 the default search around target 13 would miss the
-    // legal trough at index 10. A wider trough_search_probs can choose it while
-    // still keeping the remaining pieces within strict=15.
-    let mut probs = vec![1.0f32; 40];
-    probs[10] = 0.4;
-    let opts = ChunkerOpts {
-        sample_rate: 1,
-        samples_per_prob: 1,
-        threshold: 0.5,
-        min_duration: 1.0,
-        max_duration: 10.0,
-        cluster_target_duration: None,
-        strict_limit_duration: 15.0,
-        min_speech_probs: 1,
-        min_silence_probs: 2,
-        merge_gap_probs: 0,
-        trough_search_probs: Some(8),
-        trough_threshold: None,
-        pad_samples: 0,
-        align_to: 1,
-    };
-    let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert_eq!(chunks, vec![AudioChunk::new(0, 10), AudioChunk::new(10, 25), AudioChunk::new(25, 40)]);
+    assert!((opts.min_chunk_max_prob - default.min_chunk_max_prob).abs() < 1e-6);
 }
 
 #[cfg(feature = "serde")]
 #[test]
 fn test_chunker_serde_partial_overrides() {
-    // Confirms that serde(default) on the struct lets partial JSON populate
-    // only the named fields; unspecified fields fall back to Default.
-    let json = r#"{ "min_duration": 10.0, "align_to": 640 }"#;
+    // serde(default) on the struct lets partial JSON populate only the
+    // named fields; unspecified fields fall back to Default.
+    let json = r#"{ "min_chunk_probs": 100, "align_to": 640 }"#;
     let opts: ChunkerOpts = serde_json::from_str(json).unwrap();
-    assert!((opts.min_duration - 10.0).abs() < 1e-6);
+    assert_eq!(opts.min_chunk_probs, 100);
     assert_eq!(opts.align_to, 640);
-    // Other fields stayed at default.
     assert_eq!(opts.sample_rate, 16_000);
     assert_eq!(opts.samples_per_prob, 512);
 }

--- a/arch/src/test/unit/vad/chunker.rs
+++ b/arch/src/test/unit/vad/chunker.rs
@@ -12,6 +12,7 @@ fn fast_opts() -> ChunkerOpts {
         threshold: 0.5,
         min_duration: 5.0,
         max_duration: 10.0,
+        cluster_target_duration: None,
         strict_limit_duration: 15.0,
         min_speech_probs: 1,
         min_silence_probs: 2,
@@ -40,7 +41,7 @@ fn test_chunker_single_segment_under_max() {
     // 7 probs of speech (= 7s, < max=10) bracketed by 3-prob silences.
     let probs = cat(&[silence(3), speech(7), silence(3)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 3, end_sample: 10 }]);
+    assert_eq!(chunks, vec![AudioChunk::new(3, 10)]);
 }
 
 #[test]
@@ -48,7 +49,7 @@ fn test_chunker_pack_two_segments_under_max() {
     // 4s + 4s with 2s silence gap = 10s total → fits one chunk (max=10).
     let probs = cat(&[speech(4), silence(2), speech(4)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 0, end_sample: 10 }]);
+    assert_eq!(chunks, vec![AudioChunk::new(0, 10)]);
 }
 
 #[test]
@@ -59,9 +60,69 @@ fn test_chunker_close_at_inter_segment_silence() {
     //   Close → chunk[0]=[0,10], chunk[1]=[12,16]. Silence [10,12) dropped.
     let probs = cat(&[speech(4), silence(2), speech(4), silence(2), speech(4)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
+    assert_eq!(chunks, vec![AudioChunk::new(0, 10), AudioChunk::new(12, 16)]);
+}
+
+#[test]
+fn test_chunker_cluster_target_splits_at_internal_gap() {
+    // The coarse packer would keep this as one 20s chunk. With a 8s cluster
+    // target, the second pass splits at the real 4s VAD gap nearest that
+    // target. The next core starts inside the gap, preserving bounded pre-roll
+    // for low-confidence speech that may sit before the next VAD run.
+    let probs = cat(&[speech(8), silence(4), speech(8)]);
+    let opts = ChunkerOpts {
+        max_duration: 30.0,
+        strict_limit_duration: 30.0,
+        cluster_target_duration: Some(8.0),
+        ..fast_opts()
+    };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert_eq!(chunks, vec![AudioChunk::new(0, 8), AudioChunk::new(10, 20)]);
+}
+
+#[test]
+fn test_chunker_cluster_target_splits_greedy_envelopes_at_midpoint_gaps() {
+    // Mirrors a pause-heavy longform layout: many short speech runs should first
+    // be packed into model-sized envelopes, then each long envelope split near
+    // its midpoint. A global duration-only partition tends to cut after the
+    // largest early gaps and separates short runs that belong together.
+    let speech_lens = [229, 59, 14, 60, 92, 56, 68, 38, 92, 73, 51, 95, 24, 56];
+    let gap_lens = [107, 92, 46, 28, 48, 39, 61, 32, 30, 46, 126, 117, 31];
+    let mut parts = Vec::new();
+    for (i, &speech_len) in speech_lens.iter().enumerate() {
+        parts.push(speech(speech_len));
+        if let Some(&gap_len) = gap_lens.get(i) {
+            parts.push(silence(gap_len));
+        }
+    }
+    let probs = cat(&parts);
+    let opts = ChunkerOpts {
+        sample_rate: 1,
+        samples_per_prob: 1,
+        threshold: 0.5,
+        min_duration: 469.0,
+        max_duration: 638.0,
+        cluster_target_duration: Some(319.0),
+        strict_limit_duration: 638.0,
+        min_speech_probs: 8,
+        min_silence_probs: 4,
+        merge_gap_probs: 8,
+        trough_search_probs: None,
+        trough_threshold: None,
+        pad_samples: 0,
+        align_to: 1,
+    };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
     assert_eq!(
         chunks,
-        vec![AudioChunk { start_sample: 0, end_sample: 10 }, AudioChunk { start_sample: 12, end_sample: 16 }]
+        vec![
+            AudioChunk::new(0, 229),
+            AudioChunk::new(233, 607),
+            AudioChunk::new(611, 938),
+            AudioChunk::new(942, 1264),
+            AudioChunk::new(1268, 1582),
+            AudioChunk::new(1586, 1810),
+        ]
     );
 }
 
@@ -69,16 +130,12 @@ fn test_chunker_close_at_inter_segment_silence() {
 fn test_chunker_strict_limit_splits_long_run() {
     // One 30-prob unbroken segment with a deliberate prob trough at index 14
     // (value 0.4). With strict=15, n=ceil(30/15)=2 ⇒ one split target at 15.
-    // Search radius = min_silence_probs = 2 ⇒ window [13..=17]. argmin lands
-    // on index 14 — *not* the geometric target 15. This is the "do better
-    // than GigaAM" property: split at the trough, not at strict_limit.
+    // Search radius = min_silence_probs = 2, but index 14 is illegal because
+    // it would leave a 16-prob suffix. The hard limit wins over trough quality.
     let mut probs = vec![1.0f32; 30];
     probs[14] = 0.4;
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
-    assert_eq!(
-        chunks,
-        vec![AudioChunk { start_sample: 0, end_sample: 14 }, AudioChunk { start_sample: 14, end_sample: 30 }]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 15), AudioChunk::new(15, 30)]);
 }
 
 #[test]
@@ -87,10 +144,7 @@ fn test_chunker_drops_silence_between_chunks() {
     // silence gap between them is gone from the output.
     let probs = cat(&[speech(4), silence(8), speech(4)]);
     let chunks = chunks_from_probs(&probs, &fast_opts()).unwrap();
-    assert_eq!(
-        chunks,
-        vec![AudioChunk { start_sample: 0, end_sample: 4 }, AudioChunk { start_sample: 12, end_sample: 16 }]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 4), AudioChunk::new(12, 16)]);
 }
 
 #[test]
@@ -127,7 +181,7 @@ fn test_chunker_pad_samples() {
     let opts = ChunkerOpts { pad_samples: 5, ..fast_opts() };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
     // Raw chunk would be (10, 20). With pad=5: (5, 25).
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 5, end_sample: 25 }]);
+    assert_eq!(chunks, vec![AudioChunk::with_decode(10, 20, 5, 25)]);
 }
 
 #[test]
@@ -139,7 +193,9 @@ fn test_chunker_pad_clamps_at_edges() {
     let max_sample = probs.len(); // samples_per_prob = 1
     assert_eq!(chunks.len(), 1);
     assert_eq!(chunks[0].start_sample, 0);
-    assert_eq!(chunks[0].end_sample, max_sample);
+    assert_eq!(chunks[0].end_sample, 8);
+    assert_eq!(chunks[0].decode_start_sample, 0);
+    assert_eq!(chunks[0].decode_end_sample, max_sample);
 }
 
 #[test]
@@ -155,6 +211,7 @@ fn test_chunker_align_to_640() {
         threshold: 0.5,
         min_duration: 0.0,
         max_duration: 1.0,
+        cluster_target_duration: None,
         strict_limit_duration: 1.0,
         min_speech_probs: 1,
         min_silence_probs: 2,
@@ -165,10 +222,10 @@ fn test_chunker_align_to_640() {
         align_to: 640,
     };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 1280, end_sample: 3840 }]);
+    assert_eq!(chunks, vec![AudioChunk::with_decode(1536, 3584, 1280, 3840)]);
     for c in &chunks {
-        assert_eq!(c.start_sample % 640, 0);
-        assert_eq!(c.end_sample % 640, 0);
+        assert_eq!(c.decode_start_sample % 640, 0);
+        assert_eq!(c.decode_end_sample % 640, 0);
     }
 }
 
@@ -177,9 +234,9 @@ fn test_chunker_end_sample_can_exceed_waveform_len() {
     // `chunks_from_probs` sees only `probs`, not the raw `waveform`. When the
     // waveform's actual length isn't a multiple of `samples_per_prob`, the
     // last prob's window straddles the waveform end and the emitted chunk's
-    // `end_sample` reflects the full window — overshooting the waveform by
+    // `decode_end_sample` reflects the full window — overshooting the waveform by
     // up to `samples_per_prob - 1` samples. This is the contract documented
-    // at `AudioChunk::end_sample`: callers owning the waveform must clamp at
+    // at `AudioChunk::decode_end_sample`: callers owning the waveform must clamp at
     // slice time. Pinned here so the documented overshoot is exercised by a
     // test, not just a comment.
     let probs = vec![1.0_f32; 4]; // 4 windows × 512 = 2048 samples of coverage
@@ -190,6 +247,7 @@ fn test_chunker_end_sample_can_exceed_waveform_len() {
         threshold: 0.5,
         min_duration: 0.0,
         max_duration: 1.0,
+        cluster_target_duration: None,
         strict_limit_duration: 1.0,
         min_speech_probs: 1,
         min_silence_probs: 1,
@@ -200,8 +258,8 @@ fn test_chunker_end_sample_can_exceed_waveform_len() {
         align_to: 640, // GigaAM: hop_length * subsampling_factor
     };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 0, end_sample: 2048 }]);
-    assert!(chunks[0].end_sample > waveform_len);
+    assert_eq!(chunks, vec![AudioChunk::new(0, 2048)]);
+    assert!(chunks[0].decode_end_sample > waveform_len);
 }
 
 #[test]
@@ -254,10 +312,8 @@ fn test_chunker_validates_zero_align_to() {
 // 1. Structural — sorted, non-overlapping, in-bounds, alignment-aligned, and
 //    deterministic across re-runs of the same input/opts.
 // 2. Strict-limit — with `pad=0, align=1`, every output chunk's sample length
-//    is bounded by `(strict_limit_probs + 2 * trough_radius) * samples_per_prob`.
-//    The `2 * radius` slack accounts for split_long_runs pieces that can
-//    exceed strict_limit by up to `radius` on each side; pack_segments's
-//    strict-limit guard caps any further growth.
+//    is bounded by `strict_limit_probs * samples_per_prob`. Trough search can
+//    move split points only inside legal ranges that preserve that hard cap.
 // 3. Coverage — with all smoothing knobs set to 1 (no smoothing) and
 //    `pad=0, align=1`, every above-threshold prob in the input falls inside
 //    some output chunk's sample range. Catches phantom-coverage regressions
@@ -289,6 +345,7 @@ proptest! {
             threshold,
             min_duration: min_dur,
             max_duration: max_dur,
+            cluster_target_duration: None,
             strict_limit_duration: strict_dur,
             min_speech_probs: min_speech,
             min_silence_probs: min_silence,
@@ -301,31 +358,34 @@ proptest! {
         let chunks = chunks_from_probs(&probs, &opts).unwrap();
         let max_sample = probs.len() * samples_per_prob;
 
-        // Sorted + non-overlapping (touching allowed). Adaptive padding
-        // caps each chunk's pad at half the silence gap to the neighbour,
-        // so padding can never bump adjacent chunks into one another.
+        // Core output ranges are sorted + non-overlapping (touching allowed).
         for w in chunks.windows(2) {
             prop_assert!(
                 w[0].end_sample <= w[1].start_sample,
-                "overlapping chunks: {:?} and {:?}", w[0], w[1]
+                "overlapping chunk cores: {:?} and {:?}", w[0], w[1]
             );
         }
-        // Each chunk is non-empty and inside the input extent.
+        // Each core/decode range is non-empty and inside the input extent.
         for c in &chunks {
             prop_assert!(c.start_sample < c.end_sample, "empty chunk: {c:?}");
             prop_assert!(c.end_sample <= max_sample,
-                "chunk {c:?} exceeds max_sample {max_sample}");
+                "chunk core {c:?} exceeds max_sample {max_sample}");
+            prop_assert!(c.decode_start_sample <= c.start_sample, "decode starts after core: {c:?}");
+            prop_assert!(c.end_sample <= c.decode_end_sample, "decode ends before core: {c:?}");
+            prop_assert!(c.decode_start_sample < c.decode_end_sample, "empty decode window: {c:?}");
+            prop_assert!(c.decode_end_sample <= max_sample,
+                "chunk decode {c:?} exceeds max_sample {max_sample}");
         }
-        // Alignment: start always aligned, end aligned OR clamped to max_sample
-        // (which is the only legitimate way an end can be non-aligned).
+        // Decode-window alignment: start always aligned, end aligned OR
+        // clamped to max_sample (the only legitimate non-aligned end).
         for c in &chunks {
-            prop_assert_eq!(c.start_sample % align_to, 0,
-                "start {} not aligned to {}", c.start_sample, align_to);
-            let end_aligned = c.end_sample % align_to == 0;
-            let end_at_max = c.end_sample == max_sample;
+            prop_assert_eq!(c.decode_start_sample % align_to, 0,
+                "decode start {} not aligned to {}", c.decode_start_sample, align_to);
+            let end_aligned = c.decode_end_sample % align_to == 0;
+            let end_at_max = c.decode_end_sample == max_sample;
             prop_assert!(end_aligned || end_at_max,
-                "end {} not aligned to {} and not at max_sample {}",
-                c.end_sample, align_to, max_sample);
+                "decode end {} not aligned to {} and not at max_sample {}",
+                c.decode_end_sample, align_to, max_sample);
         }
         // Same input, same output.
         let chunks2 = chunks_from_probs(&probs, &opts).unwrap();
@@ -353,6 +413,7 @@ proptest! {
             threshold,
             min_duration: min_dur,
             max_duration: max_dur,
+            cluster_target_duration: None,
             strict_limit_duration: strict_dur,
             min_speech_probs: min_speech,
             min_silence_probs: min_silence,
@@ -365,11 +426,8 @@ proptest! {
         let chunks = chunks_from_probs(&probs, &opts).unwrap();
         let probs_per_sec = sample_rate as f32 / samples_per_prob as f32;
         let strict_limit_probs = (strict_dur * probs_per_sec).ceil() as usize;
-        // With `trough_search_probs: None` the radius defaults to min_silence.
-        let radius = min_silence;
         let bound_samples = crate::vad::strict_chunk_sample_bound(
             strict_limit_probs,
-            radius,
             samples_per_prob,
             opts.pad_samples,
             opts.align_to,
@@ -379,7 +437,7 @@ proptest! {
             prop_assert!(
                 len <= bound_samples,
                 "chunk {c:?} length {len} exceeds bound {bound_samples} \
-                 (strict_probs={strict_limit_probs}, radius={radius}, spp={samples_per_prob})"
+                 (strict_probs={strict_limit_probs}, spp={samples_per_prob})"
             );
         }
     }
@@ -400,6 +458,7 @@ proptest! {
             threshold,
             min_duration: 0.05,
             max_duration: 0.5,
+            cluster_target_duration: None,
             strict_limit_duration: 0.5,
             min_speech_probs: 1,
             min_silence_probs: 1,
@@ -435,6 +494,7 @@ fn test_chunker_serde_default_roundtrip() {
     assert!((opts.threshold - default.threshold).abs() < 1e-6);
     assert!((opts.min_duration - default.min_duration).abs() < 1e-6);
     assert!((opts.max_duration - default.max_duration).abs() < 1e-6);
+    assert_eq!(opts.cluster_target_duration, default.cluster_target_duration);
     assert!((opts.strict_limit_duration - default.strict_limit_duration).abs() < 1e-6);
     assert_eq!(opts.min_speech_probs, default.min_speech_probs);
     assert_eq!(opts.min_silence_probs, default.min_silence_probs);
@@ -457,6 +517,7 @@ fn test_chunker_split_long_runs_respects_min_piece_floor() {
         threshold: 0.5,
         min_duration: 1.0,
         max_duration: 10.0,
+        cluster_target_duration: None,
         strict_limit_duration: 10.0,
         min_speech_probs: 1,
         min_silence_probs: 100, // suppress smoothing-driven termination
@@ -473,20 +534,50 @@ fn test_chunker_split_long_runs_respects_min_piece_floor() {
 }
 
 #[test]
-fn test_chunker_decoupled_trough_search_radius() {
-    // Same 30-prob long-run setup as test_chunker_strict_limit_splits_long_run,
-    // but with min_silence=2 (tight smoothing) and a deliberately wide
-    // trough_search_probs. Verifies the radius knob is independent of
-    // min_silence_probs: the wider window still finds the trough at idx 14
-    // even though min_silence is small.
-    let mut probs = vec![1.0f32; 30];
-    probs[14] = 0.4;
+fn test_chunker_split_long_runs_respects_strict_limit_with_wide_search() {
+    // Wide trough search must not pull a split so far toward a low-prob frame
+    // that any produced cluster exceeds the hard model-context limit.
+    let mut probs = vec![1.0f32; 25];
+    probs[18] = 0.0;
     let opts = ChunkerOpts {
         sample_rate: 1,
         samples_per_prob: 1,
         threshold: 0.5,
         min_duration: 1.0,
         max_duration: 10.0,
+        cluster_target_duration: None,
+        strict_limit_duration: 10.0,
+        min_speech_probs: 1,
+        min_silence_probs: 100,
+        merge_gap_probs: 0,
+        trough_search_probs: Some(20),
+        trough_threshold: None,
+        pad_samples: 0,
+        align_to: 1,
+    };
+    let chunks = chunks_from_probs(&probs, &opts).unwrap();
+    assert!(!chunks.is_empty());
+    for c in &chunks {
+        assert!(c.core_len() <= 10, "chunk exceeds strict limit: {c:?}");
+    }
+    assert_eq!(chunks.first().unwrap().start_sample, 0);
+    assert_eq!(chunks.last().unwrap().end_sample, 25);
+}
+
+#[test]
+fn test_chunker_decoupled_trough_search_radius() {
+    // With min_silence=2 the default search around target 13 would miss the
+    // legal trough at index 10. A wider trough_search_probs can choose it while
+    // still keeping the remaining pieces within strict=15.
+    let mut probs = vec![1.0f32; 40];
+    probs[10] = 0.4;
+    let opts = ChunkerOpts {
+        sample_rate: 1,
+        samples_per_prob: 1,
+        threshold: 0.5,
+        min_duration: 1.0,
+        max_duration: 10.0,
+        cluster_target_duration: None,
         strict_limit_duration: 15.0,
         min_speech_probs: 1,
         min_silence_probs: 2,
@@ -497,10 +588,7 @@ fn test_chunker_decoupled_trough_search_radius() {
         align_to: 1,
     };
     let chunks = chunks_from_probs(&probs, &opts).unwrap();
-    assert_eq!(
-        chunks,
-        vec![AudioChunk { start_sample: 0, end_sample: 14 }, AudioChunk { start_sample: 14, end_sample: 30 }]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 10), AudioChunk::new(10, 25), AudioChunk::new(25, 40)]);
 }
 
 #[cfg(feature = "serde")]

--- a/arch/src/test/unit/vad/segment.rs
+++ b/arch/src/test/unit/vad/segment.rs
@@ -1,15 +1,4 @@
-use crate::vad::ChunkerOpts;
-use crate::vad::segment::threshold_segments;
-
-fn opts(threshold: f32, min_speech: usize, min_silence: usize, merge_gap: usize) -> ChunkerOpts {
-    ChunkerOpts {
-        threshold,
-        min_speech_probs: min_speech,
-        min_silence_probs: min_silence,
-        merge_gap_probs: merge_gap,
-        ..ChunkerOpts::default()
-    }
-}
+use crate::vad::segment::{hysteresis_segments, merge_close};
 
 /// Builds a `[0|1]` prob array from a bit-string spec like `"00111111110000111111"`.
 fn probs_from(spec: &str) -> Vec<f32> {
@@ -23,64 +12,82 @@ fn probs_from(spec: &str) -> Vec<f32> {
 }
 
 #[test]
-fn test_threshold_segments_basic() {
-    // Two distinct speech runs, separated by enough silence to avoid
-    // both the smoothing-merge and the gap-merge.
+fn test_hysteresis_basic_two_runs() {
+    // Two distinct speech runs separated by enough silence to close cleanly.
     let probs = probs_from("00111111110000111111");
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 1));
-    assert_eq!(segments, vec![(2, 10), (14, 20)]);
+    let runs = hysteresis_segments(&probs, 0.5, 0.5, 4, 3);
+    assert_eq!(runs, vec![(2, 10), (14, 20)]);
 }
 
 #[test]
-fn test_threshold_segments_min_speech_filters_short_runs() {
-    // 2-frame speech blip is filtered by min_speech_probs=4; only the
-    // longer trailing run survives.
+fn test_hysteresis_min_speech_filters_short_runs() {
+    // 2-frame blip is filtered by min_speech=4.
     let probs = probs_from("0011000011111111");
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 0));
-    assert_eq!(segments, vec![(8, 16)]);
+    let runs = hysteresis_segments(&probs, 0.5, 0.5, 4, 3);
+    assert_eq!(runs, vec![(8, 16)]);
 }
 
 #[test]
-fn test_threshold_segments_min_silence_keeps_short_gaps() {
-    // 2-frame silence gap is below min_silence_probs=3, so the two
-    // speech runs are kept as a single continuous run.
+fn test_hysteresis_min_silence_keeps_short_gaps() {
+    // 2-frame silence gap is below min_silence=3, so the two speech runs stay fused.
     let probs = probs_from("11111100111111");
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 0));
-    assert_eq!(segments, vec![(0, 14)]);
+    let runs = hysteresis_segments(&probs, 0.5, 0.5, 4, 3);
+    assert_eq!(runs, vec![(0, 14)]);
 }
 
 #[test]
-fn test_threshold_segments_merge_gap_does_not_merge_when_far() {
-    // Two runs separated by 10 silence probs; merge_gap=8 keeps them split.
-    let probs = probs_from("11111111000000000011111111");
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 8));
-    assert_eq!(segments, vec![(0, 8), (18, 26)]);
+fn test_hysteresis_sustain_band_keeps_run_open() {
+    // onset=0.6, offset=0.3. A mid-run prob of 0.4 is in the sustain band:
+    // it does NOT increment the silence streak even though it's < onset.
+    let probs = vec![0.7, 0.7, 0.7, 0.4, 0.7, 0.7];
+    let runs = hysteresis_segments(&probs, 0.6, 0.3, 2, 2);
+    assert_eq!(runs, vec![(0, 6)]);
 }
 
 #[test]
-fn test_threshold_segments_merge_gap_merges_when_close() {
-    // Same shape, but merge_gap=10 fuses them into one.
-    let probs = probs_from("11111111000000000011111111");
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 10));
-    assert_eq!(segments, vec![(0, 26)]);
+fn test_hysteresis_offset_closes_run_promptly() {
+    // Run opens at p>=onset=0.6. Two consecutive p<offset=0.3 then close.
+    let probs = vec![0.7, 0.7, 0.7, 0.7, 0.1, 0.1, 0.7, 0.7];
+    let runs = hysteresis_segments(&probs, 0.6, 0.3, 2, 2);
+    // First run [0,4); after two `<offset` frames, run reopens at index 6.
+    // Tail run length 2 == min_speech, retained.
+    assert_eq!(runs, vec![(0, 4), (6, 8)]);
 }
 
 #[test]
-fn test_threshold_segments_empty() {
-    let segments = threshold_segments(&[], &opts(0.5, 4, 3, 0));
-    assert!(segments.is_empty());
+fn test_hysteresis_empty_input() {
+    assert!(hysteresis_segments(&[], 0.5, 0.5, 4, 3).is_empty());
 }
 
 #[test]
-fn test_threshold_segments_all_silence() {
+fn test_hysteresis_all_silence() {
     let probs = vec![0.0f32; 50];
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 0));
-    assert!(segments.is_empty());
+    assert!(hysteresis_segments(&probs, 0.5, 0.5, 4, 3).is_empty());
 }
 
 #[test]
-fn test_threshold_segments_all_speech() {
+fn test_hysteresis_all_speech_flushes_tail() {
     let probs = vec![1.0f32; 50];
-    let segments = threshold_segments(&probs, &opts(0.5, 4, 3, 0));
-    assert_eq!(segments, vec![(0, 50)]);
+    let runs = hysteresis_segments(&probs, 0.5, 0.5, 4, 3);
+    assert_eq!(runs, vec![(0, 50)]);
+}
+
+#[test]
+fn test_merge_close_does_not_merge_when_far() {
+    // Gap = 10 probs; merge_gap = 8 keeps them split.
+    let runs = vec![(0, 8), (18, 26)];
+    assert_eq!(merge_close(runs, 8), vec![(0, 8), (18, 26)]);
+}
+
+#[test]
+fn test_merge_close_merges_when_close() {
+    let runs = vec![(0, 8), (18, 26)];
+    assert_eq!(merge_close(runs, 10), vec![(0, 26)]);
+}
+
+#[test]
+fn test_merge_close_zero_gap_disables_merging() {
+    // merge_gap=0 means only directly-adjacent runs (gap == 0) merge.
+    let runs = vec![(0, 8), (8, 16), (20, 24)];
+    assert_eq!(merge_close(runs, 0), vec![(0, 16), (20, 24)]);
 }

--- a/arch/src/vad/mod.rs
+++ b/arch/src/vad/mod.rs
@@ -3,8 +3,8 @@
 //! Operates on `&[f32]` per-frame speech probabilities — the output of any
 //! frame-level VAD — and packs them into bounded-length [`AudioChunk`]s
 //! suitable for feeding to an encoder one chunk at a time. Speech-bearing
-//! regions of the waveform are preserved; pure-silence regions between
-//! chunks are dropped.
+//! regions of the waveform are preserved; inter-chunk silence is dropped except
+//! for bounded handoff pre-roll in clustered mode.
 //!
 //! The chunker is purely algorithmic: no Tensor or model dependency, no
 //! coupling to a specific VAD. The output is sample-index ranges that any
@@ -15,15 +15,17 @@
 //! ```text
 //! 1. threshold + smoothing  → speech runs (prob-grid indices)
 //! 2. split runs ≥ strict_limit at internal prob troughs
-//! 3. greedy-pack runs into chunks of ~[min_duration, max_duration]
-//!    (closing at inter-segment silence rather than mid-speech)
-//! 4. convert prob indices → samples, apply pad, align to align_to
+//! 3. greedy-pack runs into bounded envelopes
+//! 4. optionally split long envelopes at midpoint-nearest VAD gaps
+//! 5. convert prob indices → samples, apply pad, align to align_to
 //! ```
 //!
 //! All knobs live in [`ChunkerOpts`]; nothing inside the algorithm hardcodes
 //! sample rates, prob granularity, or alignment.
 
 pub(crate) mod segment;
+
+use std::cmp::Reverse;
 
 #[cfg(feature = "serde")]
 use serde::Deserialize;
@@ -56,6 +58,10 @@ pub struct ChunkerOpts {
     /// at the next inter-segment silence (or, for a single long run, at a
     /// local prob trough) instead of extending past max.
     pub max_duration: f32,
+    /// Optional target duration for gap-aware clustering. When set, chunking
+    /// recursively splits greedy VAD envelopes at midpoint-nearest inter-run
+    /// gaps, with the hard strict limit still enforced.
+    pub cluster_target_duration: Option<f32>,
     /// Hard ceiling. A single VAD segment longer than this is split
     /// internally at prob-trough argmins so no output chunk exceeds it.
     /// Also caps chunk length when an under-min chunk would otherwise
@@ -76,16 +82,15 @@ pub struct ChunkerOpts {
     /// to want the same scale; set explicitly to decouple them.
     pub trough_search_probs: Option<usize>,
     /// Secondary threshold (typically lower than `threshold`) for
-    /// `split_long_runs`. When `Some(t)`, search the full legal split
+    /// overlong-run splitting. When `Some(t)`, search the full legal split
     /// range for the frame closest to the geometric target with prob
     /// `< t`; fall back to the narrow argmin around the target when no
     /// frame qualifies. `None` always uses narrow argmin.
     pub trough_threshold: Option<f32>,
-    /// Symmetric pad in samples added to each chunk's start/end (clamped at
-    /// 0 and the implicit waveform end). Gives the encoder context at chunk
-    /// boundaries.
+    /// Symmetric pad in samples added to each decode window (clamped at 0 and
+    /// the implicit waveform end). Gives the encoder context at chunk seams.
     pub pad_samples: usize,
-    /// Snap chunk boundaries to integer multiples of this many samples.
+    /// Snap decode-window boundaries to integer multiples of this many samples.
     /// `1` = sample-precise. Set to the encoder's effective frame stride
     /// (e.g. `mel_hop * subsample_factor`) so chunks land on encoder-frame
     /// boundaries. Pathological values (e.g. > min_duration) are the
@@ -102,6 +107,7 @@ impl Default for ChunkerOpts {
             threshold: 0.5,
             min_duration: 15.0,
             max_duration: 22.0,
+            cluster_target_duration: None,
             strict_limit_duration: 30.0,
             min_speech_probs: 8,
             min_silence_probs: 4,
@@ -116,20 +122,47 @@ impl Default for ChunkerOpts {
 
 // ─── Output ───────────────────────────────────────────────────────────────
 
-/// A speech-bearing region of the source waveform.
+/// A speech-bearing output region plus the waveform window used to decode it.
 ///
-/// Sample indices reference the *original* waveform passed to the VAD.
-/// `start_sample` is `chunk_index * samples_per_prob` (after pad + align);
-/// callers can derive `start_sec = start_sample as f32 / sample_rate as f32`
-/// to offset per-chunk transcripts.
+/// `start_sample..end_sample` is the non-overlapping core range that owns
+/// output text. `decode_start_sample..decode_end_sample` is the possibly
+/// wider model input window that supplies acoustic context. All sample indices
+/// reference the original waveform passed to the VAD.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AudioChunk {
-    /// Inclusive start sample index in the original waveform.
+    /// Inclusive core/output start sample index in the original waveform.
     pub start_sample: usize,
-    /// Exclusive end sample index. May exceed the waveform length if the
-    /// last prob entry covered samples past the waveform end; callers
-    /// should clamp at slice time.
+    /// Exclusive core/output end sample index.
     pub end_sample: usize,
+    /// Inclusive decode-window start sample index in the original waveform.
+    pub decode_start_sample: usize,
+    /// Exclusive decode-window end sample index. May exceed the waveform
+    /// length if the last prob entry covered samples past the waveform end;
+    /// callers owning the waveform should clamp before slicing.
+    pub decode_end_sample: usize,
+}
+
+impl AudioChunk {
+    pub fn new(start_sample: usize, end_sample: usize) -> Self {
+        Self { start_sample, end_sample, decode_start_sample: start_sample, decode_end_sample: end_sample }
+    }
+
+    pub fn with_decode(
+        start_sample: usize,
+        end_sample: usize,
+        decode_start_sample: usize,
+        decode_end_sample: usize,
+    ) -> Self {
+        Self { start_sample, end_sample, decode_start_sample, decode_end_sample }
+    }
+
+    pub fn core_len(&self) -> usize {
+        self.end_sample.saturating_sub(self.start_sample)
+    }
+
+    pub fn decode_len(&self) -> usize {
+        self.decode_end_sample.saturating_sub(self.decode_start_sample)
+    }
 }
 
 // ─── Errors ───────────────────────────────────────────────────────────────
@@ -149,30 +182,28 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Upper bound (in samples) on any chunk [`chunks_from_probs`] can emit:
-/// `strict_limit + 2·trough_radius` (split_long_runs slack) `+ 2·pad +
-/// align_to` (post-process slack at waveform edges + alignment ceil).
-/// Single source of truth for downstream callers that need to size
-/// buffers or assert the contract.
+/// Upper bound (in samples) on any chunk decode window [`chunks_from_probs`]
+/// can emit: `strict_limit + 2·pad + 2·(align_to - 1)`. Single source of
+/// truth for downstream callers that need to size buffers or assert the
+/// contract.
 pub fn strict_chunk_sample_bound(
     strict_limit_probs: usize,
-    trough_radius: usize,
     samples_per_prob: usize,
     pad_samples: usize,
     align_to: usize,
 ) -> usize {
-    (strict_limit_probs + 2 * trough_radius) * samples_per_prob + 2 * pad_samples + align_to
+    strict_limit_probs * samples_per_prob + 2 * pad_samples + 2 * align_to.saturating_sub(1)
 }
 
 // ─── Public entry point ───────────────────────────────────────────────────
 
 /// Pack VAD speech probabilities into bounded-length chunks.
 ///
-/// Output chunks cover only speech-bearing portions of the waveform; silence
-/// between chunks is dropped. Boundaries are padded by `opts.pad_samples` and
-/// snapped to `opts.align_to` multiples (start floored, end ceil'd, so
-/// coverage is preserved). Adjacent chunks that overlap after padding are
-/// merged.
+/// Output chunk cores cover speech-bearing portions of the waveform and may
+/// retain bounded pre-roll from a split gap when clustering is enabled. Decode
+/// windows are expanded by `opts.pad_samples` and snapped to `opts.align_to`
+/// multiples (start floored, end ceil'd) so the model receives boundary context
+/// without changing output ownership.
 pub fn chunks_from_probs(probs: &[f32], opts: &ChunkerOpts) -> Result<Vec<AudioChunk>> {
     validate(opts)?;
     if probs.is_empty() {
@@ -183,12 +214,16 @@ pub fn chunks_from_probs(probs: &[f32], opts: &ChunkerOpts) -> Result<Vec<AudioC
     let strict_limit_probs = (opts.strict_limit_duration * probs_per_sec).ceil() as usize;
     let min_probs = (opts.min_duration * probs_per_sec).ceil() as usize;
     let max_probs = (opts.max_duration * probs_per_sec).ceil() as usize;
+    let cluster_target_probs = opts
+        .cluster_target_duration
+        .map(|duration| (duration * probs_per_sec).ceil() as usize)
+        .filter(|&probs| probs > 0);
 
     let trough_radius = opts.trough_search_probs.unwrap_or(opts.min_silence_probs);
     let trough_threshold = opts.trough_threshold;
 
     // Halve the silence-sensitivity knobs and retry if `threshold_segments`
-    // produced any segment exceeding `strict_limit_probs` — gives `split_long_runs`
+    // produced any segment exceeding `strict_limit_probs` — gives long-run splitting
     // less work / more silence to cut at. Floor at 2 because a single
     // sub-threshold prob is reliably a VAD micro-dip mid-word, not silence.
     let mut adapted = opts.clone();
@@ -201,8 +236,13 @@ pub fn chunks_from_probs(probs: &[f32], opts: &ChunkerOpts) -> Result<Vec<AudioC
         adapted.min_silence_probs = (adapted.min_silence_probs / 2).max(2);
         adapted.merge_gap_probs = (adapted.merge_gap_probs / 2).max(1);
     };
-    let segments = split_long_runs(segments, probs, trough_radius, trough_threshold, strict_limit_probs);
-    let chunks = pack_segments(&segments, min_probs, max_probs, strict_limit_probs);
+    let segments = LongRunSplitter::new(probs, trough_radius, trough_threshold, strict_limit_probs).split(segments);
+    let chunks = if let Some(target_probs) = cluster_target_probs {
+        ClusterPacker::new(&segments, min_probs, max_probs, strict_limit_probs, target_probs, opts.min_silence_probs)
+            .pack()
+    } else {
+        pack_segments(&segments, min_probs, max_probs, strict_limit_probs)
+    };
 
     Ok(post_process(&chunks, probs.len(), opts))
 }
@@ -225,84 +265,99 @@ fn validate(opts: &ChunkerOpts) -> Result<()> {
     Ok(())
 }
 
-/// Break any speech segment whose length exceeds `strict_limit_probs` into
-/// `ceil(len / strict_limit)` near-equal pieces, choosing each split point
-/// as the prob argmin within ±`search_radius` of the geometric target. Lands
-/// on natural pauses inside long unbroken runs instead of hard-cutting at
-/// fixed time intervals.
-///
-/// Each emitted piece is at least `len / (2 * n)` long. Without that floor
-/// a wide `search_radius` can let the argmin land arbitrarily close to a
-/// split's neighbours and produce 1-prob shards that downstream code has to
-/// special-case. With the floor the worst-case shrinkage is half the
-/// average piece length.
-fn split_long_runs(
-    segments: Vec<(usize, usize)>,
-    probs: &[f32],
+/// Splits single VAD runs that are longer than the model can decode.
+struct LongRunSplitter<'a> {
+    probs: &'a [f32],
     search_radius: usize,
     trough_threshold: Option<f32>,
     strict_limit_probs: usize,
-) -> Vec<(usize, usize)> {
-    if strict_limit_probs == 0 {
-        return segments;
-    }
-    let mut out = Vec::with_capacity(segments.len());
-    for (start, end) in segments {
-        let len = end - start;
-        if len <= strict_limit_probs {
-            out.push((start, end));
-            continue;
-        }
-        let n = len.div_ceil(strict_limit_probs);
-        let min_piece = (len / (2 * n)).max(1);
-        let mut cur = start;
-        for k in 1..n {
-            let target = start + (len * k) / n;
-            let pieces_left = n - k;
-            // Constrain the argmin window so this split is at least
-            // min_piece away from cur and from `end - pieces_left * min_piece`
-            // (i.e. each remaining piece can still hit min_piece).
-            let lo_narrow = target.saturating_sub(search_radius).max(cur + min_piece);
-            let hi_floor = end.saturating_sub(pieces_left * min_piece);
-            let hi_narrow = (target + search_radius).min(hi_floor.saturating_sub(1));
+}
 
-            // With `trough_threshold`: prefer a real silence frame anywhere
-            // in the legal range (closest to target for balance) over the
-            // narrow-radius argmin which may land inside speech.
-            let trough_split = trough_threshold.and_then(|t| {
-                let lo_wide = cur + min_piece;
-                let hi_wide = hi_floor.saturating_sub(1);
-                if hi_wide < lo_wide {
-                    return None;
-                }
-                let slice = &probs[lo_wide..=hi_wide];
-                slice
-                    .iter()
-                    .enumerate()
-                    .filter(|&(_, &p)| p < t)
-                    .min_by_key(|(i, _)| (lo_wide + i).abs_diff(target))
-                    .map(|(i, _)| lo_wide + i)
-            });
-            let split = if let Some(s) = trough_split {
-                s
-            } else if hi_narrow >= lo_narrow {
-                lo_narrow + argmin(&probs[lo_narrow..=hi_narrow])
-            } else {
-                // Constraints incompatible (radius wider than the available
-                // slack). Fall back to the geometric target, clamped so the
-                // remaining pieces are still non-empty.
-                target.clamp(cur + min_piece, hi_floor.saturating_sub(1).max(cur + min_piece))
+#[derive(Clone, Copy)]
+struct SplitWindow {
+    lo: usize,
+    hi: usize,
+}
+
+impl<'a> LongRunSplitter<'a> {
+    fn new(probs: &'a [f32], search_radius: usize, trough_threshold: Option<f32>, strict_limit_probs: usize) -> Self {
+        Self { probs, search_radius, trough_threshold, strict_limit_probs }
+    }
+
+    fn split(&self, segments: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+        if self.strict_limit_probs == 0 {
+            return segments;
+        }
+
+        let mut out = Vec::with_capacity(segments.len());
+        for segment in segments {
+            self.split_one(segment, &mut out);
+        }
+        out
+    }
+
+    fn split_one(&self, (start, end): (usize, usize), out: &mut Vec<(usize, usize)>) {
+        let len = end - start;
+        if len <= self.strict_limit_probs {
+            out.push((start, end));
+            return;
+        }
+
+        let pieces = len.div_ceil(self.strict_limit_probs);
+        let min_piece = (len / (2 * pieces)).max(1);
+        let mut cur = start;
+        for piece_idx in 1..pieces {
+            let target = start + (len * piece_idx) / pieces;
+            let pieces_left = pieces - piece_idx;
+            let Some(window) = self.legal_window(cur, end, pieces_left, min_piece) else {
+                continue;
             };
+            let split = self.choose_split(target, window);
             if split > cur && split < end {
                 out.push((cur, split));
                 cur = split;
             }
         }
+
         if cur < end {
             out.push((cur, end));
         }
     }
-    out
+
+    fn legal_window(&self, cur: usize, end: usize, pieces_left: usize, min_piece: usize) -> Option<SplitWindow> {
+        let lo_fit = end.saturating_sub(pieces_left * self.strict_limit_probs).max(cur + 1);
+        let hi_fit = (cur + self.strict_limit_probs).min(end.saturating_sub(pieces_left));
+        if hi_fit < lo_fit {
+            return None;
+        }
+
+        let lo_quality = lo_fit.max(cur + min_piece.min(self.strict_limit_probs));
+        let lo = if lo_quality <= hi_fit { lo_quality } else { lo_fit };
+        Some(SplitWindow { lo, hi: hi_fit })
+    }
+
+    fn choose_split(&self, target: usize, window: SplitWindow) -> usize {
+        if let Some(split) = self.threshold_split(target, window) {
+            return split;
+        }
+
+        let lo = target.saturating_sub(self.search_radius).max(window.lo);
+        let hi = (target + self.search_radius).min(window.hi);
+        if hi < lo {
+            return target.clamp(window.lo, window.hi);
+        }
+        lo + argmin(&self.probs[lo..=hi])
+    }
+
+    fn threshold_split(&self, target: usize, window: SplitWindow) -> Option<usize> {
+        let threshold = self.trough_threshold?;
+        self.probs[window.lo..=window.hi]
+            .iter()
+            .enumerate()
+            .filter(|&(_, &p)| p < threshold)
+            .min_by_key(|(i, _)| (window.lo + i).abs_diff(target))
+            .map(|(i, _)| window.lo + i)
+    }
 }
 
 fn argmin(slice: &[f32]) -> usize {
@@ -350,10 +405,149 @@ fn pack_segments(
     chunks
 }
 
-/// Convert prob-index ranges to sample ranges. Padding is adaptive: each
-/// side is capped at half the silence gap to the neighbour, so chunks
-/// never overlap their neighbours' speech. Alignment-induced overlap
-/// (floor-start / ceil-end rounding) is clipped to preserve splits.
+/// Gap-aware ordered clustering for RNNT-sensitive long-form decoding.
+struct ClusterPacker<'a> {
+    segments: &'a [(usize, usize)],
+    min_probs: usize,
+    max_probs: usize,
+    strict_limit_probs: usize,
+    target_probs: usize,
+    handoff_probs: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SegmentGroup {
+    start_idx: usize,
+    end_idx: usize,
+}
+
+impl SegmentGroup {
+    fn new(start_idx: usize, end_idx: usize) -> Self {
+        Self { start_idx, end_idx }
+    }
+}
+
+impl<'a> ClusterPacker<'a> {
+    fn new(
+        segments: &'a [(usize, usize)],
+        min_probs: usize,
+        max_probs: usize,
+        strict_limit_probs: usize,
+        target_probs: usize,
+        handoff_probs: usize,
+    ) -> Self {
+        Self { segments, min_probs, max_probs, strict_limit_probs, target_probs, handoff_probs }
+    }
+
+    fn pack(&self) -> Vec<(usize, usize)> {
+        if self.segments.is_empty() || self.target_probs == 0 {
+            return Vec::new();
+        }
+
+        let mut groups = Vec::new();
+        for group in self.greedy_groups() {
+            self.split_at_midpoints(group, &mut groups);
+        }
+        self.materialize(&groups)
+    }
+
+    fn greedy_groups(&self) -> Vec<SegmentGroup> {
+        let mut groups = Vec::new();
+        let mut start_idx = 0usize;
+        for idx in 1..self.segments.len() {
+            let prospective = self.segments[idx].1 - self.segments[start_idx].0;
+            let cur_len = self.segments[idx - 1].1 - self.segments[start_idx].0;
+            if prospective > self.max_probs && (cur_len >= self.min_probs || prospective > self.strict_limit_probs) {
+                groups.push(SegmentGroup::new(start_idx, idx));
+                start_idx = idx;
+            }
+        }
+        groups.push(SegmentGroup::new(start_idx, self.segments.len()));
+        groups
+    }
+
+    fn split_at_midpoints(&self, group: SegmentGroup, out: &mut Vec<SegmentGroup>) {
+        if group.end_idx <= group.start_idx + 1 || self.group_len(group) <= self.split_threshold() {
+            out.push(group);
+            return;
+        }
+
+        let split = self.midpoint_gap(group).expect("non-singleton group has an internal split");
+        self.split_at_midpoints(SegmentGroup::new(group.start_idx, split), out);
+        self.split_at_midpoints(SegmentGroup::new(split, group.end_idx), out);
+    }
+
+    fn materialize(&self, groups: &[SegmentGroup]) -> Vec<(usize, usize)> {
+        if groups.is_empty() {
+            return Vec::new();
+        }
+
+        let mut chunks = Vec::with_capacity(groups.len());
+        let mut start = self.segments[groups[0].start_idx].0;
+
+        for (idx, group) in groups.iter().copied().enumerate() {
+            let end = self.segments[group.end_idx - 1].1;
+            if end > start {
+                chunks.push((start.max(end.saturating_sub(self.strict_limit_probs)), end));
+            }
+            if let Some(next) = groups.get(idx + 1).copied() {
+                start = self.handoff_start(end, self.segments[next.start_idx].0);
+            }
+        }
+        chunks
+    }
+
+    fn group_len(&self, group: SegmentGroup) -> usize {
+        self.segments[group.end_idx - 1].1 - self.group_start(group.start_idx)
+    }
+
+    fn group_start(&self, start_idx: usize) -> usize {
+        if start_idx == 0 {
+            self.segments[0].0
+        } else {
+            self.handoff_start(self.segments[start_idx - 1].1, self.segments[start_idx].0)
+        }
+    }
+
+    fn split_threshold(&self) -> usize {
+        self.target_probs.saturating_add(self.target_probs / 2)
+    }
+
+    fn midpoint_gap(&self, group: SegmentGroup) -> Option<usize> {
+        let group_start = self.group_start(group.start_idx);
+        let group_end = self.segments[group.end_idx - 1].1;
+        let midpoint_twice = group_start + group_end;
+
+        (group.start_idx + 1..group.end_idx).min_by_key(|&idx| self.gap_key(idx, midpoint_twice))
+    }
+
+    fn gap_key(&self, split_idx: usize, midpoint_twice: usize) -> (usize, Reverse<usize>) {
+        let gap_start = self.segments[split_idx - 1].1;
+        let gap_end = self.segments[split_idx].0;
+        let distance_twice = if midpoint_twice < 2 * gap_start {
+            2 * gap_start - midpoint_twice
+        } else {
+            midpoint_twice.saturating_sub(2 * gap_end)
+        };
+        (distance_twice, Reverse(gap_end.saturating_sub(gap_start)))
+    }
+
+    fn handoff_start(&self, gap_start: usize, gap_end: usize) -> usize {
+        if gap_end <= gap_start {
+            return gap_end;
+        }
+
+        let gap = gap_end - gap_start;
+        let drop_after_prev = self.handoff_probs.min(gap / 2);
+        let pre_context = (self.target_probs * 2 / 5).max(1);
+        (gap_start + drop_after_prev).max(gap_end.saturating_sub(pre_context)).min(gap_end)
+    }
+}
+
+/// Convert prob-index core ranges to sample ranges and derive decode windows.
+/// Padding is adaptive: each side is capped at half the core gap to the
+/// neighbour, so decode windows remain non-overlapping while still exposing
+/// local silence/context around each core.
 fn post_process(chunks: &[(usize, usize)], probs_len: usize, opts: &ChunkerOpts) -> Vec<AudioChunk> {
     let max_sample = probs_len * opts.samples_per_prob;
     let pad = opts.pad_samples;
@@ -361,48 +555,36 @@ fn post_process(chunks: &[(usize, usize)], probs_len: usize, opts: &ChunkerOpts)
 
     let mut out: Vec<AudioChunk> = Vec::with_capacity(chunks.len());
     for (i, &(s, e)) in chunks.iter().enumerate() {
-        let raw_start = s * opts.samples_per_prob;
-        let raw_end = e * opts.samples_per_prob;
+        let core_start = s * opts.samples_per_prob;
+        let core_end = e * opts.samples_per_prob;
 
         // Cap each side's padding at half the silence gap to the neighbour
         // (or the full margin at the waveform edges). Floor division: total
         // pad consumed by adjacent chunks ≤ gap, so they never overlap.
         let pad_left = if i == 0 {
-            pad.min(raw_start)
+            pad.min(core_start)
         } else {
             let prev_raw_end = chunks[i - 1].1 * opts.samples_per_prob;
-            pad.min(raw_start.saturating_sub(prev_raw_end) / 2)
+            pad.min(core_start.saturating_sub(prev_raw_end) / 2)
         };
         let pad_right = if i + 1 == chunks.len() {
-            pad.min(max_sample.saturating_sub(raw_end))
+            pad.min(max_sample.saturating_sub(core_end))
         } else {
             let next_raw_start = chunks[i + 1].0 * opts.samples_per_prob;
-            pad.min(next_raw_start.saturating_sub(raw_end) / 2)
+            pad.min(next_raw_start.saturating_sub(core_end) / 2)
         };
 
-        let padded_start = raw_start - pad_left;
-        let padded_end = (raw_end + pad_right).min(max_sample);
-        let aligned_start = (padded_start / align) * align;
-        let mut aligned_end = padded_end.div_ceil(align) * align;
-        if aligned_end > max_sample {
-            aligned_end = max_sample;
+        let padded_start = core_start - pad_left;
+        let padded_end = (core_end + pad_right).min(max_sample);
+        let decode_start = (padded_start / align) * align;
+        let mut decode_end = padded_end.div_ceil(align) * align;
+        if decode_end > max_sample {
+            decode_end = max_sample;
         }
-        if aligned_end <= aligned_start {
+        if core_end <= core_start || decode_end <= decode_start {
             continue;
         }
-        if let Some(last) = out.last_mut()
-            && aligned_start < last.end_sample
-        {
-            // Alignment-only overlap (asymmetric floor/ceil rounding put us
-            // inside the previous chunk). Clip our start up to preserve the
-            // split. Drop if it collapses to empty.
-            let bumped_start = last.end_sample;
-            if aligned_end > bumped_start {
-                out.push(AudioChunk { start_sample: bumped_start, end_sample: aligned_end });
-            }
-            continue;
-        }
-        out.push(AudioChunk { start_sample: aligned_start, end_sample: aligned_end });
+        out.push(AudioChunk::with_decode(core_start, core_end, decode_start, decode_end));
     }
     out
 }

--- a/arch/src/vad/mod.rs
+++ b/arch/src/vad/mod.rs
@@ -1,44 +1,42 @@
-//! VAD-aware chunker for long-form ASR.
+//! Cut & Merge VAD chunker for long-form ASR.
 //!
 //! Operates on `&[f32]` per-frame speech probabilities — the output of any
 //! frame-level VAD — and packs them into bounded-length [`AudioChunk`]s
-//! suitable for feeding to an encoder one chunk at a time. Speech-bearing
-//! regions of the waveform are preserved; inter-chunk silence is dropped except
-//! for bounded handoff pre-roll in clustered mode.
-//!
-//! The chunker is purely algorithmic: no Tensor or model dependency, no
-//! coupling to a specific VAD. The output is sample-index ranges that any
-//! downstream decoder can consume.
+//! suitable for feeding to an encoder one chunk at a time.
 //!
 //! # Algorithm
 //!
 //! ```text
-//! 1. threshold + smoothing  → speech runs (prob-grid indices)
-//! 2. split runs ≥ strict_limit at internal prob troughs
-//! 3. greedy-pack runs into bounded envelopes
-//! 4. optionally split long envelopes at midpoint-nearest VAD gaps
-//! 5. convert prob indices → samples, apply pad, align to align_to
+//! 1. hysteresis_segments    (onset/offset → speech runs)
+//! 2. merge_close            (fold runs separated by ≤ merge_gap_probs)
+//! 3. cut_long_runs          (any run > max_chunk_probs is split at silence trough)
+//! 4. pack_chunks            (greedy concat up to max_chunk_probs)
+//! 5. post_process           (prob → samples, raw pad, frame-align, no decode overlap)
+//! 6. speech_gate            (drop chunks with peak core prob < min_chunk_max_prob)
 //! ```
 //!
-//! All knobs live in [`ChunkerOpts`]; nothing inside the algorithm hardcodes
-//! sample rates, prob granularity, or alignment.
+//! Compared with the previous design this collapses smoothing + cluster
+//! packing + trough-radius search into a single pass that always splits on
+//! the rightmost real silence (or argmin fallback), guarantees decode
+//! windows never overlap (eliminating duplicate tokens at seams), and gates
+//! out chunks that contain no Silero-confident speech.
 
 pub(crate) mod segment;
-
-use std::cmp::Reverse;
 
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 use snafu::Snafu;
 
-use segment::threshold_segments;
+use segment::{hysteresis_segments, merge_close};
 
 // ─── Config ───────────────────────────────────────────────────────────────
 
 /// Configuration for [`chunks_from_probs`].
 ///
-/// All `*_duration` fields are wall-clock seconds; the chunker converts to
-/// prob-grid indices via `(sample_rate, samples_per_prob)`.
+/// All durations are expressed in prob-grid units — the upstream
+/// [`SileroVadSplitter`](../silero_vad/struct.SileroVadSplitter.html) (or
+/// equivalent) is responsible for converting wall-clock seconds and
+/// `sample_rate` into prob counts.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -46,76 +44,65 @@ pub struct ChunkerOpts {
     /// Sample rate of the source waveform in Hz.
     pub sample_rate: u32,
     /// Number of input samples covered by one entry of the `probs` array.
-    /// Match the stride of the upstream frame-level VAD. Required so the
-    /// chunker stays VAD-agnostic.
+    /// Match the stride of the upstream frame-level VAD.
     pub samples_per_prob: usize,
-    /// Speech threshold: prob entries `>= threshold` count as speech.
-    pub threshold: f32,
-    /// Soft minimum chunk duration. The chunker won't voluntarily close a
-    /// chunk shorter than this.
-    pub min_duration: f32,
-    /// Soft maximum chunk duration. Past `min_duration`, the chunk closes
-    /// at the next inter-segment silence (or, for a single long run, at a
-    /// local prob trough) instead of extending past max.
-    pub max_duration: f32,
-    /// Optional target duration for gap-aware clustering. When set, chunking
-    /// recursively splits greedy VAD envelopes at midpoint-nearest inter-run
-    /// gaps, with the hard strict limit still enforced.
-    pub cluster_target_duration: Option<f32>,
-    /// Hard ceiling. A single VAD segment longer than this is split
-    /// internally at prob-trough argmins so no output chunk exceeds it.
-    /// Also caps chunk length when an under-min chunk would otherwise
-    /// be extended past this.
-    pub strict_limit_duration: f32,
-    /// Pre-segmentation smoothing: a speech run must contain at least this
-    /// many above-threshold probs to be retained.
+
+    /// Hysteresis open threshold: a speech run begins at the first prob `≥ onset`.
+    pub onset: f32,
+    /// Hysteresis close threshold (`≤ onset`): probs `< offset` accumulate
+    /// silence; reaching `min_silence_probs` consecutive such frames closes
+    /// the run. Pass equal to `onset` for single-threshold behaviour.
+    pub offset: f32,
+
+    /// Minimum length (in probs) of a committed speech run. Shorter runs are
+    /// dropped before chunk packing.
     pub min_speech_probs: usize,
-    /// Pre-segmentation smoothing: a silence gap must span at least this
-    /// many below-threshold probs to terminate a speech run.
+    /// Number of consecutive `< offset` probs required to terminate a speech run.
     pub min_silence_probs: usize,
-    /// Two speech runs separated by ≤ this many silence probs are merged
-    /// before chunking.
+    /// Two committed runs separated by ≤ this many probs are merged.
     pub merge_gap_probs: usize,
-    /// Window radius (in prob-grid units) for the trough-argmin search when
-    /// splitting overlong runs. `None` (default) reuses `min_silence_probs`,
-    /// which is fine when smoothing tightness and trough-search width happen
-    /// to want the same scale; set explicitly to decouple them.
-    pub trough_search_probs: Option<usize>,
-    /// Secondary threshold (typically lower than `threshold`) for
-    /// overlong-run splitting. When `Some(t)`, search the full legal split
-    /// range for the frame closest to the geometric target with prob
-    /// `< t`; fall back to the narrow argmin around the target when no
-    /// frame qualifies. `None` always uses narrow argmin.
-    pub trough_threshold: Option<f32>,
-    /// Symmetric pad in samples added to each decode window (clamped at 0 and
-    /// the implicit waveform end). Gives the encoder context at chunk seams.
+
+    /// Soft minimum chunk length (in probs). Used as the left edge of the
+    /// legal split window when min-cutting an over-long run; not a hard
+    /// emission floor.
+    pub min_chunk_probs: usize,
+    /// Hard maximum chunk length (in probs). No emitted chunk's core spans
+    /// more than this many probs.
+    pub max_chunk_probs: usize,
+
+    /// Symmetric pad in samples added to each decode window (clamped at 0
+    /// and the implicit waveform end). After alignment, the next chunk's
+    /// decode_start is pinned to `≥ prev.decode_end` so decode windows
+    /// never overlap.
     pub pad_samples: usize,
-    /// Snap decode-window boundaries to integer multiples of this many samples.
-    /// `1` = sample-precise. Set to the encoder's effective frame stride
+    /// Snap decode-window boundaries to integer multiples of this many
+    /// samples. Set to the encoder's effective frame stride
     /// (e.g. `mel_hop * subsample_factor`) so chunks land on encoder-frame
-    /// boundaries. Pathological values (e.g. > min_duration) are the
-    /// caller's responsibility — boundaries can shift by up to
-    /// `align_to - 1` samples.
+    /// boundaries.
     pub align_to: usize,
+
+    /// Speech gate: drop any chunk whose **peak** Silero prob over its core
+    /// (prob-grid) range is below this. Set to `0.0` to disable.
+    pub min_chunk_max_prob: f32,
 }
 
 impl Default for ChunkerOpts {
     fn default() -> Self {
+        // Defaults assume 16 kHz / 512-sample Silero windows ≈ 31.25 probs/s.
+        // 8 probs ≈ 256 ms · 4 probs ≈ 128 ms · 13 probs ≈ 416 ms · 875 probs ≈ 28 s.
         Self {
             sample_rate: 16_000,
             samples_per_prob: 512,
-            threshold: 0.5,
-            min_duration: 15.0,
-            max_duration: 22.0,
-            cluster_target_duration: None,
-            strict_limit_duration: 30.0,
+            onset: 0.50,
+            offset: 0.35,
             min_speech_probs: 8,
             min_silence_probs: 4,
-            merge_gap_probs: 8,
-            trough_search_probs: None,
-            trough_threshold: None,
-            pad_samples: 0,
+            merge_gap_probs: 13,
+            min_chunk_probs: 16,
+            max_chunk_probs: 875,
+            pad_samples: 4_800,
             align_to: 1,
+            min_chunk_max_prob: 0.3,
         }
     }
 }
@@ -130,15 +117,9 @@ impl Default for ChunkerOpts {
 /// reference the original waveform passed to the VAD.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AudioChunk {
-    /// Inclusive core/output start sample index in the original waveform.
     pub start_sample: usize,
-    /// Exclusive core/output end sample index.
     pub end_sample: usize,
-    /// Inclusive decode-window start sample index in the original waveform.
     pub decode_start_sample: usize,
-    /// Exclusive decode-window end sample index. May exceed the waveform
-    /// length if the last prob entry covered samples past the waveform end;
-    /// callers owning the waveform should clamp before slicing.
     pub decode_end_sample: usize,
 }
 
@@ -174,77 +155,43 @@ pub enum Error {
     ZeroSamplesPerProb,
     #[snafu(display("align_to must be > 0"))]
     ZeroAlignTo,
-    #[snafu(display("min_duration ({min}) must be ≤ max_duration ({max})"))]
-    MinExceedsMax { min: f32, max: f32 },
-    #[snafu(display("max_duration ({max}) must be ≤ strict_limit_duration ({strict})"))]
-    MaxExceedsStrict { max: f32, strict: f32 },
+    #[snafu(display("max_chunk_probs must be > 0"))]
+    ZeroMaxChunk,
+    #[snafu(display("min_chunk_probs ({min}) must be ≤ max_chunk_probs ({max})"))]
+    MinExceedsMax { min: usize, max: usize },
+    #[snafu(display("offset ({offset}) must be ≤ onset ({onset})"))]
+    OffsetExceedsOnset { offset: f32, onset: f32 },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Upper bound (in samples) on any chunk decode window [`chunks_from_probs`]
-/// can emit: `strict_limit + 2·pad + 2·(align_to - 1)`. Single source of
-/// truth for downstream callers that need to size buffers or assert the
-/// contract.
-pub fn strict_chunk_sample_bound(
-    strict_limit_probs: usize,
+/// can emit: `max_chunk_probs · samples_per_prob + 2·pad + 2·(align_to - 1)`.
+/// Downstream callers use this to size buffers.
+pub fn max_chunk_sample_bound(
+    max_chunk_probs: usize,
     samples_per_prob: usize,
     pad_samples: usize,
     align_to: usize,
 ) -> usize {
-    strict_limit_probs * samples_per_prob + 2 * pad_samples + 2 * align_to.saturating_sub(1)
+    max_chunk_probs * samples_per_prob + 2 * pad_samples + 2 * align_to.saturating_sub(1)
 }
 
 // ─── Public entry point ───────────────────────────────────────────────────
 
-/// Pack VAD speech probabilities into bounded-length chunks.
-///
-/// Output chunk cores cover speech-bearing portions of the waveform and may
-/// retain bounded pre-roll from a split gap when clustering is enabled. Decode
-/// windows are expanded by `opts.pad_samples` and snapped to `opts.align_to`
-/// multiples (start floored, end ceil'd) so the model receives boundary context
-/// without changing output ownership.
+/// Pack VAD speech probabilities into bounded-length chunks via Cut & Merge.
 pub fn chunks_from_probs(probs: &[f32], opts: &ChunkerOpts) -> Result<Vec<AudioChunk>> {
     validate(opts)?;
     if probs.is_empty() {
         return Ok(Vec::new());
     }
 
-    let probs_per_sec = opts.sample_rate as f32 / opts.samples_per_prob as f32;
-    let strict_limit_probs = (opts.strict_limit_duration * probs_per_sec).ceil() as usize;
-    let min_probs = (opts.min_duration * probs_per_sec).ceil() as usize;
-    let max_probs = (opts.max_duration * probs_per_sec).ceil() as usize;
-    let cluster_target_probs = opts
-        .cluster_target_duration
-        .map(|duration| (duration * probs_per_sec).ceil() as usize)
-        .filter(|&probs| probs > 0);
-
-    let trough_radius = opts.trough_search_probs.unwrap_or(opts.min_silence_probs);
-    let trough_threshold = opts.trough_threshold;
-
-    // Halve the silence-sensitivity knobs and retry if `threshold_segments`
-    // produced any segment exceeding `strict_limit_probs` — gives long-run splitting
-    // less work / more silence to cut at. Floor at 2 because a single
-    // sub-threshold prob is reliably a VAD micro-dip mid-word, not silence.
-    let mut adapted = opts.clone();
-    let segments = loop {
-        let segs = threshold_segments(probs, &adapted);
-        let any_over = segs.iter().any(|&(s, e)| e - s > strict_limit_probs);
-        if !any_over || adapted.min_silence_probs <= 2 {
-            break segs;
-        }
-        adapted.min_silence_probs = (adapted.min_silence_probs / 2).max(2);
-        adapted.merge_gap_probs = (adapted.merge_gap_probs / 2).max(1);
-    };
-    let segments = LongRunSplitter::new(probs, trough_radius, trough_threshold, strict_limit_probs).split(segments);
-    let chunks = if let Some(target_probs) = cluster_target_probs {
-        ClusterPacker::new(&segments, min_probs, max_probs, strict_limit_probs, target_probs, opts.min_silence_probs)
-            .pack()
-    } else {
-        pack_segments(&segments, min_probs, max_probs, strict_limit_probs)
-    };
-
-    Ok(post_process(&chunks, probs.len(), opts))
+    let runs = hysteresis_segments(probs, opts.onset, opts.offset, opts.min_speech_probs, opts.min_silence_probs);
+    let runs = merge_close(runs, opts.merge_gap_probs);
+    let sub_runs = cut_long_runs(probs, &runs, opts.min_chunk_probs, opts.max_chunk_probs, opts.offset);
+    let chunks = pack_chunks(&sub_runs, opts.max_chunk_probs);
+    let chunks = post_process(&chunks, probs.len(), opts);
+    Ok(speech_gate(chunks, probs, opts))
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────
@@ -256,335 +203,170 @@ fn validate(opts: &ChunkerOpts) -> Result<()> {
     if opts.align_to == 0 {
         return ZeroAlignToSnafu.fail();
     }
-    if opts.min_duration > opts.max_duration {
-        return MinExceedsMaxSnafu { min: opts.min_duration, max: opts.max_duration }.fail();
+    if opts.max_chunk_probs == 0 {
+        return ZeroMaxChunkSnafu.fail();
     }
-    if opts.max_duration > opts.strict_limit_duration {
-        return MaxExceedsStrictSnafu { max: opts.max_duration, strict: opts.strict_limit_duration }.fail();
+    if opts.min_chunk_probs > opts.max_chunk_probs {
+        return MinExceedsMaxSnafu { min: opts.min_chunk_probs, max: opts.max_chunk_probs }.fail();
+    }
+    if opts.offset > opts.onset {
+        return OffsetExceedsOnsetSnafu { offset: opts.offset, onset: opts.onset }.fail();
     }
     Ok(())
 }
 
-/// Splits single VAD runs that are longer than the model can decode.
-struct LongRunSplitter<'a> {
-    probs: &'a [f32],
-    search_radius: usize,
-    trough_threshold: Option<f32>,
-    strict_limit_probs: usize,
+/// Split any run longer than `max_chunk_probs` at the rightmost frame within
+/// the legal window `[run_start + min_chunk, run_start + max_chunk]` whose
+/// prob is below `offset` (real silence). Falls back to the legal-window
+/// argmin if no qualifying silence exists. Recurses on the right remainder.
+fn cut_long_runs(
+    probs: &[f32],
+    runs: &[(usize, usize)],
+    min_chunk: usize,
+    max_chunk: usize,
+    offset: f32,
+) -> Vec<(usize, usize)> {
+    let mut out = Vec::with_capacity(runs.len());
+    for &(start, end) in runs {
+        cut_one(probs, start, end, min_chunk, max_chunk, offset, &mut out);
+    }
+    out
 }
 
-#[derive(Clone, Copy)]
-struct SplitWindow {
-    lo: usize,
-    hi: usize,
+fn cut_one(
+    probs: &[f32],
+    start: usize,
+    end: usize,
+    min_chunk: usize,
+    max_chunk: usize,
+    offset: f32,
+    out: &mut Vec<(usize, usize)>,
+) {
+    if end - start <= max_chunk {
+        out.push((start, end));
+        return;
+    }
+    // Left edge of the legal split window: keep the LEFT piece ≥ min_chunk.
+    let lo = (start + min_chunk.min(max_chunk)).max(start + 1);
+    // Right edge: keep both pieces inside their length caps. The split must
+    // leave the RIGHT remainder ≥ min_chunk where possible (avoids tiny
+    // tails on the next recursion); always ≥ 1 frame.
+    let hi_cap = start + max_chunk;
+    let hi_keep_tail = end.saturating_sub(min_chunk.max(1));
+    let hi = hi_cap.min(hi_keep_tail).min(end.saturating_sub(1)).max(lo);
+    let split = find_split(probs, lo, hi, offset);
+    out.push((start, split));
+    cut_one(probs, split, end, min_chunk, max_chunk, offset, out);
 }
 
-impl<'a> LongRunSplitter<'a> {
-    fn new(probs: &'a [f32], search_radius: usize, trough_threshold: Option<f32>, strict_limit_probs: usize) -> Self {
-        Self { probs, search_radius, trough_threshold, strict_limit_probs }
-    }
-
-    fn split(&self, segments: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
-        if self.strict_limit_probs == 0 {
-            return segments;
-        }
-
-        let mut out = Vec::with_capacity(segments.len());
-        for segment in segments {
-            self.split_one(segment, &mut out);
-        }
-        out
-    }
-
-    fn split_one(&self, (start, end): (usize, usize), out: &mut Vec<(usize, usize)>) {
-        let len = end - start;
-        if len <= self.strict_limit_probs {
-            out.push((start, end));
-            return;
-        }
-
-        let pieces = len.div_ceil(self.strict_limit_probs);
-        let min_piece = (len / (2 * pieces)).max(1);
-        let mut cur = start;
-        for piece_idx in 1..pieces {
-            let target = start + (len * piece_idx) / pieces;
-            let pieces_left = pieces - piece_idx;
-            let Some(window) = self.legal_window(cur, end, pieces_left, min_piece) else {
-                continue;
-            };
-            let split = self.choose_split(target, window);
-            if split > cur && split < end {
-                out.push((cur, split));
-                cur = split;
-            }
-        }
-
-        if cur < end {
-            out.push((cur, end));
+/// Pick a split point in `[lo, hi]` (inclusive). Preferences:
+/// 1. Rightmost frame with `prob < offset` — a real silence trough. Picking
+///    the rightmost maximises chunk fill (WhisperX min-cut rule).
+/// 2. Fallback when no qualifying silence exists: lowest-prob frame in
+///    `[lo, hi]`, ties broken to the right. On a flat-speech run this
+///    becomes `hi`, producing maximally-sized chunks.
+fn find_split(probs: &[f32], lo: usize, hi: usize, offset: f32) -> usize {
+    for i in (lo..=hi).rev() {
+        if probs[i] < offset {
+            return i;
         }
     }
-
-    fn legal_window(&self, cur: usize, end: usize, pieces_left: usize, min_piece: usize) -> Option<SplitWindow> {
-        let lo_fit = end.saturating_sub(pieces_left * self.strict_limit_probs).max(cur + 1);
-        let hi_fit = (cur + self.strict_limit_probs).min(end.saturating_sub(pieces_left));
-        if hi_fit < lo_fit {
-            return None;
-        }
-
-        let lo_quality = lo_fit.max(cur + min_piece.min(self.strict_limit_probs));
-        let lo = if lo_quality <= hi_fit { lo_quality } else { lo_fit };
-        Some(SplitWindow { lo, hi: hi_fit })
-    }
-
-    fn choose_split(&self, target: usize, window: SplitWindow) -> usize {
-        if let Some(split) = self.threshold_split(target, window) {
-            return split;
-        }
-
-        let lo = target.saturating_sub(self.search_radius).max(window.lo);
-        let hi = (target + self.search_radius).min(window.hi);
-        if hi < lo {
-            return target.clamp(window.lo, window.hi);
-        }
-        lo + argmin(&self.probs[lo..=hi])
-    }
-
-    fn threshold_split(&self, target: usize, window: SplitWindow) -> Option<usize> {
-        let threshold = self.trough_threshold?;
-        self.probs[window.lo..=window.hi]
-            .iter()
-            .enumerate()
-            .filter(|&(_, &p)| p < threshold)
-            .min_by_key(|(i, _)| (window.lo + i).abs_diff(target))
-            .map(|(i, _)| window.lo + i)
-    }
-}
-
-fn argmin(slice: &[f32]) -> usize {
-    let mut best = 0usize;
-    let mut best_v = slice[0];
-    for (i, &v) in slice.iter().enumerate().skip(1) {
-        if v < best_v {
-            best_v = v;
+    let mut best = hi;
+    let mut best_v = probs[hi];
+    for i in (lo..hi).rev() {
+        if probs[i] < best_v {
+            best_v = probs[i];
             best = i;
         }
     }
     best
 }
 
-/// Greedy-concat speech segments into bounded-length chunks. Closes a chunk
-/// when the next segment would push it past `max_probs` AND either the
-/// current chunk has reached `min_probs` *or* extending would exceed
-/// `strict_limit_probs` (the hard ceiling).
-fn pack_segments(
-    segments: &[(usize, usize)],
-    min_probs: usize,
-    max_probs: usize,
-    strict_limit_probs: usize,
-) -> Vec<(usize, usize)> {
-    let mut chunks = Vec::new();
-    let mut cur: Option<(usize, usize)> = None;
-    for &(s, e) in segments {
-        match cur {
-            None => cur = Some((s, e)),
-            Some((cs, ce)) => {
-                let prospective = e - cs;
-                let cur_len = ce - cs;
-                if prospective > max_probs && (cur_len >= min_probs || prospective > strict_limit_probs) {
-                    chunks.push((cs, ce));
-                    cur = Some((s, e));
-                } else {
-                    cur = Some((cs, e));
-                }
-            }
+/// Greedy-concat runs into chunks bounded by `max_chunk_probs`. Each input
+/// run is assumed to already satisfy `len ≤ max_chunk_probs` (post-cut).
+fn pack_chunks(runs: &[(usize, usize)], max_chunk: usize) -> Vec<(usize, usize)> {
+    let mut chunks: Vec<(usize, usize)> = Vec::new();
+    for &(rs, re) in runs {
+        match chunks.last_mut() {
+            Some(last) if re - last.0 <= max_chunk => last.1 = re,
+            _ => chunks.push((rs, re)),
         }
-    }
-    if let Some(c) = cur {
-        chunks.push(c);
     }
     chunks
 }
 
-/// Gap-aware ordered clustering for RNNT-sensitive long-form decoding.
-struct ClusterPacker<'a> {
-    segments: &'a [(usize, usize)],
-    min_probs: usize,
-    max_probs: usize,
-    strict_limit_probs: usize,
-    target_probs: usize,
-    handoff_probs: usize,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct SegmentGroup {
-    start_idx: usize,
-    end_idx: usize,
-}
-
-impl SegmentGroup {
-    fn new(start_idx: usize, end_idx: usize) -> Self {
-        Self { start_idx, end_idx }
-    }
-}
-
-impl<'a> ClusterPacker<'a> {
-    fn new(
-        segments: &'a [(usize, usize)],
-        min_probs: usize,
-        max_probs: usize,
-        strict_limit_probs: usize,
-        target_probs: usize,
-        handoff_probs: usize,
-    ) -> Self {
-        Self { segments, min_probs, max_probs, strict_limit_probs, target_probs, handoff_probs }
-    }
-
-    fn pack(&self) -> Vec<(usize, usize)> {
-        if self.segments.is_empty() || self.target_probs == 0 {
-            return Vec::new();
-        }
-
-        let mut groups = Vec::new();
-        for group in self.greedy_groups() {
-            self.split_at_midpoints(group, &mut groups);
-        }
-        self.materialize(&groups)
-    }
-
-    fn greedy_groups(&self) -> Vec<SegmentGroup> {
-        let mut groups = Vec::new();
-        let mut start_idx = 0usize;
-        for idx in 1..self.segments.len() {
-            let prospective = self.segments[idx].1 - self.segments[start_idx].0;
-            let cur_len = self.segments[idx - 1].1 - self.segments[start_idx].0;
-            if prospective > self.max_probs && (cur_len >= self.min_probs || prospective > self.strict_limit_probs) {
-                groups.push(SegmentGroup::new(start_idx, idx));
-                start_idx = idx;
-            }
-        }
-        groups.push(SegmentGroup::new(start_idx, self.segments.len()));
-        groups
-    }
-
-    fn split_at_midpoints(&self, group: SegmentGroup, out: &mut Vec<SegmentGroup>) {
-        if group.end_idx <= group.start_idx + 1 || self.group_len(group) <= self.split_threshold() {
-            out.push(group);
-            return;
-        }
-
-        let split = self.midpoint_gap(group).expect("non-singleton group has an internal split");
-        self.split_at_midpoints(SegmentGroup::new(group.start_idx, split), out);
-        self.split_at_midpoints(SegmentGroup::new(split, group.end_idx), out);
-    }
-
-    fn materialize(&self, groups: &[SegmentGroup]) -> Vec<(usize, usize)> {
-        if groups.is_empty() {
-            return Vec::new();
-        }
-
-        let mut chunks = Vec::with_capacity(groups.len());
-        let mut start = self.segments[groups[0].start_idx].0;
-
-        for (idx, group) in groups.iter().copied().enumerate() {
-            let end = self.segments[group.end_idx - 1].1;
-            if end > start {
-                chunks.push((start.max(end.saturating_sub(self.strict_limit_probs)), end));
-            }
-            if let Some(next) = groups.get(idx + 1).copied() {
-                start = self.handoff_start(end, self.segments[next.start_idx].0);
-            }
-        }
-        chunks
-    }
-
-    fn group_len(&self, group: SegmentGroup) -> usize {
-        self.segments[group.end_idx - 1].1 - self.group_start(group.start_idx)
-    }
-
-    fn group_start(&self, start_idx: usize) -> usize {
-        if start_idx == 0 {
-            self.segments[0].0
-        } else {
-            self.handoff_start(self.segments[start_idx - 1].1, self.segments[start_idx].0)
-        }
-    }
-
-    fn split_threshold(&self) -> usize {
-        self.target_probs.saturating_add(self.target_probs / 2)
-    }
-
-    fn midpoint_gap(&self, group: SegmentGroup) -> Option<usize> {
-        let group_start = self.group_start(group.start_idx);
-        let group_end = self.segments[group.end_idx - 1].1;
-        let midpoint_twice = group_start + group_end;
-
-        (group.start_idx + 1..group.end_idx).min_by_key(|&idx| self.gap_key(idx, midpoint_twice))
-    }
-
-    fn gap_key(&self, split_idx: usize, midpoint_twice: usize) -> (usize, Reverse<usize>) {
-        let gap_start = self.segments[split_idx - 1].1;
-        let gap_end = self.segments[split_idx].0;
-        let distance_twice = if midpoint_twice < 2 * gap_start {
-            2 * gap_start - midpoint_twice
-        } else {
-            midpoint_twice.saturating_sub(2 * gap_end)
-        };
-        (distance_twice, Reverse(gap_end.saturating_sub(gap_start)))
-    }
-
-    fn handoff_start(&self, gap_start: usize, gap_end: usize) -> usize {
-        if gap_end <= gap_start {
-            return gap_end;
-        }
-
-        let gap = gap_end - gap_start;
-        let drop_after_prev = self.handoff_probs.min(gap / 2);
-        let pre_context = (self.target_probs * 2 / 5).max(1);
-        (gap_start + drop_after_prev).max(gap_end.saturating_sub(pre_context)).min(gap_end)
-    }
-}
-
 /// Convert prob-index core ranges to sample ranges and derive decode windows.
-/// Padding is adaptive: each side is capped at half the core gap to the
-/// neighbour, so decode windows remain non-overlapping while still exposing
-/// local silence/context around each core.
+/// Pad on each side is capped at half the silence gap to the neighbouring
+/// core so pre-align decode windows never cross a core. After alignment,
+/// the next chunk's `decode_start` is pinned up to the previous chunk's
+/// `decode_end` to eliminate the ≤ `align_to - 1` overlap that floor/ceil
+/// rounding can introduce.
 fn post_process(chunks: &[(usize, usize)], probs_len: usize, opts: &ChunkerOpts) -> Vec<AudioChunk> {
     let max_sample = probs_len * opts.samples_per_prob;
     let pad = opts.pad_samples;
     let align = opts.align_to;
+    let spp = opts.samples_per_prob;
 
     let mut out: Vec<AudioChunk> = Vec::with_capacity(chunks.len());
-    for (i, &(s, e)) in chunks.iter().enumerate() {
-        let core_start = s * opts.samples_per_prob;
-        let core_end = e * opts.samples_per_prob;
+    for (i, &(ps, pe)) in chunks.iter().enumerate() {
+        let core_start = ps * spp;
+        let core_end = pe * spp;
+        if core_end <= core_start {
+            continue;
+        }
 
-        // Cap each side's padding at half the silence gap to the neighbour
-        // (or the full margin at the waveform edges). Floor division: total
-        // pad consumed by adjacent chunks ≤ gap, so they never overlap.
+        // Cap each side's pad at half the gap to the neighbouring core (full
+        // budget at file edges). Floor division → adjacent chunks' raw pads
+        // never cross.
         let pad_left = if i == 0 {
             pad.min(core_start)
         } else {
-            let prev_raw_end = chunks[i - 1].1 * opts.samples_per_prob;
-            pad.min(core_start.saturating_sub(prev_raw_end) / 2)
+            let prev_core_end = chunks[i - 1].1 * spp;
+            pad.min(core_start.saturating_sub(prev_core_end) / 2)
         };
         let pad_right = if i + 1 == chunks.len() {
             pad.min(max_sample.saturating_sub(core_end))
         } else {
-            let next_raw_start = chunks[i + 1].0 * opts.samples_per_prob;
-            pad.min(next_raw_start.saturating_sub(core_end) / 2)
+            let next_core_start = chunks[i + 1].0 * spp;
+            pad.min(next_core_start.saturating_sub(core_end) / 2)
         };
 
-        let padded_start = core_start - pad_left;
-        let padded_end = (core_end + pad_right).min(max_sample);
+        let padded_start = core_start.saturating_sub(pad_left);
+        let padded_end = core_end.saturating_add(pad_right).min(max_sample);
+
         let decode_start = (padded_start / align) * align;
         let mut decode_end = padded_end.div_ceil(align) * align;
         if decode_end > max_sample {
             decode_end = max_sample;
         }
-        if core_end <= core_start || decode_end <= decode_start {
+        if decode_end <= decode_start {
             continue;
         }
+        // Floor/ceil rounding around touching cores can leave adjacent
+        // decode windows overlapping by ≤ align - 1 samples. We accept
+        // that overlap rather than pinning past `core_start`: cores never
+        // overlap (pack guarantees this) so any duplicated word at the
+        // seam is filtered by `crop_words_to_core` downstream.
         out.push(AudioChunk::with_decode(core_start, core_end, decode_start, decode_end));
     }
     out
+}
+
+/// Drop any chunk whose peak prob over its core (prob-grid) range is below
+/// `min_chunk_max_prob`. Defensive backstop: hysteresis already requires each
+/// run to peak `≥ onset`, so this only fires on configuration accidents or
+/// future bugs that emit chunks with no high-confidence speech.
+fn speech_gate(chunks: Vec<AudioChunk>, probs: &[f32], opts: &ChunkerOpts) -> Vec<AudioChunk> {
+    if opts.min_chunk_max_prob <= 0.0 {
+        return chunks;
+    }
+    chunks
+        .into_iter()
+        .filter(|c| {
+            let lo = c.start_sample / opts.samples_per_prob;
+            let hi = c.end_sample.div_ceil(opts.samples_per_prob).min(probs.len());
+            let slice = probs.get(lo..hi).unwrap_or(&[]);
+            slice.iter().copied().fold(f32::NEG_INFINITY, f32::max) >= opts.min_chunk_max_prob
+        })
+        .collect()
 }

--- a/arch/src/vad/segment.rs
+++ b/arch/src/vad/segment.rs
@@ -1,74 +1,85 @@
-//! Threshold + smoothing pass that turns per-frame speech probabilities into
-//! `[start, end)` prob-index ranges of speech.
+//! Hysteresis binarisation + merge-close pass that turns per-frame speech
+//! probabilities into `[start, end)` prob-index ranges of speech.
 //!
-//! Output is in *prob-grid index* units so downstream code (chunker
-//! post-process) can decide on sample/time conversion. Smoothing constants
-//! (min run lengths, merge gaps) are read from [`super::ChunkerOpts`].
-
-use super::ChunkerOpts;
+//! Hysteresis (two thresholds, `onset > offset`) suppresses the
+//! single-threshold chatter that earlier needed `min_speech` / `min_silence`
+//! smoothing to paper over. The smoothing knobs still exist as run-length
+//! floors: a run only commits when it lasts at least `min_speech_probs`, and
+//! only closes after `min_silence_probs` consecutive below-`offset` probs.
 
 /// Returns `[start, end)` ranges (prob-grid indices) of speech runs in
-/// `probs`, with smoothing per `opts`:
+/// `probs`, using hysteresis binarisation:
 ///
-/// - A speech run begins at the first prob ≥ `opts.threshold` after a
-///   silence run.
-/// - A speech run terminates at the first index where `opts.min_silence_probs`
-///   consecutive sub-threshold probs have been seen. The terminator index
-///   itself is *exclusive*.
-/// - Runs containing fewer than `opts.min_speech_probs` total above-threshold
-///   indices are dropped.
-/// - Adjacent speech runs separated by ≤ `opts.merge_gap_probs` silence
-///   probs are merged.
-pub(crate) fn threshold_segments(probs: &[f32], opts: &ChunkerOpts) -> Vec<(usize, usize)> {
-    let min_speech = opts.min_speech_probs;
-    let min_silence = opts.min_silence_probs;
-    let merge_gap = opts.merge_gap_probs;
-    let threshold = opts.threshold;
-
-    let mut raw: Vec<(usize, usize)> = Vec::new();
+/// - A speech run opens at the first prob `≥ onset`.
+/// - While in speech, probs `≥ offset` keep the run open (the band
+///   `[offset, onset)` is "in-speech sustain"). Below `offset` starts a
+///   silence streak.
+/// - A speech run terminates at the first index where
+///   `min_silence_probs` consecutive probs `< offset` have been seen.
+///   The terminator index is *exclusive*.
+/// - Runs shorter than `min_speech_probs` are dropped.
+///
+/// `onset` and `offset` are assumed to satisfy `offset ≤ onset`. Pass equal
+/// values to recover plain single-threshold behaviour.
+pub(crate) fn hysteresis_segments(
+    probs: &[f32],
+    onset: f32,
+    offset: f32,
+    min_speech_probs: usize,
+    min_silence_probs: usize,
+) -> Vec<(usize, usize)> {
+    let mut runs: Vec<(usize, usize)> = Vec::new();
     let mut speech_start: Option<usize> = None;
     let mut silence_count = 0usize;
 
     for (i, &p) in probs.iter().enumerate() {
-        if p >= threshold {
-            if speech_start.is_none() {
-                speech_start = Some(i);
-            }
-            silence_count = 0;
-        } else if let Some(start) = speech_start {
-            silence_count += 1;
-            if min_silence == 0 || silence_count >= min_silence {
-                // First non-speech index in the trailing silence run; the run
-                // started at `i + 1 - silence_count` and the speech segment
-                // ends just before it.
-                let end = i + 1 - silence_count;
-                if end > start && end - start >= min_speech {
-                    raw.push((start, end));
+        match speech_start {
+            None => {
+                if p >= onset {
+                    speech_start = Some(i);
+                    silence_count = 0;
                 }
-                speech_start = None;
-                silence_count = 0;
+            }
+            Some(start) => {
+                if p >= offset {
+                    silence_count = 0;
+                } else {
+                    silence_count += 1;
+                    if min_silence_probs == 0 || silence_count >= min_silence_probs {
+                        let end = i + 1 - silence_count;
+                        if end > start && end - start >= min_speech_probs {
+                            runs.push((start, end));
+                        }
+                        speech_start = None;
+                        silence_count = 0;
+                    }
+                }
             }
         }
     }
 
     if let Some(start) = speech_start {
         let end = probs.len();
-        if end - start >= min_speech {
-            raw.push((start, end));
+        if end > start && end - start >= min_speech_probs {
+            runs.push((start, end));
         }
     }
 
-    // Merge consecutive runs separated by ≤ merge_gap silence probs.
-    let mut merged: Vec<(usize, usize)> = Vec::new();
-    for seg in raw {
-        if let Some(last) = merged.last_mut()
-            && seg.0 - last.1 <= merge_gap
+    runs
+}
+
+/// Fold consecutive speech runs whose gap is `≤ merge_gap_probs` into one.
+/// Pass `0` to disable merging.
+pub(crate) fn merge_close(runs: Vec<(usize, usize)>, merge_gap_probs: usize) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::with_capacity(runs.len());
+    for seg in runs {
+        if let Some(last) = out.last_mut()
+            && seg.0.saturating_sub(last.1) <= merge_gap_probs
         {
             last.1 = seg.1;
             continue;
         }
-        merged.push(seg);
+        out.push(seg);
     }
-
-    merged
+    out
 }

--- a/model/src/audio/splitter.rs
+++ b/model/src/audio/splitter.rs
@@ -102,6 +102,8 @@ pub fn trim_chunks_to_waveform(chunks: &mut Vec<AudioChunk>, waveform_len: usize
             continue;
         }
         last.end_sample = last.end_sample.min(waveform_len);
+        last.decode_start_sample = last.decode_start_sample.min(waveform_len);
+        last.decode_end_sample = last.decode_end_sample.min(waveform_len);
         chunks.push(last);
         break;
     }
@@ -156,7 +158,7 @@ impl Splitter for FixedLengthSplitter {
                 let aligned_span = (span / align) * align;
                 start + aligned_span.max(align)
             };
-            chunks.push(AudioChunk { start_sample: start, end_sample: aligned_end });
+            chunks.push(AudioChunk::new(start, aligned_end));
             start = aligned_end;
         }
         Ok(chunks)

--- a/model/src/audio/splitter.rs
+++ b/model/src/audio/splitter.rs
@@ -109,8 +109,10 @@ pub fn trim_chunks_to_waveform(chunks: &mut Vec<AudioChunk>, waveform_len: usize
     }
 }
 
-/// No-VAD splitter: walks the waveform in `bounds.max_samples()`-sized
-/// strides, aligning non-final chunks to `bounds.align_to_samples()`.
+/// No-VAD splitter: walks the waveform in fixed-size strides. By default the
+/// stride is `bounds.max_samples()`; use
+/// [`with_max_duration_secs`](Self::with_max_duration_secs) for a wall-clock
+/// cap such as 20 seconds.
 ///
 /// Zero model load. Suitable when the caller already segmented the input,
 /// for short utterances that fit a single chunk, or for tests. Boundary
@@ -125,13 +127,30 @@ pub fn trim_chunks_to_waveform(chunks: &mut Vec<AudioChunk>, waveform_len: usize
 /// the JIT pads it.
 #[derive(Clone, Debug, Default)]
 pub struct FixedLengthSplitter {
-    // Field-form (not a unit struct) so v2 can add `overlap_samples` without
-    // a breaking API change.
+    max_duration_secs: Option<f32>,
 }
 
 impl FixedLengthSplitter {
     pub fn new() -> Self {
-        Self {}
+        Self::default()
+    }
+
+    pub fn with_max_duration_secs(max_duration_secs: f32) -> Self {
+        assert!(max_duration_secs.is_finite() && max_duration_secs > 0.0, "max duration must be positive");
+        Self { max_duration_secs: Some(max_duration_secs) }
+    }
+
+    pub fn max_duration_secs(&self) -> Option<f32> {
+        self.max_duration_secs
+    }
+
+    fn target_samples(&self, bounds: &EncoderBounds) -> usize {
+        let encoder_cap = bounds.max_samples();
+        let Some(max_duration_secs) = self.max_duration_secs else {
+            return encoder_cap;
+        };
+        let duration_cap = (max_duration_secs * bounds.sample_rate as f32).floor() as usize;
+        duration_cap.max(1).min(encoder_cap.max(1))
     }
 }
 
@@ -143,9 +162,13 @@ impl Splitter for FixedLengthSplitter {
             return Ok(Vec::new());
         }
         let align = bounds.align_to_samples().max(1);
-        // Saturating max_samples so a misconfigured bounds (zero, overflow)
-        // never stalls the loop. Floor at `align` so the loop always advances.
-        let max = bounds.max_samples().max(align);
+        // Saturating target so misconfigured bounds (zero, overflow) or tiny
+        // duration caps never stall the loop.
+        let max = if self.max_duration_secs.is_some() {
+            self.target_samples(bounds).max(1)
+        } else {
+            self.target_samples(bounds).max(align)
+        };
 
         let mut chunks = Vec::new();
         let mut start = 0usize;
@@ -156,11 +179,15 @@ impl Splitter for FixedLengthSplitter {
             } else {
                 let span = nominal_end - start;
                 let aligned_span = (span / align) * align;
-                start + aligned_span.max(align)
+                if aligned_span == 0 { nominal_end } else { start + aligned_span }
             };
             chunks.push(AudioChunk::new(start, aligned_end));
             start = aligned_end;
         }
         Ok(chunks)
+    }
+
+    fn max_chunk_samples(&self, bounds: &EncoderBounds) -> usize {
+        self.target_samples(bounds)
     }
 }

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -127,6 +127,43 @@ pub struct ChunkResult {
     pub words: Option<Vec<Word>>,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ChunkMeta {
+    decode_start: usize,
+    decode_end: usize,
+    mel_len: usize,
+    start_sec: f32,
+    end_sec: f32,
+    decode_start_sec: f32,
+}
+
+impl ChunkMeta {
+    fn from_chunk(chunk: &AudioChunk, mel: &MelSpectrogram, sample_rate_hz: usize) -> Option<Self> {
+        let mel_len = mel.num_frames(chunk.decode_len());
+        if mel_len == 0 {
+            return None;
+        }
+
+        let sample_rate = sample_rate_hz as f32;
+        Some(Self {
+            decode_start: chunk.decode_start_sample,
+            decode_end: chunk.decode_end_sample,
+            mel_len,
+            start_sec: chunk.start_sample as f32 / sample_rate,
+            end_sec: chunk.end_sample as f32 / sample_rate,
+            decode_start_sec: chunk.decode_start_sample as f32 / sample_rate,
+        })
+    }
+
+    fn decode_duration_sec(&self, sample_rate_hz: usize) -> f32 {
+        (self.decode_end - self.decode_start) as f32 / sample_rate_hz as f32
+    }
+
+    fn result(self, text: String, words: Option<Vec<Word>>) -> ChunkResult {
+        ChunkResult { start_sec: self.start_sec, end_sec: self.end_sec, text, words }
+    }
+}
+
 /// Per-head decoder + JIT state. CTC needs a bounds-tied head JIT (Conv1d
 /// projection); RN-T's predictor/joint JITs ride with [`RnntStepBackend`].
 /// One instance per `Transcriber`, so the variant-size disparity is
@@ -173,6 +210,33 @@ pub(crate) fn ctc_frames_to_words(text: &str, frames: &[usize], frame_shift: f32
     }
     commit(&mut words, &mut current, first_frame, last_frame);
     words
+}
+
+pub(crate) fn crop_words_to_core(
+    words: Vec<Word>,
+    decode_start_sec: f32,
+    core_start_sec: f32,
+    core_end_sec: f32,
+) -> Vec<Word> {
+    let core_duration = core_end_sec - core_start_sec;
+    words
+        .into_iter()
+        .filter_map(|mut w| {
+            let abs_start = w.start + decode_start_sec;
+            let abs_end = w.end + decode_start_sec;
+            let mid = 0.5 * (abs_start + abs_end);
+            if !(core_start_sec..core_end_sec).contains(&mid) {
+                return None;
+            }
+            w.start = (abs_start - core_start_sec).clamp(0.0, core_duration);
+            w.end = (abs_end - core_start_sec).clamp(w.start, core_duration);
+            Some(w)
+        })
+        .collect()
+}
+
+pub(crate) fn words_to_text(words: &[Word]) -> String {
+    words.iter().map(|w| w.text.as_str()).filter(|s| !s.is_empty()).collect::<Vec<_>>().join(" ")
 }
 
 /// Transpose `[d_model, t_exec_sub]` row-major → `[actual_sub, d_model]`.
@@ -400,7 +464,14 @@ impl<S: Splitter> Transcriber<S> {
                     waveform_len: waveform.len(),
                 });
             }
-            let samples = chunk.end_sample.saturating_sub(chunk.start_sample);
+            if chunk.decode_end_sample > waveform.len() {
+                return Err(TranscribeError::ChunkOutOfRange {
+                    idx,
+                    end_sample: chunk.decode_end_sample,
+                    waveform_len: waveform.len(),
+                });
+            }
+            let samples = chunk.decode_len();
             if samples > max_samples {
                 return Err(TranscribeError::ChunkExceedsCapacity { idx, samples, max_samples });
             }
@@ -422,19 +493,8 @@ impl<S: Splitter> Transcriber<S> {
         let max_batch = self.max_batch;
         let want_words = self.opts.word_timestamps;
 
-        // (start_sample, end_sample, mel_len, start_sec, end_sec) per chunk.
-        let chunks_meta: Vec<(usize, usize, usize, f32, f32)> = chunks
-            .iter()
-            .filter_map(|c| {
-                let mel_len = self.mel.num_frames(c.end_sample.saturating_sub(c.start_sample));
-                if mel_len == 0 {
-                    return None;
-                }
-                let start_sec = c.start_sample as f32 / sample_rate_hz as f32;
-                let end_sec = c.end_sample as f32 / sample_rate_hz as f32;
-                Some((c.start_sample, c.end_sample, mel_len, start_sec, end_sec))
-            })
-            .collect();
+        let chunks_meta: Vec<ChunkMeta> =
+            chunks.iter().filter_map(|chunk| ChunkMeta::from_chunk(chunk, &self.mel, sample_rate_hz)).collect();
         if chunks_meta.is_empty() {
             return Ok(TranscribeResult { text: String::new(), chunks: Vec::new() });
         }
@@ -447,11 +507,11 @@ impl<S: Splitter> Transcriber<S> {
 
             let batch_mels: Vec<Vec<f32>> = (0..b)
                 .map(|bi| {
-                    let &(start_sample, end_sample, valid, _, _) = &chunks_meta[chunk_batch_start + bi];
-                    let mut chunk_mel = ndarray::Array3::<f32>::zeros((1, n_mels, valid));
+                    let meta = chunks_meta[chunk_batch_start + bi];
+                    let mut chunk_mel = ndarray::Array3::<f32>::zeros((1, n_mels, meta.mel_len));
                     {
                         let mut view = chunk_mel.view_mut().into_dyn();
-                        self.mel.forward_into(&waveform[start_sample..end_sample], &mut view);
+                        self.mel.forward_into(&waveform[meta.decode_start..meta.decode_end], &mut view);
                     }
                     chunk_mel.as_slice().expect("contiguous chunk mel").to_vec()
                 })
@@ -464,13 +524,13 @@ impl<S: Splitter> Transcriber<S> {
                 let slice = view.as_slice_mut().expect("contiguous mel buffer");
                 slice.fill(0.0);
                 for (bi, chunk_len) in chunk_lengths.iter_mut().enumerate() {
-                    let &(_, _, valid, _, _) = &chunks_meta[chunk_batch_start + bi];
-                    *chunk_len = valid;
+                    let meta = chunks_meta[chunk_batch_start + bi];
+                    *chunk_len = meta.mel_len;
                     let chunk_mel = &batch_mels[bi];
                     for mel_bin in 0..n_mels {
-                        let src = mel_bin * valid;
+                        let src = mel_bin * meta.mel_len;
                         let dst = ((bi * n_mels) + mel_bin) * max_t_mel;
-                        slice[dst..dst + valid].copy_from_slice(&chunk_mel[src..src + valid]);
+                        slice[dst..dst + meta.mel_len].copy_from_slice(&chunk_mel[src..src + meta.mel_len]);
                     }
                 }
             }
@@ -520,26 +580,23 @@ impl<S: Splitter> Transcriber<S> {
                     let flat = logits.as_slice().expect("contiguous head logits");
                     for (bi, mel_len) in chunk_lengths.iter().enumerate() {
                         let actual_sub = subs_output_length(subs_kernel_size, *mel_len);
-                        let &(start_sample, end_sample, _, start_sec, end_sec) = &chunks_meta[chunk_batch_start + bi];
-                        let chunk_duration_sec = (end_sample - start_sample) as f32 / sample_rate_hz as f32;
-                        let frame_shift = chunk_duration_sec / (actual_sub.max(1) as f32);
+                        let meta = chunks_meta[chunk_batch_start + bi];
+                        let frame_shift = meta.decode_duration_sec(sample_rate_hz) / (actual_sub.max(1) as f32);
 
                         let item_slice = &flat[bi * item_stride..bi * item_stride + item_stride];
 
-                        let (text, frames) = if want_words {
-                            let (text, frames) = decoder
-                                .decode_with_timestamps(item_slice, t_exec_sub, actual_sub)
-                                .context(CtcDecodeSnafu)?;
-                            (text, Some(frames))
-                        } else {
-                            let text = decoder.decode(item_slice, t_exec_sub, actual_sub).context(CtcDecodeSnafu)?;
-                            (text, None)
-                        };
-                        let words = want_words.then(|| {
-                            let frames = frames.as_deref().unwrap_or(&[]);
-                            ctc_frames_to_words(&text, frames, frame_shift)
-                        });
-                        chunk_results.push(ChunkResult { start_sec, end_sec, text, words });
+                        let (text, frames) = decoder
+                            .decode_with_timestamps(item_slice, t_exec_sub, actual_sub)
+                            .context(CtcDecodeSnafu)?;
+                        let cropped_words = crop_words_to_core(
+                            ctc_frames_to_words(&text, &frames, frame_shift),
+                            meta.decode_start_sec,
+                            meta.start_sec,
+                            meta.end_sec,
+                        );
+                        let text = words_to_text(&cropped_words);
+                        let words = want_words.then_some(cropped_words);
+                        chunk_results.push(meta.result(text, words));
                     }
                 }
                 HeadDecoder::Rnnt { backend, decoder, sentencepiece } => {
@@ -549,9 +606,8 @@ impl<S: Splitter> Transcriber<S> {
                     let flat = enc.as_slice().expect("contiguous encoder output");
                     for (bi, mel_len) in chunk_lengths.iter().enumerate() {
                         let actual_sub = subs_output_length(subs_kernel_size, *mel_len);
-                        let &(start_sample, end_sample, _, start_sec, end_sec) = &chunks_meta[chunk_batch_start + bi];
-                        let chunk_duration_sec = (end_sample - start_sample) as f32 / sample_rate_hz as f32;
-                        let frame_shift = chunk_duration_sec / (actual_sub.max(1) as f32);
+                        let meta = chunks_meta[chunk_batch_start + bi];
+                        let frame_shift = meta.decode_duration_sec(sample_rate_hz) / (actual_sub.max(1) as f32);
 
                         let item_slice = &flat[bi * item_stride..bi * item_stride + item_stride];
                         // Encoder output is [d_model, t_exec_sub] row-major;
@@ -559,22 +615,21 @@ impl<S: Splitter> Transcriber<S> {
                         let frames = transpose_dt_to_td(item_slice, d_model, t_exec_sub, actual_sub);
 
                         let backend: &mut RnntStepBackend = backend;
-                        let (raw, emissions) = if want_words {
-                            let (s, e) = decoder
-                                .decode_with_timestamps(&frames, actual_sub, actual_sub, d_model, backend)
-                                .map_err(rnnt_decode_err)?;
-                            (s, e)
-                        } else {
-                            let s = decoder
-                                .decode(&frames, actual_sub, actual_sub, d_model, backend)
-                                .map_err(rnnt_decode_err)?;
-                            (s, Vec::new())
-                        };
-                        let words = want_words.then(|| decoder.frames_to_words(&emissions, frame_shift));
-                        // SP pieces carry `▁` (U+2581) as word-initial markers;
-                        // after concatenation we restore them as spaces.
-                        let text = if *sentencepiece { raw.replace('\u{2581}', " ").trim().to_string() } else { raw };
-                        chunk_results.push(ChunkResult { start_sec, end_sec, text, words });
+                        let (_raw, emissions) = decoder
+                            .decode_with_timestamps(&frames, actual_sub, actual_sub, d_model, backend)
+                            .map_err(rnnt_decode_err)?;
+                        let cropped_words = crop_words_to_core(
+                            decoder.frames_to_words(&emissions, frame_shift),
+                            meta.decode_start_sec,
+                            meta.start_sec,
+                            meta.end_sec,
+                        );
+                        let mut text = words_to_text(&cropped_words);
+                        if *sentencepiece {
+                            text = text.replace('\u{2581}', " ").trim().to_string();
+                        }
+                        let words = want_words.then_some(cropped_words);
+                        chunk_results.push(meta.result(text, words));
                     }
                 }
             }

--- a/model/src/silero_vad/mod.rs
+++ b/model/src/silero_vad/mod.rs
@@ -276,14 +276,16 @@ impl VadInference {
     }
 
     /// Convenience wrapper around [`Self::probs`] +
-    /// [`svod_arch::vad::chunks_from_probs`] with default chunker knobs and
-    /// the given `threshold`. Errors from the JIT or chunker are swallowed —
-    /// callers that need fault-visibility should drive `probs()` and
-    /// `chunks_from_probs` directly.
+    /// [`morok_arch::vad::chunks_from_probs`] with default chunker knobs and
+    /// the given single threshold (mapped to `onset == offset` —
+    /// non-hysteresis behaviour). Errors from the JIT or chunker are
+    /// swallowed — callers that need fault-visibility should drive
+    /// `probs()` and `chunks_from_probs` directly.
     pub fn segment(&mut self, waveform: &[f32], threshold: f32) -> Vec<(usize, usize)> {
         let Ok(probs) = self.probs(waveform) else { return Vec::new() };
         let opts = svod_arch::vad::ChunkerOpts {
-            threshold,
+            onset: threshold,
+            offset: threshold,
             samples_per_prob: NUM_SAMPLES,
             ..svod_arch::vad::ChunkerOpts::default()
         };

--- a/model/src/silero_vad/mod.rs
+++ b/model/src/silero_vad/mod.rs
@@ -15,7 +15,10 @@ extern crate self as svod_model;
 
 mod splitter;
 
-pub use splitter::{SileroVadSplitter, SileroVadSplitterError};
+pub use splitter::{SileroFixedWindowSplitter, SileroVadSplitter, SileroVadSplitterError};
+
+#[cfg(test)]
+pub(crate) use splitter::fixed_windows_from_probs;
 
 use std::path::Path;
 

--- a/model/src/silero_vad/splitter.rs
+++ b/model/src/silero_vad/splitter.rs
@@ -29,6 +29,13 @@ pub struct SileroVadSplitter {
     pad_samples: usize,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct DurationBudget {
+    min: f32,
+    max: f32,
+    strict_limit: f32,
+}
+
 #[bon]
 impl SileroVadSplitter {
     /// Build from an already-loaded [`VadInference`]. All knob defaults match
@@ -83,17 +90,15 @@ impl Splitter for SileroVadSplitter {
 
     fn split(&mut self, waveform: &[f32], bounds: &EncoderBounds) -> Result<Vec<AudioChunk>, Self::Error> {
         let probs = self.vad.probs(waveform).context(ProbsSnafu)?;
-        // Clamp ALL THREE duration knobs to encoder capacity. Without the
-        // `min_duration` clamp the arch chunker's `MinExceedsMax` validator
-        // fires when encoder capacity < 15s.
-        let cap = bounds.encoder_capacity_secs();
+        let budget = self.duration_budget(bounds);
         let chunker_opts = svod_arch::vad::ChunkerOpts {
             sample_rate: bounds.sample_rate,
             samples_per_prob: NUM_SAMPLES,
             threshold: self.threshold,
-            min_duration: self.min_duration.min(cap),
-            max_duration: self.max_duration.min(cap),
-            strict_limit_duration: self.strict_limit_duration.min(cap),
+            min_duration: budget.min,
+            max_duration: budget.max,
+            cluster_target_duration: Some(budget.max * 0.5),
+            strict_limit_duration: budget.strict_limit,
             min_speech_probs: self.min_speech_probs,
             min_silence_probs: self.min_silence_probs,
             merge_gap_probs: self.merge_gap_probs,
@@ -116,18 +121,28 @@ impl Splitter for SileroVadSplitter {
     /// encoder's full capacity. Shared bound math lives in
     /// [`svod_arch::vad::strict_chunk_sample_bound`].
     fn max_chunk_samples(&self, bounds: &EncoderBounds) -> usize {
-        let cap = bounds.encoder_capacity_secs();
-        let secs = self.strict_limit_duration.min(cap);
         let probs_per_sec = bounds.sample_rate as f32 / NUM_SAMPLES as f32;
-        let strict_limit_probs = (secs * probs_per_sec).ceil() as usize;
-        let radius = self.trough_search_probs.unwrap_or(self.min_silence_probs);
+        let strict_limit_probs = (self.duration_budget(bounds).strict_limit * probs_per_sec).ceil() as usize;
         svod_arch::vad::strict_chunk_sample_bound(
             strict_limit_probs,
-            radius,
             NUM_SAMPLES,
             self.pad_samples,
             bounds.align_to_samples(),
         )
+    }
+}
+
+impl SileroVadSplitter {
+    fn duration_budget(&self, bounds: &EncoderBounds) -> DurationBudget {
+        let align = bounds.align_to_samples().max(1);
+        let overhead = 2 * self.pad_samples + 2 * align.saturating_sub(1);
+        let safe_core_probs = bounds.max_samples().saturating_sub(overhead) / NUM_SAMPLES;
+        let configured_probs =
+            (self.strict_limit_duration * bounds.sample_rate as f32 / NUM_SAMPLES as f32).ceil() as usize;
+        let strict_limit_probs = configured_probs.min(safe_core_probs).max(1);
+        let strict_limit = strict_limit_probs as f32 * NUM_SAMPLES as f32 / bounds.sample_rate as f32;
+        let max = self.max_duration.min(strict_limit);
+        DurationBudget { min: self.min_duration.min(strict_limit), max, strict_limit }
     }
 }
 

--- a/model/src/silero_vad/splitter.rs
+++ b/model/src/silero_vad/splitter.rs
@@ -1,10 +1,9 @@
 //! Silero-VAD-driven [`Splitter`](crate::audio::Splitter) implementation.
 //!
-//! Wraps [`VadInference`] + [`svod_arch::vad::chunks_from_probs`] so the
-//! pre-refactor `Transcriber` chunking flow is reachable through the generic
-//! splitter trait. Knobs forward to [`ChunkerOpts`](svod_arch::vad::ChunkerOpts)
-//! except for `sample_rate`, `samples_per_prob`, and `align_to` — those come
-//! from [`EncoderBounds`](crate::audio::EncoderBounds) at split time.
+//! Wraps [`VadInference`] + [`svod_arch::vad::chunks_from_probs`] for
+//! long-form ASR. Knobs are exposed in wall-clock seconds and translated to
+//! the prob-grid units that [`ChunkerOpts`](svod_arch::vad::ChunkerOpts)
+//! expects at split time.
 
 use bon::bon;
 use snafu::{ResultExt, Snafu};
@@ -12,27 +11,31 @@ use snafu::{ResultExt, Snafu};
 use crate::audio::{AudioChunk, EncoderBounds, Splitter, trim_chunks_to_waveform};
 use crate::silero_vad::{NUM_SAMPLES, SileroVad, VadInference};
 
+/// 2-second safety margin under the encoder's `max_samples()` so chunks
+/// never sit at the JIT capacity ceiling.
+const ENCODER_SAFETY_MARGIN_SECS: f32 = 2.0;
+
 /// VAD-driven splitter. Construction: [`from_hub`](Self::from_hub) loads the
-/// default model from HF and pulls overrides from `SVOD_VAD_THRESHOLD`. For
+/// default model from HF and pulls overrides from `SVOD_VAD_*` env vars. For
 /// custom knobs use [`builder`](Self::builder) and supply a pre-loaded
 /// [`VadInference`].
 pub struct SileroVadSplitter {
     vad: VadInference,
-    threshold: f32,
-    min_duration: f32,
-    max_duration: f32,
-    strict_limit_duration: f32,
-    min_speech_probs: usize,
-    min_silence_probs: usize,
-    merge_gap_probs: usize,
-    trough_search_probs: Option<usize>,
-    pad_samples: usize,
+    onset: f32,
+    offset: f32,
+    min_speech_secs: f32,
+    min_silence_secs: f32,
+    merge_gap_secs: f32,
+    min_chunk_secs: f32,
+    max_chunk_secs: f32,
+    pad_secs: f32,
+    min_chunk_max_prob: f32,
 }
 
 /// Silero-gated fixed-window splitter. Runs VAD to decide which global,
 /// non-overlapping fixed windows contain speech, then transcribes the full
-/// retained windows. This keeps weak speech inside a retained 20s window even
-/// if Silero does not mark every frame as speech.
+/// retained windows. Useful as a robust fallback when VAD probabilities are
+/// unreliable.
 pub struct SileroFixedWindowSplitter {
     vad: VadInference,
     threshold: f32,
@@ -40,59 +43,76 @@ pub struct SileroFixedWindowSplitter {
     min_speech_probs: usize,
 }
 
-#[derive(Clone, Copy, Debug)]
-struct DurationBudget {
-    min: f32,
-    max: f32,
-    strict_limit: f32,
-}
-
 #[bon]
 impl SileroVadSplitter {
-    /// Build from an already-loaded [`VadInference`]. All knob defaults match
-    /// [`ChunkerOpts::default`](svod_arch::vad::ChunkerOpts) except
-    /// `threshold`, which consults `SVOD_VAD_THRESHOLD`.
+    /// Build from an already-loaded [`VadInference`]. Defaults pull from
+    /// `SVOD_VAD_ONSET` / `SVOD_VAD_OFFSET` env vars, with fallbacks
+    /// `0.50` / `0.35`.
     #[builder]
     pub fn builder(
         vad: VadInference,
-        #[builder(default = std::env::var("SVOD_VAD_THRESHOLD").ok().and_then(|s| s.parse().ok()).unwrap_or(0.5))]
-        threshold: f32,
-        #[builder(default = 15.0)] min_duration: f32,
-        #[builder(default = 22.0)] max_duration: f32,
-        #[builder(default = 30.0)] strict_limit_duration: f32,
-        #[builder(default = 8)] min_speech_probs: usize,
-        #[builder(default = 4)] min_silence_probs: usize,
-        #[builder(default = 8)] merge_gap_probs: usize,
-        trough_search_probs: Option<usize>,
-        /// Pad budget (samples) per chunk side. Default `1600` (= 100 ms at
-        /// 16 kHz). The actual pad applied is capped at half the silence
-        /// gap to the neighbouring chunk — so chunks never overlap into
-        /// each other's speech (no transcript duplication), but at seams
-        /// with enough surrounding silence the encoder sees up to this
-        /// many extra samples of context on each side.
-        #[builder(default = 1600)]
-        pad_samples: usize,
+        #[builder(default = env_f32("SVOD_VAD_ONSET", 0.50))] onset: f32,
+        #[builder(default = env_f32("SVOD_VAD_OFFSET", 0.35))] offset: f32,
+        /// Minimum length (s) of a committed speech run.
+        #[builder(default = env_f32("SVOD_VAD_MIN_SPEECH_SECS", 0.25))]
+        min_speech_secs: f32,
+        /// Consecutive `< offset` duration (s) required to close a run.
+        #[builder(default = env_f32("SVOD_VAD_MIN_SILENCE_SECS", 0.10))]
+        min_silence_secs: f32,
+        /// Adjacent speech runs separated by ≤ this many seconds are merged.
+        #[builder(default = env_f32("SVOD_VAD_MERGE_GAP_SECS", 0.40))]
+        merge_gap_secs: f32,
+        /// Soft floor for chunk length — used as the left edge of the legal
+        /// min-cut window when splitting an over-long run.
+        #[builder(default = env_f32("SVOD_VAD_MIN_CHUNK_SECS", 0.5))]
+        min_chunk_secs: f32,
+        /// Hard ceiling for chunk length. Clamped at split time to the
+        /// encoder's prepared budget minus a 2 s safety margin. Empirically
+        /// 20 s gives the best RN-T results — longer chunks (22 s, 28 s)
+        /// degrade quality on heterogeneous content because the decoder
+        /// "skips" earlier tokens when it encounters garbled/transition
+        /// audio mid-chunk. Upstream Python (`gigaam/vad_utils.py`) uses
+        /// max=22, but it accumulates short speech segments and is less
+        /// affected by this failure mode.
+        #[builder(default = env_f32("SVOD_VAD_MAX_CHUNK_SECS", 20.0))]
+        max_chunk_secs: f32,
+        /// Per-side decode-window pad in seconds. 300 ms covers the Conformer
+        /// convolutional receptive field at the subsampled rate.
+        #[builder(default = env_f32("SVOD_VAD_PAD_SECS", 0.30))]
+        pad_secs: f32,
+        /// Speech gate: drop chunks whose peak Silero prob is below this.
+        #[builder(default = env_f32("SVOD_VAD_GATE", 0.3))]
+        min_chunk_max_prob: f32,
     ) -> Self {
         Self {
             vad,
-            threshold,
-            min_duration,
-            max_duration,
-            strict_limit_duration,
-            min_speech_probs,
-            min_silence_probs,
-            merge_gap_probs,
-            trough_search_probs,
-            pad_samples,
+            onset,
+            offset,
+            min_speech_secs,
+            min_silence_secs,
+            merge_gap_secs,
+            min_chunk_secs,
+            max_chunk_secs,
+            pad_secs,
+            min_chunk_max_prob,
         }
     }
 
     /// Convenience: download the default Silero model from HF Hub, wrap it in
-    /// a [`VadInference`], and apply env-var-driven knob defaults.
+    /// a [`VadInference`], and apply env-var-driven defaults.
     pub fn from_hub() -> Result<Self, SileroVadSplitterError> {
         let model = SileroVad::from_hub().context(LoadSnafu)?;
         let vad = VadInference::new(model).context(InferenceSnafu)?;
         Ok(Self::builder().vad(vad).build())
+    }
+
+    fn effective_max_chunk_secs(&self, bounds: &EncoderBounds) -> f32 {
+        let pad_samples = (self.pad_secs * bounds.sample_rate as f32).round() as usize;
+        let align = bounds.align_to_samples().max(1);
+        let overhead = 2 * pad_samples + 2 * align.saturating_sub(1);
+        let encoder_capacity = bounds.max_samples().saturating_sub(overhead) as f32 / bounds.sample_rate as f32;
+        let safe_capacity = (encoder_capacity - ENCODER_SAFETY_MARGIN_SECS).max(0.0);
+        self.max_chunk_secs.min(safe_capacity).max(0.0)
     }
 }
 
@@ -104,8 +124,7 @@ impl SileroFixedWindowSplitter {
     #[builder]
     pub fn builder(
         vad: VadInference,
-        #[builder(default = std::env::var("MOROK_VAD_THRESHOLD").ok().and_then(|s| s.parse().ok()).unwrap_or(0.5))]
-        threshold: f32,
+        #[builder(default = env_f32("MOROK_VAD_THRESHOLD", 0.5))] threshold: f32,
         #[builder(default = 20.0)] window_duration_secs: f32,
         #[builder(default = 1)] min_speech_probs: usize,
     ) -> Self {
@@ -184,60 +203,47 @@ impl Splitter for SileroVadSplitter {
 
     fn split(&mut self, waveform: &[f32], bounds: &EncoderBounds) -> Result<Vec<AudioChunk>, Self::Error> {
         let probs = self.vad.probs(waveform).context(ProbsSnafu)?;
-        let budget = self.duration_budget(bounds);
-        let chunker_opts = svod_arch::vad::ChunkerOpts {
-            sample_rate: bounds.sample_rate,
-            samples_per_prob: NUM_SAMPLES,
-            threshold: self.threshold,
-            min_duration: budget.min,
-            max_duration: budget.max,
-            cluster_target_duration: Some(budget.max * 0.5),
-            strict_limit_duration: budget.strict_limit,
-            min_speech_probs: self.min_speech_probs,
-            min_silence_probs: self.min_silence_probs,
-            merge_gap_probs: self.merge_gap_probs,
-            trough_search_probs: self.trough_search_probs,
-            trough_threshold: Some(self.threshold * 0.5),
-            pad_samples: self.pad_samples,
-            align_to: bounds.align_to_samples().max(1),
-        };
-        let mut chunks = svod_arch::vad::chunks_from_probs(&probs, &chunker_opts).context(ChunkSnafu)?;
-        // `align_to` rounds chunk ends up to a stride multiple, which can push
-        // the trailing chunk past `waveform.len()`. The `Splitter` contract
+        let opts = self.chunker_opts(bounds);
+        let mut chunks = svod_arch::vad::chunks_from_probs(&probs, &opts).context(ChunkSnafu)?;
+        // align_to rounds chunk ends up to a stride multiple, which can push
+        // the trailing chunk past `waveform.len()`. The Splitter contract
         // forbids that, so clamp the tail before returning.
         trim_chunks_to_waveform(&mut chunks, waveform.len());
         Ok(chunks)
     }
 
-    /// Upper bound on chunk length the chunker can emit under this
-    /// splitter's config. Translating to samples lets `Transcriber::new`
-    /// size JIT buffers to this chunker's actual emission rather than the
-    /// encoder's full capacity. Shared bound math lives in
-    /// [`svod_arch::vad::strict_chunk_sample_bound`].
     fn max_chunk_samples(&self, bounds: &EncoderBounds) -> usize {
-        let probs_per_sec = bounds.sample_rate as f32 / NUM_SAMPLES as f32;
-        let strict_limit_probs = (self.duration_budget(bounds).strict_limit * probs_per_sec).ceil() as usize;
-        svod_arch::vad::strict_chunk_sample_bound(
-            strict_limit_probs,
-            NUM_SAMPLES,
-            self.pad_samples,
-            bounds.align_to_samples(),
-        )
+        let opts = self.chunker_opts(bounds);
+        svod_arch::vad::max_chunk_sample_bound(opts.max_chunk_probs, NUM_SAMPLES, opts.pad_samples, opts.align_to)
     }
 }
 
 impl SileroVadSplitter {
-    fn duration_budget(&self, bounds: &EncoderBounds) -> DurationBudget {
-        let align = bounds.align_to_samples().max(1);
-        let overhead = 2 * self.pad_samples + 2 * align.saturating_sub(1);
-        let safe_core_probs = bounds.max_samples().saturating_sub(overhead) / NUM_SAMPLES;
-        let configured_probs =
-            (self.strict_limit_duration * bounds.sample_rate as f32 / NUM_SAMPLES as f32).ceil() as usize;
-        let strict_limit_probs = configured_probs.min(safe_core_probs).max(1);
-        let strict_limit = strict_limit_probs as f32 * NUM_SAMPLES as f32 / bounds.sample_rate as f32;
-        let max = self.max_duration.min(strict_limit);
-        DurationBudget { min: self.min_duration.min(strict_limit), max, strict_limit }
+    fn chunker_opts(&self, bounds: &EncoderBounds) -> svod_arch::vad::ChunkerOpts {
+        let sr = bounds.sample_rate as f32;
+        let probs_per_sec = sr / NUM_SAMPLES as f32;
+        let max_chunk_secs = self.effective_max_chunk_secs(bounds);
+        let max_chunk_probs = (max_chunk_secs * probs_per_sec).floor() as usize;
+        let min_chunk_probs = (self.min_chunk_secs * probs_per_sec).ceil() as usize;
+        svod_arch::vad::ChunkerOpts {
+            sample_rate: bounds.sample_rate,
+            samples_per_prob: NUM_SAMPLES,
+            onset: self.onset,
+            offset: self.offset,
+            min_speech_probs: (self.min_speech_secs * probs_per_sec).ceil() as usize,
+            min_silence_probs: (self.min_silence_secs * probs_per_sec).ceil() as usize,
+            merge_gap_probs: (self.merge_gap_secs * probs_per_sec).ceil() as usize,
+            min_chunk_probs: min_chunk_probs.min(max_chunk_probs.max(1)),
+            max_chunk_probs: max_chunk_probs.max(1),
+            pad_samples: (self.pad_secs * sr).round() as usize,
+            align_to: bounds.align_to_samples().max(1),
+            min_chunk_max_prob: self.min_chunk_max_prob,
+        }
     }
+}
+
+fn env_f32(key: &str, fallback: f32) -> f32 {
+    std::env::var(key).ok().and_then(|s| s.parse().ok()).unwrap_or(fallback)
 }
 
 #[derive(Debug, Snafu)]

--- a/model/src/silero_vad/splitter.rs
+++ b/model/src/silero_vad/splitter.rs
@@ -29,6 +29,17 @@ pub struct SileroVadSplitter {
     pad_samples: usize,
 }
 
+/// Silero-gated fixed-window splitter. Runs VAD to decide which global,
+/// non-overlapping fixed windows contain speech, then transcribes the full
+/// retained windows. This keeps weak speech inside a retained 20s window even
+/// if Silero does not mark every frame as speech.
+pub struct SileroFixedWindowSplitter {
+    vad: VadInference,
+    threshold: f32,
+    window_duration_secs: f32,
+    min_speech_probs: usize,
+}
+
 #[derive(Clone, Copy, Debug)]
 struct DurationBudget {
     min: f32,
@@ -83,6 +94,89 @@ impl SileroVadSplitter {
         let vad = VadInference::new(model).context(InferenceSnafu)?;
         Ok(Self::builder().vad(vad).build())
     }
+}
+
+#[bon]
+impl SileroFixedWindowSplitter {
+    /// Build from an already-loaded [`VadInference`]. Defaults to 20-second
+    /// non-overlapping windows and keeps any window with at least one
+    /// above-threshold Silero probability.
+    #[builder]
+    pub fn builder(
+        vad: VadInference,
+        #[builder(default = std::env::var("MOROK_VAD_THRESHOLD").ok().and_then(|s| s.parse().ok()).unwrap_or(0.5))]
+        threshold: f32,
+        #[builder(default = 20.0)] window_duration_secs: f32,
+        #[builder(default = 1)] min_speech_probs: usize,
+    ) -> Self {
+        assert!(window_duration_secs.is_finite() && window_duration_secs > 0.0, "window duration must be positive");
+        Self { vad, threshold, window_duration_secs, min_speech_probs: min_speech_probs.max(1) }
+    }
+
+    pub fn from_hub() -> Result<Self, SileroVadSplitterError> {
+        let model = SileroVad::from_hub().context(LoadSnafu)?;
+        let vad = VadInference::new(model).context(InferenceSnafu)?;
+        Ok(Self::builder().vad(vad).build())
+    }
+
+    pub fn from_hub_with_window_duration_secs(window_duration_secs: f32) -> Result<Self, SileroVadSplitterError> {
+        let model = SileroVad::from_hub().context(LoadSnafu)?;
+        let vad = VadInference::new(model).context(InferenceSnafu)?;
+        Ok(Self::builder().vad(vad).window_duration_secs(window_duration_secs).build())
+    }
+
+    fn window_samples(&self, bounds: &EncoderBounds) -> usize {
+        let duration_samples = (self.window_duration_secs * bounds.sample_rate as f32).floor() as usize;
+        duration_samples.max(1).min(bounds.max_samples().max(1))
+    }
+}
+
+impl Splitter for SileroFixedWindowSplitter {
+    type Error = SileroVadSplitterError;
+
+    fn split(&mut self, waveform: &[f32], bounds: &EncoderBounds) -> Result<Vec<AudioChunk>, Self::Error> {
+        let probs = self.vad.probs(waveform).context(ProbsSnafu)?;
+        Ok(fixed_windows_from_probs(
+            &probs,
+            waveform.len(),
+            NUM_SAMPLES,
+            self.threshold,
+            self.min_speech_probs,
+            self.window_samples(bounds),
+        ))
+    }
+
+    fn max_chunk_samples(&self, bounds: &EncoderBounds) -> usize {
+        self.window_samples(bounds)
+    }
+}
+
+pub(crate) fn fixed_windows_from_probs(
+    probs: &[f32],
+    waveform_len: usize,
+    samples_per_prob: usize,
+    threshold: f32,
+    min_speech_probs: usize,
+    window_samples: usize,
+) -> Vec<AudioChunk> {
+    if probs.is_empty() || waveform_len == 0 || samples_per_prob == 0 || window_samples == 0 {
+        return Vec::new();
+    }
+
+    let min_speech_probs = min_speech_probs.max(1);
+    let mut chunks = Vec::new();
+    let mut start = 0usize;
+    while start < waveform_len {
+        let end = start.saturating_add(window_samples).min(waveform_len);
+        let prob_start = start / samples_per_prob;
+        let prob_end = end.div_ceil(samples_per_prob).min(probs.len());
+        let speech_probs = probs.get(prob_start..prob_end).unwrap_or(&[]).iter().filter(|&&p| p >= threshold).count();
+        if speech_probs >= min_speech_probs {
+            chunks.push(AudioChunk::new(start, end));
+        }
+        start = end;
+    }
+    chunks
 }
 
 impl Splitter for SileroVadSplitter {

--- a/model/src/test/unit/silero_vad.rs
+++ b/model/src/test/unit/silero_vad.rs
@@ -6,10 +6,11 @@
 //! exercises the full `VadInference` JIT path (prepare → step → output reads)
 //! — useful when actively touching VAD wiring but too slow for default CI.
 
+use svod_arch::vad::AudioChunk;
 use svod_dtype::DType;
 use svod_tensor::Tensor;
 
-use crate::silero_vad::{CONTEXT_SIZE, HIDDEN, NUM_SAMPLES, SileroVad, VadInference};
+use crate::silero_vad::{CONTEXT_SIZE, HIDDEN, NUM_SAMPLES, SileroVad, VadInference, fixed_windows_from_probs};
 
 // ---------------------------------------------------------------------------
 // Cheap default tests (no realize): build forward graph, check symbolic shape.
@@ -35,6 +36,27 @@ fn forward_chunk_zero_weights_shape() {
         .collect();
     // [B=1, prob(1) + h(HIDDEN) + c(HIDDEN)]
     assert_eq!(shape, vec![1, 1 + 2 * HIDDEN]);
+}
+
+#[test]
+fn fixed_windows_from_probs_keeps_only_speech_windows() {
+    let mut probs = vec![0.0_f32; 55];
+    probs[2] = 0.8;
+    probs[42] = 0.9;
+
+    let chunks = fixed_windows_from_probs(&probs, 55, 1, 0.5, 1, 20);
+    assert_eq!(chunks, vec![AudioChunk::new(0, 20), AudioChunk::new(40, 55)]);
+}
+
+#[test]
+fn fixed_windows_from_probs_respects_min_speech_probs() {
+    let mut probs = vec![0.0_f32; 40];
+    probs[2] = 0.8;
+    probs[21] = 0.9;
+    probs[22] = 0.95;
+
+    let chunks = fixed_windows_from_probs(&probs, 40, 1, 0.5, 2, 20);
+    assert_eq!(chunks, vec![AudioChunk::new(20, 40)]);
 }
 
 // ---------------------------------------------------------------------------

--- a/model/src/test/unit/splitter.rs
+++ b/model/src/test/unit/splitter.rs
@@ -51,7 +51,7 @@ fn fixed_length_splitter_shorter_than_max() {
     let mut s = FixedLengthSplitter::new();
     let wf = vec![0.0; 10];
     let chunks = s.split(&wf, &bounds_tiny()).unwrap();
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 0, end_sample: 10 }]);
+    assert_eq!(chunks, vec![AudioChunk::new(0, 10)]);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn fixed_length_splitter_exact_one_chunk() {
     let mut s = FixedLengthSplitter::new();
     let wf = vec![0.0; 16];
     let chunks = s.split(&wf, &bounds_tiny()).unwrap();
-    assert_eq!(chunks, vec![AudioChunk { start_sample: 0, end_sample: 16 }]);
+    assert_eq!(chunks, vec![AudioChunk::new(0, 16)]);
 }
 
 #[test]
@@ -69,10 +69,7 @@ fn fixed_length_splitter_exact_two_chunks() {
     let mut s = FixedLengthSplitter::new();
     let wf = vec![0.0; 32];
     let chunks = s.split(&wf, &bounds_tiny()).unwrap();
-    assert_eq!(
-        chunks,
-        vec![AudioChunk { start_sample: 0, end_sample: 16 }, AudioChunk { start_sample: 16, end_sample: 32 },]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 16), AudioChunk::new(16, 32)]);
 }
 
 #[test]
@@ -81,14 +78,7 @@ fn fixed_length_splitter_two_chunks_plus_tail() {
     let mut s = FixedLengthSplitter::new();
     let wf = vec![0.0; 33];
     let chunks = s.split(&wf, &bounds_tiny()).unwrap();
-    assert_eq!(
-        chunks,
-        vec![
-            AudioChunk { start_sample: 0, end_sample: 16 },
-            AudioChunk { start_sample: 16, end_sample: 32 },
-            AudioChunk { start_sample: 32, end_sample: 33 },
-        ]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 16), AudioChunk::new(16, 32), AudioChunk::new(32, 33),]);
 }
 
 #[test]
@@ -100,10 +90,7 @@ fn fixed_length_splitter_final_chunk_can_be_unaligned() {
     let mut s = FixedLengthSplitter::new();
     let wf = vec![0.0; 30];
     let chunks = s.split(&wf, &bounds_tiny()).unwrap();
-    assert_eq!(
-        chunks,
-        vec![AudioChunk { start_sample: 0, end_sample: 16 }, AudioChunk { start_sample: 16, end_sample: 30 },]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 16), AudioChunk::new(16, 30)]);
 }
 
 #[test]
@@ -114,14 +101,7 @@ fn fixed_length_splitter_progress_under_degenerate_bounds() {
     let mut s = FixedLengthSplitter::new();
     let chunks = s.split(&[0.0_f32; 9], &bounds).unwrap();
     // align=4, max forced to 4 → chunks of 4, 4, 1.
-    assert_eq!(
-        chunks,
-        vec![
-            AudioChunk { start_sample: 0, end_sample: 4 },
-            AudioChunk { start_sample: 4, end_sample: 8 },
-            AudioChunk { start_sample: 8, end_sample: 9 },
-        ]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 4), AudioChunk::new(4, 8), AudioChunk::new(8, 9),]);
 }
 
 #[test]
@@ -136,12 +116,5 @@ fn fixed_length_splitter_alignment_does_not_divide_max() {
     // First chunk: nominal_end=12, span=12, aligned_span=12 → 0..12.
     // Second chunk: nominal_end=24, span=12, aligned_span=12 → 12..24.
     // Third chunk: nominal_end=26 == waveform.len() → final, 24..26.
-    assert_eq!(
-        chunks,
-        vec![
-            AudioChunk { start_sample: 0, end_sample: 12 },
-            AudioChunk { start_sample: 12, end_sample: 24 },
-            AudioChunk { start_sample: 24, end_sample: 26 },
-        ]
-    );
+    assert_eq!(chunks, vec![AudioChunk::new(0, 12), AudioChunk::new(12, 24), AudioChunk::new(24, 26),]);
 }

--- a/model/src/test/unit/splitter.rs
+++ b/model/src/test/unit/splitter.rs
@@ -118,3 +118,24 @@ fn fixed_length_splitter_alignment_does_not_divide_max() {
     // Third chunk: nominal_end=26 == waveform.len() → final, 24..26.
     assert_eq!(chunks, vec![AudioChunk::new(0, 12), AudioChunk::new(12, 24), AudioChunk::new(24, 26),]);
 }
+
+#[test]
+fn fixed_length_splitter_duration_cap() {
+    let mut s = FixedLengthSplitter::with_max_duration_secs(20.0);
+    let wf = vec![0.0; 650_000];
+    let chunks = s.split(&wf, &bounds_realistic()).unwrap();
+    assert_eq!(
+        chunks,
+        vec![AudioChunk::new(0, 320_000), AudioChunk::new(320_000, 640_000), AudioChunk::new(640_000, 650_000),]
+    );
+    assert_eq!(s.max_chunk_samples(&bounds_realistic()), 320_000);
+}
+
+#[test]
+fn fixed_length_splitter_duration_cap_clamps_to_encoder_capacity() {
+    let mut s = FixedLengthSplitter::with_max_duration_secs(60.0);
+    let wf = vec![0.0; 33];
+    let chunks = s.split(&wf, &bounds_tiny()).unwrap();
+    assert_eq!(chunks, vec![AudioChunk::new(0, 16), AudioChunk::new(16, 32), AudioChunk::new(32, 33)]);
+    assert_eq!(s.max_chunk_samples(&bounds_tiny()), 16);
+}

--- a/model/src/test/unit/transcribe.rs
+++ b/model/src/test/unit/transcribe.rs
@@ -10,7 +10,7 @@
 use svod_arch::rnnt::Word;
 
 use crate::gigaam::TranscribeOpts;
-use crate::gigaam::transcribe::ctc_frames_to_words;
+use crate::gigaam::transcribe::{crop_words_to_core, ctc_frames_to_words, words_to_text};
 
 #[test]
 fn ctc_frames_to_words_empty() {
@@ -68,6 +68,34 @@ fn ctc_frames_to_words_frame_shift_scales_linearly() {
     assert_eq!(b.len(), 1);
     assert!((a[0].start - 2.0 * b[0].start).abs() < 1e-6);
     assert!((a[0].end - 2.0 * b[0].end).abs() < 1e-6);
+}
+
+#[test]
+fn crop_words_to_core_keeps_midpoints_inside_core() {
+    let words = vec![
+        Word { text: "left".to_string(), start: 0.0, end: 0.25 },
+        Word { text: "keep".to_string(), start: 0.5, end: 0.75 },
+        Word { text: "right".to_string(), start: 1.25, end: 1.5 },
+    ];
+    let cropped = crop_words_to_core(words, 0.0, 0.375, 1.0);
+    assert_eq!(cropped, vec![Word { text: "keep".to_string(), start: 0.125, end: 0.375 }]);
+}
+
+#[test]
+fn crop_words_to_core_clamps_boundary_word_times() {
+    let words = vec![Word { text: "edge".to_string(), start: 0.25, end: 0.75 }];
+    let cropped = crop_words_to_core(words, 0.0, 0.375, 0.625);
+    assert_eq!(cropped, vec![Word { text: "edge".to_string(), start: 0.0, end: 0.25 }]);
+}
+
+#[test]
+fn words_to_text_joins_non_empty_words() {
+    let words = vec![
+        Word { text: "hello".to_string(), start: 0.0, end: 0.1 },
+        Word { text: "".to_string(), start: 0.1, end: 0.2 },
+        Word { text: "world".to_string(), start: 0.2, end: 0.3 },
+    ];
+    assert_eq!(words_to_text(&words), "hello world");
 }
 
 // ─── TranscribeOpts builder ──────────────────────────────────────────────


### PR DESCRIPTION
- Separate VAD chunk cores from decode windows, so text ownership stays non-overlapping while the encoder still gets boundary context.
- Decode timestamps internally for both CTC and RNNT, then crop words back to each chunk core before assembling final text.
- Rework Silero VAD chunk packing to split long greedy envelopes at stable inter-run gaps instead of decoding overly long boundary-sensitive RNNT windows.
- Preserve bounded gap pre-roll for low-confidence speech before the next VAD run.
- Tighten chunk capacity accounting around decode padding/alignment.
- Add focused VAD, splitter, and transcription tests for core/decode ranges, strict limits, clustering, and timestamp cropping.

## Motivation

GigaAM RNNT is sensitive to long-form chunk boundaries. The previous VAD windows could drop phrases such as `Включай` / `Включи` and corrupt nearby text even though the speech was inside VAD-covered regions.
This keeps chunk output ownership deterministic while choosing decode windows that better match upstream GigaAM behavior.