### PR TITLE
CI: publish svod-model alongside svod-onnx at L7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,10 @@ jobs:
           publish_crate svod-tensor
           wait_for_crate svod-tensor "$VERSION"
 
-          # L7
-          publish_crate svod-onnx
+          # L7: parallel leaves (no inter-dep, nothing depends on them)
+          publish_crate svod-onnx &
+          publish_crate svod-model &
+          wait
           echo "All crates published successfully!"
 
   release:
@@ -146,7 +148,7 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-          CRATES="svod-dtype svod-macros svod-arch svod-ir svod-device svod-schedule svod-codegen svod-runtime svod-tensor svod-onnx"
+          CRATES="svod-dtype svod-macros svod-arch svod-ir svod-device svod-schedule svod-codegen svod-runtime svod-tensor svod-onnx svod-model"
           {
             echo "links<<EOF"
             echo "## Crates"


### PR DESCRIPTION
  - Add `svod-model` to the crates.io publish flow. It was previously omitted (the same omission existed pre-rename for `morok-model`) even though its `Cargo.toml` has no `publish = false`.
  - `svod-onnx` and `svod-model` are independent leaves (nothing depends on either, neither depends on the other), so they now publish in parallel at L7 instead of `svod-onnx` running alone.
  - Append `svod-model` to the `CRATES` env in the release job so the GitHub Release notes include its crates.io link.