### PR TITLE
ndarray-style indexing (s!/getitem/set) + qr/cholesky

### DIFF
--- a/model/src/diarizen/model.rs
+++ b/model/src/diarizen/model.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use snafu::ResultExt;
 use svod_dtype::DType;
 use svod_ir::SInt;
-use svod_tensor::{BoundVariable, Tensor};
+use svod_tensor::{BoundVariable, Tensor, s};
 
 use crate::init::{fan_in_uniform, zeros};
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
@@ -117,11 +117,8 @@ impl DiariZenSegmentationModel {
     }
 
     fn select_channel(&self, waveforms: &Tensor) -> Result<Tensor> {
-        waveforms
-            .try_shrink([None, Some((0isize, 1isize)), None])
-            .context(TensorSnafu)?
-            .try_squeeze(Some(1))
-            .context(TensorSnafu)
+        // Py: waveforms[:, 0, :]
+        waveforms.getitem(s![.., 0, ..]).context(TensorSnafu)
     }
 
     fn head_forward(&self, stacked: &Tensor) -> Result<Tensor> {

--- a/model/src/wavlm/attention.rs
+++ b/model/src/wavlm/attention.rs
@@ -24,8 +24,8 @@
 
 use snafu::ResultExt;
 use svod_dtype::DType;
-use svod_tensor::Tensor;
 use svod_tensor::reduce::AxisSpec;
+use svod_tensor::{Tensor, s};
 
 use crate::init::{fan_in_uniform, ones, zeros};
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
@@ -249,8 +249,7 @@ impl GatedRelPosAttention {
 
         // Py:712  attn_mask_rel_pos = attn_mask_rel_pos.view((-1, seq_len, seq_len))
         // Py:713  attn_mask_rel_pos = attn_mask_rel_pos.reshape(bsz, h, seq_len, seq_len)[:, self.remaining_heads, :, :]
-        let head_idx = Tensor::from_slice(self.remaining_heads.iter().map(|&i| i as i64).collect::<Vec<_>>());
-        let attn_mask = attn_mask_rel_pos.index_select(1, &head_idx).context(TensorSnafu)?; // (B, nk, L, L)
+        let attn_mask = attn_mask_rel_pos.getitem(s![.., self.remaining_heads.clone(), .., ..]).context(TensorSnafu)?; // (B, nk, L, L)
 
         // =================================================================
         // Q / K / V projections (SelfAttention.forward, lines 455-458)

--- a/schedule/src/rangeify/patterns.rs
+++ b/schedule/src/rangeify/patterns.rs
@@ -1057,13 +1057,12 @@ fn map_after_like_node(node: &Arc<UOp>, ctx: &mut LocalAddBufferContext) -> Opti
         _ => buf,
     };
 
-    if ctx.has_buffer(&buf) {
-        debug_assert!(false, "handle_after_like: duplicate buffer mapping for buf id={}", buf.id);
-        tracing::warn!(buf_id = buf.id, "handle_after_like: duplicate buffer mapping, skipping");
-        return None;
-    }
-
-    // Map buf -> node (AFTER/MSTACK/MSELECT), then replace node in AST with buf.
+    // A reused buffer (the level-interval planner aliases non-overlapping
+    // lifetimes) can be the target of more than one AFTER within a kernel's
+    // input cone. That is legal: keep the last writer as this kernel's source
+    // (matching tinygrad's `{u.buf_uop: u for u in afters}` last-wins), and let
+    // `fix_assign` re-derive the cross-kernel ordering globally from `buf_uop`.
+    // Either way the node is replaced by its buffer so consumers read the buffer.
     ctx.map_buffer(buf.clone(), node.clone());
     Some(buf)
 }

--- a/tensor/src/einsum.rs
+++ b/tensor/src/einsum.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use snafu::ResultExt;
 
-use crate::Tensor;
 use crate::error::UOpSnafu;
 use crate::reduce::AxisSpec;
+use crate::{Tensor, s};
 
 type Result<T> = crate::Result<T>;
 
@@ -130,13 +130,8 @@ impl Tensor {
                         // unflatten last dim into [n, n+1]
                         x = x.unflatten(-1, &[n as isize, (n + 1) as isize])?;
 
-                        // take element 0 along last dim (shrink + squeeze)
-                        let cur_ndim = x.ndim()?;
-                        let mut ranges: Vec<(isize, isize)> =
-                            x.shape()?.iter().map(|d| (0, d.as_const().unwrap() as isize)).collect();
-                        ranges[cur_ndim - 1] = (0, 1);
-                        x = x.try_shrink(&ranges)?;
-                        x = x.try_squeeze(Some(-1))?;
+                        // take element 0 along last dim (collapses it)
+                        x = x.getitem(s![Ellipsis, 0])?;
                     } else {
                         // 2D diagonal: use flatten + stride approach
                         // For a [n, n] matrix, diagonal = flatten then take every (n+1)th element

--- a/tensor/src/index.rs
+++ b/tensor/src/index.rs
@@ -1,0 +1,550 @@
+//! ndarray-style indexing: the [`s!`] macro plus [`Tensor::getitem`] / [`Tensor::set`].
+//!
+//! This is an ergonomic, numpy-faithful front-end over the existing movement /
+//! gather / `where_` backend. Basic slicing lowers to `try_shrink` (graph-identical
+//! to a hand-written shrink) or, when steps / reverse are involved, to
+//! [`Tensor::slice_with`]. Advanced (tensor) indices lower to `index_select` /
+//! gather. [`Tensor::set`] is a *functional* setitem — it returns a new tensor
+//! (the lib is immutable; `assign` covers realized-buffer in-place writes).
+
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+
+use svod_ir::SInt;
+
+use super::*;
+
+/// One axis selector in an indexing expression (built by [`s!`]).
+#[derive(Clone)]
+pub enum Idx {
+    /// Integer index — selects one element and collapses the dimension.
+    Index(i64),
+    /// `a..b` / `a..` / `..b` / `a..b;step` — half-open slice (concrete bounds).
+    Range { start: Option<i64>, end: Option<i64>, step: Option<i64> },
+    /// Symbolic-bound range — for JIT batch dims (`Idx::sint(0, b)`).
+    SymRange(SInt, SInt),
+    /// `..` — keep the whole dimension.
+    Full,
+    /// Insert a new dimension of size 1 (consumes no source dim).
+    NewAxis,
+    /// `...` — expands to as many [`Idx::Full`] as needed (at most one per spec).
+    Ellipsis,
+    /// Advanced index: an integer tensor (gather / `index_select`).
+    Fancy(Tensor),
+}
+
+impl Idx {
+    /// A symbolic-bound range, e.g. `Idx::sint(SInt::Const(0), batch.as_sint())`.
+    pub fn sint(begin: impl Into<SInt>, end: impl Into<SInt>) -> Self {
+        Idx::SymRange(begin.into(), end.into())
+    }
+
+    /// Attach a step to a range produced by [`s!`]'s `a..b;step` syntax. Internal.
+    #[doc(hidden)]
+    pub fn __with_step(range: impl Into<Idx>, step: i64) -> Self {
+        match range.into() {
+            Idx::Range { start, end, .. } => Idx::Range { start, end, step: Some(step) },
+            Idx::Full => Idx::Range { start: None, end: None, step: Some(step) },
+            other => other,
+        }
+    }
+}
+
+macro_rules! impl_idx_from {
+    ($($ty:ty => |$v:pat_param| $body:expr),+ $(,)?) => {
+        $(impl From<$ty> for Idx { fn from($v: $ty) -> Self { $body } })+
+    };
+}
+impl_idx_from! {
+    i64 => |i| Idx::Index(i),
+    RangeFull => |_| Idx::Full,
+    Range<i64> => |r| Idx::Range { start: Some(r.start), end: Some(r.end), step: None },
+    RangeFrom<i64> => |r| Idx::Range { start: Some(r.start), end: None, step: None },
+    RangeTo<i64> => |r| Idx::Range { start: None, end: Some(r.end), step: None },
+    Tensor => |t| Idx::Fancy(t),
+    &Tensor => |t| Idx::Fancy(t.clone()),
+    Vec<i64> => |v| Idx::Fancy(Tensor::from_slice(v)),
+    Vec<usize> => |v| Idx::Fancy(Tensor::from_slice(v.into_iter().map(|x| x as i64).collect::<Vec<_>>())),
+}
+
+/// What [`s!`] builds and [`Tensor::getitem`] / [`Tensor::set`] accept.
+#[derive(Clone, Default)]
+pub struct IndexSpec(pub Vec<Idx>);
+
+impl From<Vec<Idx>> for IndexSpec {
+    fn from(v: Vec<Idx>) -> Self {
+        IndexSpec(v)
+    }
+}
+
+/// ndarray-style indexing macro. Builds an [`IndexSpec`] for `getitem`/`set`.
+///
+/// | spelling | meaning |
+/// |---|---|
+/// | `..` | full axis |
+/// | `a..b` / `a..` / `..b` | half-open range (concrete `i64` bounds) |
+/// | `a..b ; step` | stepped range (negative step reverses) |
+/// | `i` | integer index (collapses the axis) |
+/// | `Idx::sint(b, e)` | symbolic-bound range (JIT batch dims) |
+/// | `tensor` / `vec` | advanced (fancy) index |
+/// | `NewAxis` | insert a size-1 dimension |
+/// | `Ellipsis` | fill the remaining axes with `..` |
+///
+/// ```
+/// use ndarray::array;
+/// use svod_tensor::{Tensor, s};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let t = Tensor::from_ndarray(&array![[1.0f32, 2., 3.], [4., 5., 6.]]); // [2, 3]
+/// let _row  = t.getitem(s![0, ..])?;        // integer index collapses axis 0 → [3]
+/// let _cols = t.getitem(s![.., 0..2])?;     // ranges → [2, 2]
+/// let heads = vec![0usize, 2];
+/// let _sel  = t.getitem(s![.., heads])?;    // single-axis fancy (gather) → [2, 2]
+/// let block = Tensor::from_slice([7.0f32, 8., 9.]);
+/// let _t2   = t.set(s![1, ..], &block)?;    // functional setitem → new [2, 3]
+/// # Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! s {
+    ($($t:tt)*) => {
+        $crate::IndexSpec($crate::__s_collect!([] $($t)*))
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __s_collect {
+    // terminal: emit the accumulated items as a vec (no init-then-push).
+    ([$($acc:expr),*]) => { ::std::vec![$($acc),*] };
+    ([$($acc:expr),*] ,) => { ::std::vec![$($acc),*] };
+    // markers (matched before the generic expr arm).
+    ([$($acc:expr),*] Ellipsis $(, $($rest:tt)*)?) => {
+        $crate::__s_collect!([$($acc,)* $crate::Idx::Ellipsis] $($($rest)*)?)
+    };
+    ([$($acc:expr),*] NewAxis $(, $($rest:tt)*)?) => {
+        $crate::__s_collect!([$($acc,)* $crate::Idx::NewAxis] $($($rest)*)?)
+    };
+    // stepped range: `a..b ; step`.
+    ([$($acc:expr),*] $r:expr ; $step:expr $(, $($rest:tt)*)?) => {
+        $crate::__s_collect!([$($acc,)* $crate::Idx::__with_step($r, $step)] $($($rest)*)?)
+    };
+    // everything else via `From`: `..`, `a..b`, ints, tensors, `Idx::sint(..)`.
+    ([$($acc:expr),*] $e:expr $(, $($rest:tt)*)?) => {
+        $crate::__s_collect!([$($acc,)* $crate::Idx::from($e)] $($($rest)*)?)
+    };
+}
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+fn idx_err(details: impl Into<String>) -> Error {
+    Error::IrConstruction { details: details.into() }
+}
+
+fn concrete(shape: &svod_ir::shape::Shape, d: usize, what: &str) -> Result<usize> {
+    shape[d].as_const().ok_or_else(|| Error::SymbolicShapeUnsupported { operation: what.to_string() })
+}
+
+/// Resolve a (possibly negative) integer index against a concrete dim.
+fn resolve_index(i: i64, dim: usize) -> Result<usize> {
+    let d = dim as i64;
+    let r = if i < 0 { i + d } else { i };
+    if r < 0 || r >= d {
+        return Err(idx_err(format!("index {i} out of bounds for axis of size {dim}")));
+    }
+    Ok(r as usize)
+}
+
+/// Resolve a half-open `[start, end)` slice against a concrete dim (clamped; `b ≤ e`).
+fn resolve_range(start: Option<i64>, end: Option<i64>, dim: usize) -> (usize, usize) {
+    let b = start.unwrap_or(0).clamp(0, dim as i64) as usize;
+    let e = (end.unwrap_or(dim as i64).clamp(0, dim as i64) as usize).max(b);
+    (b, e)
+}
+
+/// Normalize a spec: validate ≤1 ellipsis, expand ellipsis / implicit-trailing
+/// into `Full` so the number of source-consuming items equals `ndim`.
+fn normalize_spec(spec: Vec<Idx>, ndim: usize) -> Result<Vec<Idx>> {
+    let ellipsis = spec.iter().filter(|i| matches!(i, Idx::Ellipsis)).count();
+    if ellipsis > 1 {
+        return Err(idx_err("at most one `Ellipsis` allowed per index"));
+    }
+    let consumed = spec.iter().filter(|i| !matches!(i, Idx::NewAxis | Idx::Ellipsis)).count();
+    if consumed > ndim {
+        return Err(idx_err(format!("too many indices: {consumed} for {ndim}-D tensor")));
+    }
+    let fill = ndim - consumed;
+
+    let mut out = Vec::with_capacity(spec.len() + fill);
+    let mut filled = false;
+    for item in spec {
+        match item {
+            Idx::Ellipsis => {
+                out.extend(std::iter::repeat_n(Idx::Full, fill));
+                filled = true;
+            }
+            other => out.push(other),
+        }
+    }
+    if !filled {
+        out.extend(std::iter::repeat_n(Idx::Full, fill));
+    }
+    Ok(out)
+}
+
+/// Does this range need the `slice_with` path (steps / reverse / negative bounds)?
+fn range_needs_slice_with(start: Option<i64>, end: Option<i64>, step: Option<i64>) -> bool {
+    step.is_some_and(|s| s != 1) || start.is_some_and(|s| s < 0) || end.is_some_and(|e| e < 0)
+}
+
+/// Per-source-axis classification of a normalized (no-Ellipsis, no-stepped) spec,
+/// shared by the basic-shrink, advanced, and set paths. Each path then validates
+/// the fields it forbids (e.g. advanced rejects `collapse`/`newaxis`).
+struct Parsed {
+    /// Per source axis: shrink bound (`None` = full, or a fancy axis kept full).
+    bounds: Vec<Option<(SInt, SInt)>>,
+    /// Source axes selected by an integer index (collapsed in the output).
+    collapse: Vec<usize>,
+    /// `(source axis, index tensor)` for advanced indices.
+    fancy: Vec<(usize, Tensor)>,
+    /// Whether any `NewAxis` appears (inserts a size-1 output dim).
+    newaxis: bool,
+}
+
+/// One pass over the spec. Errors on stepped/reverse ranges (those route through
+/// `slice_with` before this is reached).
+fn parse_spec(spec: &[Idx], shape: &svod_ir::shape::Shape, ctx: &str) -> Result<Parsed> {
+    let (mut bounds, mut collapse, mut fancy, mut newaxis) = (Vec::new(), Vec::new(), Vec::new(), false);
+    let mut d = 0;
+    for item in spec {
+        match item {
+            Idx::NewAxis => {
+                newaxis = true;
+                continue; // consumes no source axis
+            }
+            Idx::Full => bounds.push(None),
+            Idx::SymRange(b, e) => bounds.push(Some((b.clone(), e.clone()))),
+            Idx::Range { start, end, step } => {
+                if range_needs_slice_with(*start, *end, *step) {
+                    return Err(idx_err("stepped / reverse range is not allowed in this position"));
+                }
+                let (b, e) = resolve_range(*start, *end, concrete(shape, d, ctx)?);
+                bounds.push(Some((SInt::Const(b), SInt::Const(e))));
+            }
+            Idx::Index(i) => {
+                let ii = resolve_index(*i, concrete(shape, d, ctx)?)?;
+                bounds.push(Some((SInt::Const(ii), SInt::Const(ii + 1))));
+                collapse.push(d);
+            }
+            Idx::Fancy(t) => {
+                bounds.push(None);
+                fancy.push((d, t.clone()));
+            }
+            Idx::Ellipsis => unreachable!("ellipsis expanded by normalize_spec"),
+        }
+        d += 1;
+    }
+    Ok(Parsed { bounds, collapse, fancy, newaxis })
+}
+
+impl Tensor {
+    /// numpy-style read indexing. Build `spec` with [`s!`].
+    #[track_caller]
+    pub fn getitem(&self, spec: impl Into<IndexSpec>) -> Result<Tensor> {
+        self.index_impl(spec.into().0, None)
+    }
+
+    /// Functional numpy-style write indexing: returns a new tensor equal to `self`
+    /// with the `spec` region overwritten by `value` (broadcast). Nothing mutates.
+    #[track_caller]
+    pub fn set(&self, spec: impl Into<IndexSpec>, value: &Tensor) -> Result<Tensor> {
+        self.index_impl(spec.into().0, Some(value))
+    }
+
+    fn index_impl(&self, spec: Vec<Idx>, value: Option<&Tensor>) -> Result<Tensor> {
+        let ndim = self.ndim()?;
+        let spec = normalize_spec(spec, ndim)?;
+        let has_fancy = spec.iter().any(|i| matches!(i, Idx::Fancy(_)));
+
+        if has_fancy {
+            return self.index_advanced(&spec, value);
+        }
+        match value {
+            None => self.getitem_basic(&spec),
+            Some(v) => self.set_basic(&spec, v),
+        }
+    }
+
+    /// Basic read: route plain/symbolic shrinks straight to `try_shrink` (graph-
+    /// identical to a hand-written shrink); only steps / reverse use `slice_with`.
+    fn getitem_basic(&self, spec: &[Idx]) -> Result<Tensor> {
+        let shape = self.shape()?;
+        let use_slice_with = spec
+            .iter()
+            .any(|i| matches!(i, Idx::Range { start, end, step } if range_needs_slice_with(*start, *end, *step)));
+
+        let x = if use_slice_with {
+            self.basic_via_slice_with(spec, &shape)?
+        } else {
+            self.try_shrink(parse_spec(spec, &shape, "basic index on a symbolic dim")?.bounds)?
+        };
+
+        // Final reshape only if a dim collapses (int) or is inserted (NewAxis).
+        let need_reshape = spec.iter().any(|i| matches!(i, Idx::Index(_) | Idx::NewAxis));
+        if !need_reshape {
+            return Ok(x);
+        }
+        let xs = x.shape()?;
+        let mut view: Vec<SInt> = Vec::new();
+        let mut d = 0;
+        for item in spec {
+            match item {
+                Idx::NewAxis => view.push(SInt::Const(1)),
+                Idx::Index(_) => d += 1, // collapsed: drop
+                _ => {
+                    view.push(xs[d].clone());
+                    d += 1;
+                }
+            }
+        }
+        x.try_reshape(view)
+    }
+
+    /// Step / reverse / negative-bound slicing via the `slice_with` backend (concrete-only).
+    fn basic_via_slice_with(&self, spec: &[Idx], shape: &svod_ir::shape::Shape) -> Result<Tensor> {
+        let (mut starts, mut ends, mut steps, mut axes) = (vec![], vec![], vec![], vec![]);
+        let mut d = 0;
+        for item in spec {
+            match item {
+                Idx::NewAxis => {}
+                Idx::Full => d += 1, // untouched axes stay full
+                Idx::SymRange(..) => return Err(idx_err("cannot combine a symbolic range with stepped slicing")),
+                Idx::Range { start, end, step } => {
+                    let dim = concrete(shape, d, "stepped slice on a symbolic dim")? as i64;
+                    let st = (*step).unwrap_or(1);
+                    let (ds, de) = if st > 0 { (0, dim) } else { (dim - 1, -dim - 1) };
+                    axes.push(d as i64);
+                    starts.push((*start).unwrap_or(ds));
+                    ends.push((*end).unwrap_or(de));
+                    steps.push(st);
+                    d += 1;
+                }
+                Idx::Index(i) => {
+                    let dim = concrete(shape, d, "integer index on a symbolic dim")?;
+                    let ii = resolve_index(*i, dim)? as i64;
+                    axes.push(d as i64);
+                    starts.push(ii);
+                    ends.push(ii + 1);
+                    steps.push(1);
+                    d += 1;
+                }
+                Idx::Ellipsis | Idx::Fancy(_) => unreachable!("normalized / non-fancy"),
+            }
+        }
+        self.slice_with().starts(&starts).ends(&ends).axes(&axes).steps(&steps).call()
+    }
+
+    /// Advanced (fancy) indexing. Non-fancy axes may be `Full` / step-1 `Range` /
+    /// `SymRange`; `NewAxis`, integer collapse, and steps cannot mix with fancy
+    /// indices (decompose into separate calls).
+    fn index_advanced(&self, spec: &[Idx], value: Option<&Tensor>) -> Result<Tensor> {
+        let shape = self.shape()?;
+        let p = parse_spec(spec, &shape, "advanced index on a symbolic dim")?;
+        if !p.collapse.is_empty() || p.newaxis {
+            return Err(idx_err("NewAxis / integer-collapse cannot mix with advanced indices"));
+        }
+        // Pre-apply ranges on non-fancy axes (identity when all are Full → graph-identical).
+        let has_range = p.bounds.iter().any(|b| b.is_some());
+        let x = self.try_shrink(p.bounds)?;
+
+        // Fast path: a single 1-D fancy axis is exactly `index_select` (the head-pruning case).
+        if value.is_none() && p.fancy.len() == 1 && p.fancy[0].1.ndim()? == 1 {
+            let (axis, idx) = &p.fancy[0];
+            return x.index_select(*axis as isize, idx);
+        }
+        match value {
+            None => x.gather_advanced(&p.fancy),
+            // A range/slice on another axis would shrink `x`, so writing back via
+            // `set_advanced` would drop the region outside the range. Fail loud
+            // instead of silently corrupting; the caller can split it explicitly.
+            Some(_) if has_range => Err(idx_err(
+                "advanced `set` combined with a range/slice on another axis is unsupported; \
+                 split it: `let s = t.getitem(range)?; let s = s.set(fancy, v)?; t.set(range, &s)`",
+            )),
+            Some(v) => x.set_advanced(&p.fancy, v),
+        }
+    }
+
+    /// General N-axis advanced gather (one-hot / `where_` / sum, numpy axis order).
+    fn gather_advanced(&self, fancy: &[(usize, Tensor)]) -> Result<Tensor> {
+        use svod_ir::shape::{Shape, align_shapes_left, broadcast_shapes};
+
+        let xs = self.shape()?;
+        let n = xs.len();
+        let dims: Vec<usize> = fancy.iter().map(|(d, _)| *d).collect();
+        let d0 = dims[0];
+
+        // Fold negative indices and compute the broadcast index shape.
+        let folded: Vec<Tensor> = fancy
+            .iter()
+            .map(|(d, t)| {
+                let dim = concrete(&xs, *d, "advanced index on a symbolic gather axis")?;
+                t.normalize_negative_indices(dim as i64)
+            })
+            .collect::<Result<_>>()?;
+        let idx_shapes: Vec<Shape> = folded.iter().map(|t| t.shape()).collect::<Result<_>>()?;
+        let big = broadcast_shapes(&align_shapes_left(&idx_shapes)).context(UOpSnafu)?;
+        let g = big.len();
+
+        // pre_reduce_shape = xs[..d0] ++ big ++ xs[d0..]
+        let mut pre: Vec<SInt> = xs[..d0].to_vec();
+        pre.extend(big.iter().cloned());
+        pre.extend_from_slice(&xs[d0..]);
+        let pre: Shape = pre.into_iter().collect();
+
+        // Reshape x to inject g size-1 axes for `big` at d0, then build the AND of one-hot masks.
+        let mut xr: Vec<SInt> = xs[..d0].to_vec();
+        xr.extend(std::iter::repeat_n(SInt::Const(1), g));
+        xr.extend_from_slice(&xs[d0..]);
+        let x_re = self.try_reshape(xr)?;
+
+        let mut mask: Option<Tensor> = None;
+        for ((d, _), idx) in fancy.iter().zip(&folded) {
+            let num_classes = concrete(&xs, *d, "advanced index on a symbolic gather axis")?;
+            // Broadcast the index to `big`, then place that block at positions
+            // [d0 .. d0+g] with size-1 axes before and after, so the expand to `pre`
+            // works for any first-fancy-axis position d0 and for indices of differing
+            // rank (our `try_expand` requires equal rank — no implicit left-pad).
+            let mut ir: Vec<SInt> = vec![SInt::Const(1); d0];
+            ir.extend(big.iter().cloned());
+            ir.extend(std::iter::repeat_n(SInt::Const(1), n - d0));
+            let i = idx.broadcast_to(&big)?.try_reshape(ir)?.try_expand(pre.clone())?;
+            let oh = i.one_hot_along_dim(num_classes, *d as isize - n as isize)?;
+            mask = Some(match mask {
+                None => oh,
+                Some(m) => m.try_bitand(&oh)?,
+            });
+        }
+        let mask = mask.expect("advanced path has ≥1 fancy axis");
+
+        let zero = Tensor::new(x_re.uop().const_like(0));
+        let sum_axes: Vec<isize> = dims.iter().map(|&d| (d + g) as isize).collect();
+        let out = x_re.where_(&mask, &zero)?.sum_with().axes(sum_axes).dtype(self.uop().dtype()).call()?;
+
+        // numpy: non-contiguous advanced axes move the broadcast block to the front.
+        let contiguous = dims.windows(2).all(|w| w[1] == w[0] + 1);
+        if contiguous {
+            return Ok(out);
+        }
+        let rank = n - dims.len() + g;
+        let mut perm: Vec<isize> = (d0..d0 + g).map(|x| x as isize).collect();
+        perm.extend((0..d0).map(|x| x as isize));
+        perm.extend((d0 + g..rank).map(|x| x as isize));
+        out.try_permute(&perm)
+    }
+
+    /// Single-axis fancy set via `scatter` (last-writer-wins). Multi-axis → error.
+    fn set_advanced(&self, fancy: &[(usize, Tensor)], value: &Tensor) -> Result<Tensor> {
+        if fancy.len() != 1 {
+            return Err(idx_err("only single-axis fancy assignment is supported; use `scatter` directly"));
+        }
+        let (axis, idx) = &fancy[0];
+        let shape = self.shape()?;
+        let ndim = shape.len();
+        let k = concrete(&idx.shape()?, 0, "fancy assignment index length")?;
+
+        // Broadcast the 1-D index and the value to self.shape with K along `axis`.
+        let mut nd = vec![1isize; ndim];
+        nd[*axis] = k as isize;
+        let idx_nd = idx.try_reshape(&nd)?;
+        let mut tgt: Vec<SInt> = shape.iter().cloned().collect();
+        tgt[*axis] = SInt::Const(k);
+        let tgt: svod_ir::shape::Shape = tgt.into_iter().collect();
+        let idx_nd = idx_nd.try_expand(tgt.clone())?;
+        let src = value.broadcast_to(&tgt)?;
+        self.scatter(*axis as isize, &idx_nd, &src)
+    }
+
+    /// Basic functional setitem: overwrite the `spec` region with `value`.
+    /// Constrained axes must be concrete; `Full` axes may be symbolic. No steps / fancy.
+    fn set_basic(&self, spec: &[Idx], value: &Tensor) -> Result<Tensor> {
+        let shape = self.shape()?;
+        let ndim = shape.len();
+
+        // One pass → per-axis bounds + collapsed axes. `set` pads the region, so it
+        // needs concrete bounds: reject symbolic ranges (and NewAxis / fancy) here.
+        let p = parse_spec(spec, &shape, "set on a symbolic dim")?;
+        if p.newaxis || !p.fancy.is_empty() {
+            return Err(idx_err("set supports only Full / range / integer indices (no NewAxis or fancy)"));
+        }
+        let sym = || Error::SymbolicShapeUnsupported { operation: "set on a symbolic dim".to_string() };
+        let bounds: Vec<Option<(usize, usize)>> = p
+            .bounds
+            .iter()
+            .map(|b| match b {
+                None => Ok(None),
+                Some((s, e)) => Ok(Some((s.as_const().ok_or_else(sym)?, e.as_const().ok_or_else(sym)?))),
+            })
+            .collect::<Result<_>>()?;
+        let collapse = p.collapse;
+
+        // Lift `value` to the slice shape. Broadcast it to the *kept* (non-collapsed)
+        // extents first — so a scalar / lower-rank value lines up by numpy rules —
+        // then re-insert size-1 axes at the collapsed positions. Unsqueezing the raw
+        // value at the collapsed axes directly would panic when its rank is below a
+        // non-leading collapsed axis (e.g. a 0-D value with `s![.., 0]`).
+        let slice_dims: Vec<SInt> = bounds
+            .iter()
+            .enumerate()
+            .map(|(d, b)| match b {
+                Some((s, e)) => SInt::Const(e - s),
+                None => shape[d].clone(),
+            })
+            .collect();
+        let kept: svod_ir::shape::Shape =
+            slice_dims.iter().enumerate().filter(|(d, _)| !collapse.contains(d)).map(|(_, s)| s.clone()).collect();
+        let mut vb = value.broadcast_to(&kept)?;
+        for &ax in &collapse {
+            vb = vb.try_unsqueeze(ax as isize)?;
+        }
+        // Broadcast into the full slice shape, then pad back to self's shape at the offset.
+        let slice_shape: svod_ir::shape::Shape = slice_dims.into_iter().collect();
+        vb = vb.broadcast_to(&slice_shape)?;
+        let pads: Vec<(isize, isize)> = bounds
+            .iter()
+            .enumerate()
+            .map(|(d, b)| match b {
+                Some((s, e)) => {
+                    let dim = shape[d].as_const().expect("constrained axis is concrete");
+                    Ok::<_, Error>((*s as isize, (dim - e) as isize))
+                }
+                None => Ok((0, 0)),
+            })
+            .collect::<Result<_>>()?;
+        vb = vb.try_pad(&pads)?;
+
+        // Region mask: AND over constrained axes of (arange >= begin) & (arange < end).
+        let mut mask: Option<Tensor> = None;
+        for (d, b) in bounds.iter().enumerate() {
+            let Some((s, e)) = b else { continue };
+            let dim = shape[d].as_const().expect("constrained axis is concrete");
+            let ar = Tensor::arange(0, Some(dim as i64), None)?;
+            let mut ar_shape = vec![1isize; ndim];
+            ar_shape[d] = dim as isize;
+            let ar = ar.try_reshape(&ar_shape)?;
+            let dt = ar.uop().dtype();
+            let lo = ar.try_ge(&Tensor::const_(ConstValue::Int(*s as i64), dt.clone()))?;
+            let hi = ar.try_lt(&Tensor::const_(ConstValue::Int(*e as i64), dt))?;
+            let cond = lo.try_bitand(&hi)?;
+            mask = Some(match mask {
+                None => cond,
+                Some(m) => m.try_bitand(&cond)?,
+            });
+        }
+        match mask {
+            // No constrained axes (all Full) → overwrite everything.
+            None => value.broadcast_to(&shape),
+            Some(mask) => vb.where_(&mask, self),
+        }
+    }
+}

--- a/tensor/src/lib.rs
+++ b/tensor/src/lib.rs
@@ -52,6 +52,7 @@ pub mod conditional;
 pub mod config;
 pub mod data;
 pub mod einsum;
+pub mod index;
 pub mod indexing;
 pub mod math;
 pub mod matmul;
@@ -70,6 +71,7 @@ pub mod variable;
 
 // Re-export for public API
 pub use config::PrepareConfig;
+pub use index::{Idx, IndexSpec};
 pub use svod_runtime::CpuBackend;
 pub use tensor_registry::apply_map_to_tensors;
 pub use variable::{BoundVariable, Variable};

--- a/tensor/src/math.rs
+++ b/tensor/src/math.rs
@@ -9,6 +9,7 @@ use snafu::ResultExt;
 use svod_ir::ConstValue;
 
 use super::*;
+use crate::s;
 
 /// Horner's method for polynomial evaluation: `coeffs[0]*x^(n-1) + ... + coeffs[n-1]`.
 fn poly_n(x: &Tensor, coefficients: &[f64]) -> Result<Tensor> {
@@ -495,6 +496,139 @@ impl Tensor {
 
         Ok(det_val.unwrap())
     }
+
+    // =========================================================================
+    // Decompositions (prototype, concrete square last-two-dims only).
+    //
+    // These showcase the `s!`/`getitem`/`set` indexing API: the per-step
+    // slice reads/writes that a hand-rolled `pad`/`where_` expansion made
+    // painful are now one-liners that read like the reference math.
+    // =========================================================================
+
+    /// Lower-triangular Cholesky factor `L` such that `A = L Lᵀ`, batched over
+    /// leading dims (last two dims must be square). `A` must be symmetric
+    /// positive-definite; a non-SPD input yields NaNs (`sqrt` of a non-positive
+    /// pivot). Cholesky–Banachiewicz recurrence: columns are built and `cat`-ed
+    /// (no full-matrix rewrite per step), so the graph is O(n) and the work
+    /// O(n³).
+    pub fn cholesky(&self) -> Result<Tensor> {
+        let (dims, n, float_dt) = self.square_setup("cholesky")?;
+        let batch = &dims[..dims.len() - 2];
+        let a = to_float(self, &float_dt)?;
+        if n == 0 {
+            return Ok(a);
+        }
+        let nn = n as i64;
+
+        // Column 0: L[:,0] = A[:,0] / sqrt(A[0,0]) (so L[0,0] = sqrt(A[0,0])).
+        let d0 = a.getitem(s![Ellipsis, 0, 0])?.try_sqrt()?;
+        let col0 = a.getitem(s![Ellipsis, .., 0])?.try_div(&d0.try_unsqueeze(-1)?)?; // [.., n]
+        let mut l = col0.try_unsqueeze(-1)?; // columns built so far: [.., n, 1]
+
+        for j in 1..nn {
+            let row_j = l.getitem(s![Ellipsis, j, ..])?; // row j of built cols → [.., j]
+            let diag = a.getitem(s![Ellipsis, j, j])?.try_sub(&row_j.try_mul(&row_j)?.sum(-1isize)?)?.try_sqrt()?;
+            // Below-diagonal rows j..n: (A[i,j] - L[i,:j]·L[j,:j]) / diag.
+            let below = l.getitem(s![Ellipsis, j..nn, ..])?; // [.., n-j, j]
+            let dot = below.try_mul(&row_j.try_unsqueeze(-2)?)?.sum(-1isize)?; // [.., n-j]
+            let col_below = a.getitem(s![Ellipsis, j..nn, j])?.try_sub(&dot)?.try_div(&diag.try_unsqueeze(-1)?)?;
+            // Full column = j zeros (upper triangle) ++ col_below, appended to L.
+            let mut zshape: Vec<usize> = batch.to_vec();
+            zshape.push(j as usize);
+            let zeros_above = Tensor::full(&zshape, 0.0, float_dt.clone())?;
+            let col = Tensor::cat(&[&zeros_above, &col_below], -1)?.try_unsqueeze(-1)?; // [.., n, 1]
+            l = Tensor::cat(&[&l, &col], -1)?;
+        }
+        Ok(l)
+    }
+
+    /// QR decomposition via Householder reflections (batched; last two dims
+    /// `[m, n]`). Returns `(Q, R)` with `Q` orthonormal `[.., m, m]` and `R`
+    /// upper-triangular `[.., m, n]`, `A = Q R`. The reflector loop is O(min(m,n))
+    /// graph steps, each a whole-matrix update.
+    pub fn qr(&self) -> Result<(Tensor, Tensor)> {
+        let shape = self.shape()?;
+        let ndim = shape.len();
+        snafu::ensure!(
+            ndim >= 2,
+            crate::error::ShapeMismatchSnafu {
+                context: "qr".to_string(),
+                expected: "≥2-D".to_string(),
+                actual: format!("{ndim}-D")
+            }
+        );
+        let cdim = |d: usize| {
+            shape[d].as_const().ok_or_else(|| Error::SymbolicShapeUnsupported { operation: "qr".to_string() })
+        };
+        let (m, n) = (cdim(ndim - 2)?, cdim(ndim - 1)?);
+        let batch: Vec<usize> = shape[..ndim - 2].iter().map(|s| s.as_const().unwrap()).collect();
+        let float_dt = if self.uop().dtype().is_float() { self.uop().dtype() } else { DType::Float32 };
+
+        let mut r = to_float(self, &float_dt)?;
+        let mut q = batched_eye(&batch, m, float_dt.clone())?;
+        let mi = m as i64;
+        let zero = Tensor::const_(0.0, float_dt.clone());
+        let one = Tensor::const_(1.0, float_dt.clone());
+        let neg_one = Tensor::const_(-1.0, float_dt.clone());
+
+        for i in 0..m.min(n) as i64 {
+            let x = r.getitem(s![Ellipsis, i..mi, i])?; // reflector source [.., m-i]
+            let norm = x.try_mul(&x)?.sum(-1isize)?.try_sqrt()?; // [..]
+            let x0 = x.getitem(s![Ellipsis, 0])?; // [..]
+            let x0_nz = x0.try_ne(&zero)?;
+            let sgn = x0.sign()?.try_neg()?.where_(&x0_nz, &neg_one)?; // x0!=0 ? -sign(x0) : -1
+            let u1 = x0.try_sub(&sgn.try_mul(&norm)?)?;
+            let norm_nz = norm.try_ne(&zero)?;
+            let denom = u1.where_(&norm_nz, &one)?.try_unsqueeze(-1)?.try_unsqueeze(-1)?; // [..,1,1]
+            let mut w = x.try_unsqueeze(-1)?.try_div(&denom)?; // [.., m-i, 1]
+            w = w.set(s![Ellipsis, 0, 0], &one)?;
+            let tau = sgn.try_neg()?.try_mul(&u1)?.try_div(&norm.where_(&norm_nz, &one)?)?;
+            let tau = tau.try_unsqueeze(-1)?.try_unsqueeze(-1)?; // [..,1,1]
+            let tau = tau.where_(&norm_nz.try_unsqueeze(-1)?.try_unsqueeze(-1)?, &zero)?;
+
+            // R[i:, :] -= (w·tau) @ (wᵀ @ R[i:, :])
+            let rblk = r.getitem(s![Ellipsis, i..mi, ..])?; // [.., m-i, n]
+            let inner = w.try_transpose(-2, -1)?.matmul(&rblk)?; // [..,1,n]
+            let rupd = w.try_mul(&tau)?.matmul(&inner)?; // [.., m-i, n]
+            r = r.set(s![Ellipsis, i..mi, ..], &rblk.try_sub(&rupd)?)?;
+
+            // Q[:, i:] -= (Q[:, i:] @ w) @ (tau·w)ᵀ
+            let qblk = q.getitem(s![Ellipsis, .., i..mi])?; // [.., m, m-i]
+            let qw = qblk.matmul(&w)?; // [.., m, 1]
+            let qupd = qw.matmul(&tau.try_mul(&w)?.try_transpose(-2, -1)?)?; // [.., m, m-i]
+            q = q.set(s![Ellipsis, .., i..mi], &qblk.try_sub(&qupd)?)?;
+        }
+        Ok((q, r))
+    }
+
+    /// Validate a batched square matrix and return (concrete dims, n, float dtype).
+    fn square_setup(&self, op: &str) -> Result<(Vec<usize>, usize, DType)> {
+        let shape = self.shape()?;
+        let ndim = shape.len();
+        snafu::ensure!(
+            ndim >= 2,
+            crate::error::ShapeMismatchSnafu {
+                context: op.to_string(),
+                expected: "≥2-D".to_string(),
+                actual: format!("{ndim}-D")
+            }
+        );
+        let to_dim =
+            |d: usize| shape[d].as_const().ok_or_else(|| Error::SymbolicShapeUnsupported { operation: op.to_string() });
+        let (m, n) = (to_dim(ndim - 2)?, to_dim(ndim - 1)?);
+        snafu::ensure!(
+            m == n,
+            crate::error::ShapeMismatchSnafu {
+                context: op.to_string(),
+                expected: "square last two dims".to_string(),
+                actual: format!("[{m}, {n}]")
+            }
+        );
+        let dims: Vec<usize> = shape.iter().map(|s| s.as_const().unwrap()).collect();
+        let dtype = self.uop().dtype();
+        let float_dt = if dtype.is_float() { dtype } else { DType::Float32 };
+        Ok((dims, n, float_dt))
+    }
 }
 
 /// Shrink only the last two dimensions of a tensor, preserving batch dims.
@@ -505,4 +639,24 @@ fn shrink_last2(tensor: &Tensor, ndim: usize, row_range: (isize, isize), col_ran
     ranges.push(row_range);
     ranges.push(col_range);
     tensor.try_shrink(&ranges)
+}
+
+/// Cast to `float_dt` unless already float (used by the decompositions).
+fn to_float(t: &Tensor, float_dt: &DType) -> Result<Tensor> {
+    if t.uop().dtype().is_float() { Ok(t.clone()) } else { t.cast(float_dt.clone()) }
+}
+
+/// A `[batch.., n, n]` identity (the eye broadcast across the leading batch dims).
+fn batched_eye(batch: &[usize], n: usize, dtype: DType) -> Result<Tensor> {
+    let mut e = Tensor::eye(n, n, dtype)?; // [n, n]
+    if batch.is_empty() {
+        return Ok(e);
+    }
+    for _ in 0..batch.len() {
+        e = e.try_unsqueeze(0)?;
+    }
+    let mut target: Vec<isize> = batch.iter().map(|&d| d as isize).collect();
+    target.push(n as isize);
+    target.push(n as isize);
+    e.try_expand(&target)
 }

--- a/tensor/src/nn/rnn.rs
+++ b/tensor/src/nn/rnn.rs
@@ -3,6 +3,7 @@
 use bon::bon;
 
 use crate::error::{NdimExactSnafu, ParamRangeSnafu};
+use crate::s;
 
 use super::*;
 
@@ -83,7 +84,6 @@ impl Tensor {
         let x_shape = x.shape()?;
         let seq_length = x_shape[0].as_const().expect("static seq_length");
         let batch_size = x_shape[1].as_const().expect("static batch_size");
-        let input_size = x_shape[2].as_const().expect("static input_size");
         let num_directions = w.shape()?[0].as_const().expect("static num_directions");
         let dtype = x.uop().dtype();
 
@@ -118,9 +118,7 @@ impl Tensor {
 
         let mut h_list = Vec::with_capacity(seq_length);
         for t in 0..seq_length {
-            let x_t =
-                x.try_shrink([(t as isize, t as isize + 1), (0, batch_size as isize), (0, input_size as isize)])?;
-            let x_t = x_t.try_squeeze(Some(0))?; // [batch, input]
+            let x_t = x.getitem(s![t as i64, .., ..])?; // [batch, input]
 
             let mut gate = x_t.matmul(&wt)?.try_add(&h_t.matmul(&rt)?)?;
             if let Some(ref b) = combined_bias {
@@ -208,7 +206,6 @@ impl Tensor {
         let x_shape = x.shape()?;
         let seq_length = x_shape[0].as_const().expect("static seq_length");
         let batch_size = x_shape[1].as_const().expect("static batch_size");
-        let input_size = x_shape[2].as_const().expect("static input_size");
         let num_directions = w.shape()?[0].as_const().expect("static num_directions");
         let dtype = x.uop().dtype();
 
@@ -256,9 +253,7 @@ impl Tensor {
 
         let mut h_list = Vec::with_capacity(seq_length);
         for t in 0..seq_length {
-            let x_t =
-                x.try_shrink([(t as isize, t as isize + 1), (0, batch_size as isize), (0, input_size as isize)])?;
-            let x_t = x_t.try_squeeze(Some(0))?; // [batch, input]
+            let x_t = x.getitem(s![t as i64, .., ..])?; // [batch, input]
 
             // z, r gates: combined matmul
             let mut gates = x_t.matmul(&gates_w)?.try_add(&h_t.matmul(&gates_r)?)?;
@@ -377,7 +372,6 @@ impl Tensor {
         let x_shape = x.shape()?;
         let seq_length = x_shape[0].as_const().expect("static seq_length");
         let batch_size = x_shape[1].as_const().expect("static batch_size");
-        let input_size = x_shape[2].as_const().expect("static input_size");
         let num_directions = w.shape()?[0].as_const().expect("static num_directions");
         let dtype = x.uop().dtype();
 
@@ -428,9 +422,7 @@ impl Tensor {
 
         let mut h_list = Vec::with_capacity(seq_length);
         for t in 0..seq_length {
-            let x_t =
-                x.try_shrink([(t as isize, t as isize + 1), (0, batch_size as isize), (0, input_size as isize)])?;
-            let x_t = x_t.try_squeeze(Some(0))?; // [batch, input]
+            let x_t = x.getitem(s![t as i64, .., ..])?; // [batch, input]
 
             // gates = X_t @ W^T + H_{t-1} @ R^T + bias
             let mut gates = x_t.matmul(&wt)?.try_add(&h_t.matmul(&rt)?)?;

--- a/tensor/src/test/unit/einsum.rs
+++ b/tensor/src/test/unit/einsum.rs
@@ -26,6 +26,20 @@ crate::codegen_tests! {
         assert!((result.as_vec::<f32>().unwrap()[0] - 5.0).abs() < 1e-5);
     }
 
+    // ndim > 2 repeated-index diagonal — exercises the `getitem(s![Ellipsis, 0])`
+    // branch (the 2D trace above takes the flatten+stride path instead).
+    fn test_einsum_batched_diagonal(config) {
+        let a = Tensor::from_ndarray(&array![
+            [[1.0f32, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            [[10.0, 11.0, 12.0], [13.0, 14.0, 15.0], [16.0, 17.0, 18.0]]
+        ]); // [2, 3, 3]
+        let mut result = Tensor::einsum("bii->bi", &[&a]).unwrap();
+        result.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&result), vec![2, 3]);
+        // per-batch diagonals: [1,5,9] and [10,14,18]
+        assert_eq!(result.as_vec::<f32>().unwrap(), vec![1.0, 5.0, 9.0, 10.0, 14.0, 18.0]);
+    }
+
     fn test_einsum_transpose(config) {
         let a = Tensor::from_ndarray(&array![[1.0f32, 2.0, 3.0], [4.0, 5.0, 6.0]]);
         let mut result = Tensor::einsum("ij->ji", &[&a]).unwrap();

--- a/tensor/src/test/unit/index.rs
+++ b/tensor/src/test/unit/index.rs
@@ -1,0 +1,265 @@
+//! Unit tests for the ndarray-style indexing layer (`s!` + `getitem`/`set`).
+
+use crate::s;
+use crate::*;
+use ndarray::array;
+use svod_ir::SInt;
+
+fn get_shape(t: &Tensor) -> Vec<usize> {
+    t.uop().shape().unwrap().unwrap().iter().map(|s| s.as_const().unwrap()).collect()
+}
+
+crate::codegen_tests! {
+    // ---- basic getitem ----
+
+    fn test_getitem_range(config) {
+        let t = Tensor::from_slice([0f32, 1., 2., 3., 4., 5.]).try_reshape([2, 3]).unwrap();
+        let mut r = t.getitem(s![1..2, ..]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![1, 3]);
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![3., 4., 5.]);
+    }
+
+    fn test_getitem_int_collapse(config) {
+        let t = Tensor::from_slice([0f32, 1., 2., 3., 4., 5.]).try_reshape([2, 3]).unwrap();
+        let mut r = t.getitem(s![1, ..]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![3]);
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![3., 4., 5.]);
+    }
+
+    fn test_getitem_multi_axis(config) {
+        let t = Tensor::from_slice((0..12).map(|x| x as f32).collect::<Vec<_>>())
+            .try_reshape([3, 4]).unwrap();
+        let mut r = t.getitem(s![1..3, 1..3]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![2, 2]);
+        // rows 1,2 cols 1,2 → [[5,6],[9,10]]
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![5., 6., 9., 10.]);
+    }
+
+    fn test_getitem_step(config) {
+        let t = Tensor::from_slice([0f32, 1., 2., 3., 4., 5.]);
+        let mut r = t.getitem(s![0..6;2]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![3]);
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![0., 2., 4.]);
+    }
+
+    fn test_getitem_reverse(config) {
+        let t = Tensor::from_slice([0f32, 1., 2., 3.]);
+        let mut r = t.getitem(s![..;-1]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![3., 2., 1., 0.]);
+    }
+
+    fn test_getitem_neg_index(config) {
+        let t = Tensor::from_slice([0f32, 1., 2., 3.]);
+        let mut r = t.getitem(s![-1]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![3.]);
+    }
+
+    fn test_getitem_ellipsis(config) {
+        let t = Tensor::from_slice([0f32, 1., 2., 3., 4., 5.]).try_reshape([2, 3]).unwrap();
+        let mut r = t.getitem(s![Ellipsis, 0]).unwrap().contiguous(); // first column
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![2]);
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![0., 3.]);
+    }
+
+    fn test_getitem_newaxis(config) {
+        let t = Tensor::from_slice([1f32, 2., 3.]);
+        let mut r = t.getitem(s![NewAxis, ..]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![1, 3]);
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![1., 2., 3.]);
+    }
+
+    // ---- advanced (fancy) getitem ----
+
+    fn test_getitem_single_axis_fancy(config) {
+        // s![.., heads] must equal index_select(1, heads) value-for-value.
+        let data = Tensor::from_ndarray(&array![
+            [1.0f32, 2., 3., 4.],
+            [5., 6., 7., 8.]
+        ]); // [2, 4]
+        let heads = vec![0usize, 2, 3];
+
+        let mut got = data.getitem(s![.., heads.clone()]).unwrap().contiguous();
+        got.realize_with(&config).unwrap();
+
+        let head_t = Tensor::from_slice([0i64, 2, 3]);
+        let mut want = data.index_select(1, &head_t).unwrap().contiguous();
+        want.realize_with(&config).unwrap();
+
+        assert_eq!(get_shape(&got), vec![2, 3]);
+        assert_eq!(got.as_vec::<f32>().unwrap(), want.as_vec::<f32>().unwrap());
+    }
+
+    fn test_getitem_multi_axis_fancy(config) {
+        // Two adjacent fancy axes broadcast together → equivalent to gather.
+        let data = Tensor::from_ndarray(&array![
+            [10.0f32, 11., 12.],
+            [20., 21., 22.],
+            [30., 31., 32.]
+        ]); // [3, 3]
+        let rows = Tensor::from_slice([0i64, 2]);
+        let cols = Tensor::from_slice([1i64, 0]);
+
+        let mut got = data.getitem(s![rows.clone(), cols.clone()]).unwrap().contiguous();
+        got.realize_with(&config).unwrap();
+        // diagonal-style pick: (0,1)=11, (2,0)=30
+        assert_eq!(get_shape(&got), vec![2]);
+        assert_eq!(got.as_vec::<f32>().unwrap(), vec![11., 30.]);
+    }
+
+    // Regression: two fancy axes at a NON-leading position (d0=1). Previously errored
+    // in gather_advanced (try_expand rank mismatch). out[a,k] = t[a, rows[k], cols[k]].
+    fn test_getitem_fancy_nonleading_axes(config) {
+        let t = Tensor::from_slice((0..24).map(|x| x as f32).collect::<Vec<_>>())
+            .try_reshape([2, 3, 4]).unwrap(); // t[a,i,j] = 12a + 4i + j
+        let rows = vec![0i64, 2];
+        let cols = vec![1i64, 3];
+        let mut r = t.getitem(s![.., rows, cols]).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![2, 2]);
+        // a=0: t[0,0,1]=1, t[0,2,3]=11 ; a=1: t[1,0,1]=13, t[1,2,3]=23
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![1.0, 11.0, 13.0, 23.0]);
+    }
+
+    // ---- symbolic-bound getitem (the JIT batch path) ----
+
+    fn test_getitem_symbolic_batch(config) {
+        // getitem with a symbolic batch bound must be identical to a hand-written
+        // try_shrink (it MUST route through try_shrink — slice_with would panic).
+        let data = Tensor::from_ndarray(&array![
+            [[1.0f32, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0], [13.0, 14.0], [15.0, 16.0]],
+            [[17.0, 18.0], [19.0, 20.0], [21.0, 22.0], [23.0, 24.0]]
+        ]); // [3, 4, 2]
+
+        let b = Variable::new("gisb", 1, 3).bind(3).unwrap();
+        let mut manual =
+            data.try_shrink([Some((SInt::Const(0), b.as_sint())), None, None]).unwrap().contiguous();
+        manual.realize_with(&config).unwrap();
+        let want: Vec<f32> = manual.array_view::<f32>().unwrap().iter().copied().collect();
+
+        let mut got = data.getitem(s![Idx::sint(SInt::Const(0), b.as_sint()), .., ..]).unwrap().contiguous();
+        got.realize_with(&config).unwrap();
+        let got_flat: Vec<f32> = got.array_view::<f32>().unwrap().iter().copied().collect();
+
+        assert_eq!(got_flat, want);
+    }
+
+    // ---- set (functional setitem) ----
+
+    fn test_set_basic_region(config) {
+        let t = Tensor::from_slice((0..12).map(|x| x as f32).collect::<Vec<_>>())
+            .try_reshape([3, 4]).unwrap();
+        let block = Tensor::from_slice([100f32, 101., 102., 103.]).try_reshape([1, 4]).unwrap();
+        let mut r = t.set(s![1..2, ..], &block).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(get_shape(&r), vec![3, 4]);
+        assert_eq!(
+            r.as_vec::<f32>().unwrap(),
+            vec![0., 1., 2., 3., 100., 101., 102., 103., 8., 9., 10., 11.]
+        );
+    }
+
+    fn test_set_int_axis(config) {
+        let t = Tensor::from_slice((0..6).map(|x| x as f32).collect::<Vec<_>>())
+            .try_reshape([2, 3]).unwrap();
+        let row = Tensor::from_slice([7f32, 8., 9.]);
+        let mut r = t.set(s![0, ..], &row).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![7., 8., 9., 3., 4., 5.]);
+    }
+
+    // Regression: set a 0-D scalar into an integer-collapsed, non-leading axis.
+    // Previously panicked (unsqueeze of a 0-D value at axis 1 → AxisOutOfRange).
+    fn test_set_scalar_into_collapsed_column(config) {
+        let t = Tensor::from_slice([1.0f32, 2.0, 3.0, 4.0]).try_reshape([2, 2]).unwrap();
+        let scalar = Tensor::const_(9.0, svod_dtype::DType::Float32);
+        let mut r = t.set(s![.., 0], &scalar).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![9.0, 2.0, 9.0, 4.0]);
+    }
+
+    fn test_set_scalar_broadcast(config) {
+        let t = Tensor::from_slice((0..6).map(|x| x as f32).collect::<Vec<_>>())
+            .try_reshape([2, 3]).unwrap();
+        let zero = Tensor::from_slice([0f32]); // broadcast into the column
+        let mut r = t.set(s![.., 1..2], &zero).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![0., 0., 2., 3., 0., 5.]);
+    }
+
+    fn test_set_advanced_last_writer_wins(config) {
+        // Single-axis fancy set with a duplicate index → last value wins (scatter).
+        let t = Tensor::from_slice([0f32, 0., 0., 0.]).try_reshape([1, 4]).unwrap();
+        let idx = Tensor::from_slice([1i64, 1, 3]); // index 1 written twice
+        let vals = Tensor::from_slice([5f32, 9., 7.]).try_reshape([1, 3]).unwrap();
+        let mut r = t.set(s![.., idx.clone()], &vals).unwrap().contiguous();
+        r.realize_with(&config).unwrap();
+        // position 1 gets the LAST write (9), position 3 gets 7.
+        assert_eq!(r.as_vec::<f32>().unwrap(), vec![0., 9., 0., 7.]);
+    }
+
+    // ---- proptest: getitem matches try_shrink over random contiguous ranges ----
+
+    fn test_getitem_matches_shrink_proptest(config, a in 0usize..6, len in 0usize..6) {
+        let n = 6;
+        let b = (a + len).min(n);
+        let data: Vec<f32> = (0..n).map(|x| x as f32).collect();
+        let t = Tensor::from_slice(data);
+
+        let mut viafn = t.getitem(s![a as i64 .. b as i64]).unwrap().contiguous();
+        viafn.realize_with(&config).unwrap();
+        let mut shrink = t.try_shrink([(a as isize, b as isize)]).unwrap().contiguous();
+        shrink.realize_with(&config).unwrap();
+
+        assert_eq!(viafn.as_vec::<f32>().unwrap(), shrink.as_vec::<f32>().unwrap());
+    }
+}
+
+// =========================================================================
+// Shape / error tests (no codegen)
+// =========================================================================
+
+#[test]
+fn test_getitem_too_many_indices_errors() {
+    let t = Tensor::from_slice([1f32, 2., 3., 4.]).try_reshape([2, 2]).unwrap();
+    assert!(t.getitem(s![0, 0, 0]).is_err());
+}
+
+#[test]
+fn test_getitem_double_ellipsis_errors() {
+    let t = Tensor::from_slice([1f32, 2., 3., 4.]).try_reshape([2, 2]).unwrap();
+    assert!(t.getitem(s![Ellipsis, Ellipsis]).is_err());
+}
+
+#[test]
+fn test_getitem_oob_index_errors() {
+    let t = Tensor::from_slice([1f32, 2., 3.]);
+    assert!(t.getitem(s![5]).is_err());
+}
+
+#[test]
+fn test_set_rejects_fancy_multi_axis() {
+    let t = Tensor::from_slice([1f32, 2., 3., 4.]).try_reshape([2, 2]).unwrap();
+    let r = Tensor::from_slice([0i64, 1]);
+    let c = Tensor::from_slice([0i64, 1]);
+    let v = Tensor::from_slice([9f32, 9.]);
+    assert!(t.set(s![r, c], &v).is_err());
+}
+
+// A range/slice on another axis alongside a fancy set must error (not silently
+// drop the region outside the range).
+#[test]
+fn test_set_rejects_range_plus_fancy() {
+    let t = Tensor::from_slice([1f32, 2., 3., 4., 5., 6.]).try_reshape([2, 3]).unwrap();
+    let idx = Tensor::from_slice([0i64, 2]);
+    let v = Tensor::from_slice([7f32, 8.]);
+    assert!(t.set(s![0..1, idx], &v).is_err());
+}

--- a/tensor/src/test/unit/math.rs
+++ b/tensor/src/test/unit/math.rs
@@ -198,3 +198,55 @@ crate::codegen_tests! {
         assert_close_f32(&t.shrink(0.0, 0.5).unwrap().realize_with_and(&config).as_vec::<f32>().unwrap(), &[-2.0, 0.0, 0.0, 0.0, 2.0], 1e-4);
     }
 }
+
+// =========================================================================
+// Decompositions (cholesky / eigh) — built on the s!/getitem/set indexing API.
+// =========================================================================
+crate::codegen_tests! {
+    fn test_cholesky_2x2(config) {
+        // A = [[4,2],[2,3]] → L = [[2,0],[1,√2]]
+        let a = Tensor::from_slice([4.0f32, 2.0, 2.0, 3.0]).try_reshape([2, 2]).unwrap();
+        let mut l = a.cholesky().unwrap();
+        assert_close_f32(
+            &l.realize_with_and(&config).as_vec::<f32>().unwrap(),
+            &[2.0, 0.0, 1.0, std::f32::consts::SQRT_2],
+            1e-4,
+        );
+    }
+
+    fn test_cholesky_3x3_reconstruct(config) {
+        // SPD matrix; verify L @ Lᵀ ≈ A.
+        let vals = [4.0f32, 2.0, 2.0, 2.0, 5.0, 3.0, 2.0, 3.0, 6.0];
+        let a = Tensor::from_slice(vals).try_reshape([3, 3]).unwrap();
+        let l = a.cholesky().unwrap();
+        let mut recon = l.matmul(&l.try_transpose(-2, -1).unwrap()).unwrap();
+        assert_close_f32(&recon.realize_with_and(&config).as_vec::<f32>().unwrap(), &vals, 1e-4);
+    }
+
+    fn test_qr_3x3_reconstruct(config) {
+        // Verify Q @ R ≈ A and Qᵀ Q ≈ I (Q orthonormal).
+        let vals = [12.0f32, -51.0, 4.0, 6.0, 167.0, -68.0, -4.0, 24.0, -41.0];
+        let a = Tensor::from_slice(vals).try_reshape([3, 3]).unwrap();
+        let (q, r) = a.qr().unwrap();
+        let mut recon = q.matmul(&r).unwrap();
+        assert_close_f32(&recon.realize_with_and(&config).as_vec::<f32>().unwrap(), &vals, 1e-3);
+        let mut qtq = q.try_transpose(-2, -1).unwrap().matmul(&q).unwrap();
+        assert_close_f32(
+            &qtq.realize_with_and(&config).as_vec::<f32>().unwrap(),
+            &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            1e-4,
+        );
+    }
+
+    // Regression: batched (ndim>2) qr previously panicked in `w.set(s![Ellipsis,0,0],..)`.
+    fn test_qr_batched_reconstruct(config) {
+        let vals = [
+            12.0f32, -51.0, 4.0, 6.0, 167.0, -68.0, -4.0, 24.0, -41.0, // batch 0
+            2.0, 0.0, 1.0, 0.0, 3.0, 0.0, 1.0, 0.0, 2.0, // batch 1
+        ];
+        let a = Tensor::from_slice(vals).try_reshape([2, 3, 3]).unwrap();
+        let (q, r) = a.qr().unwrap();
+        let mut recon = q.matmul(&r).unwrap();
+        assert_close_f32(&recon.realize_with_and(&config).as_vec::<f32>().unwrap(), &vals, 1e-3);
+    }
+}

--- a/tensor/src/test/unit/mod.rs
+++ b/tensor/src/test/unit/mod.rs
@@ -11,6 +11,7 @@ pub mod cumsum;
 pub mod custom_kernel;
 pub mod data;
 pub mod einsum;
+pub mod index;
 pub mod indexing;
 pub mod math;
 pub mod matmul;


### PR DESCRIPTION
  Adds an ndarray-style indexing layer to svod-tensor (`s!` + `getitem`/`set`), builds
  `qr`/`cholesky` on it, fixes a rangeify buffer-reuse bug surfaced along the way, and
  moves a few call-sites onto the new API.

  ## What's added
  - **Indexing — `tensor/src/index.rs`** — `s!` → `IndexSpec`; `Tensor::getitem` / `set`:
    - basic: `..`, `a..b`/`a..`/`..b`, `a..b;step`, integer-collapse, `Ellipsis`,
      `NewAxis`, symbolic-bound `Idx::sint` (JIT batch dims);
    - advanced: single-axis fancy → `index_select`, multi-axis → one-hot/where/sum
      gather (numpy axis order);
    - `set` is functional (returns a new tensor).
    - Plain/symbolic shrinks are graph-identical to a hand-written `try_shrink`; only
      steps/reverse use `slice_with`. One `parse_spec` pass drives all paths.
  - **Decompositions — `tensor/src/math.rs`** — `qr` (Householder), `cholesky`
    (Cholesky–Banachiewicz): batched, linear-graph, scale to moderate n.

  ## Fix
  - **`schedule` rangeify buffer reuse** — `map_after_like_node` no longer asserts one
    AFTER per buffer; the level-interval planner reuses buffers across non-overlapping
    lifetimes, so a kernel cone can hold two AFTERs for one buffer (last-wins, matching
    tinygrad; `fix_assign` orders them). Previously panicked (debug) / `BufferNotFound`
    (release) on deep graphs with reused buffers.