### PR TITLE
device+dtype+schedule/amd: RDNA2 (gfx10) support

### DIFF
--- a/device/src/amd/allocator.rs
+++ b/device/src/amd/allocator.rs
@@ -56,6 +56,12 @@ impl AmdAllocator {
     pub fn alloc_uncached(&self, size: usize) -> Result<RawBuffer> {
         do_alloc(&self.dev, size, AllocKind::UncachedGtt, /*cpu_accessible=*/ true, /*zero_init=*/ true)
     }
+
+    /// Allocate cached-coherent GTT (ROCr's queue control / CWSR set —
+    /// [`AllocKind::CoherentGtt`]) for the rptr/wptr GART page and ctx-save.
+    pub fn alloc_coherent(&self, size: usize) -> Result<RawBuffer> {
+        do_alloc(&self.dev, size, AllocKind::CoherentGtt, /*cpu_accessible=*/ true, /*zero_init=*/ true)
+    }
 }
 
 impl std::fmt::Debug for AmdAllocator {
@@ -241,7 +247,7 @@ fn do_alloc(
     // VRAM data/code/kernarg buffer or GTT control memory.
     let tag = match kind {
         AllocKind::DeviceVram => AllocTag::Vram,
-        AllocKind::UncachedGtt => AllocTag::Gtt,
+        AllocKind::UncachedGtt | AllocKind::CoherentGtt => AllocTag::Gtt,
     };
     let r = dev.core().iface().alloc_raw(size, kind, tag, cpu_accessible, zero_init)?;
     Ok(RawBuffer::AmdDevice {

--- a/device/src/amd/allocator.rs
+++ b/device/src/amd/allocator.rs
@@ -56,15 +56,6 @@ impl AmdAllocator {
     pub fn alloc_uncached(&self, size: usize) -> Result<RawBuffer> {
         do_alloc(&self.dev, size, AllocKind::UncachedGtt, /*cpu_accessible=*/ true, /*zero_init=*/ true)
     }
-
-    /// Allocate the queue-descriptor page (`amd_queue_t`) with ROCr's minimal
-    /// non-MES flags: GTT, host-visible, uncached — without the fine-grained
-    /// `COHERENT`/`EXECUTABLE` bits that [`alloc_uncached`] carries. The CP reads
-    /// rptr/wptr from this page; on RDNA2 APUs the extra MTYPE bits make that
-    /// read permission-fault. See [`AllocKind::QueueDescriptor`].
-    pub fn alloc_queue_descriptor(&self, size: usize) -> Result<RawBuffer> {
-        do_alloc(&self.dev, size, AllocKind::QueueDescriptor, /*cpu_accessible=*/ true, /*zero_init=*/ true)
-    }
 }
 
 impl std::fmt::Debug for AmdAllocator {
@@ -88,7 +79,7 @@ impl Allocator for AmdAllocator {
         // device-only buffer pass `zero=false` and SDMA-zero it ourselves below,
         // keeping `zero=true` honored regardless of host visibility.
         let seam_zero = zero && cpu_access;
-        let buf = do_alloc(&self.dev, size, AllocKind::DeviceVram { executable: true }, cpu_access, seam_zero)?;
+        let buf = do_alloc(&self.dev, size, AllocKind::DeviceVram, cpu_access, seam_zero)?;
         if zero && let RawBuffer::AmdDevice { host_ptr: None, gpu_addr, size: bsize, .. } = &buf {
             self.copy_queue()?.device_zero(*gpu_addr, *bsize)?;
         }
@@ -249,8 +240,8 @@ fn do_alloc(
     // site (`device::alloc_scratch`); everything routed through here is either a
     // VRAM data/code/kernarg buffer or GTT control memory.
     let tag = match kind {
-        AllocKind::DeviceVram { .. } => AllocTag::Vram,
-        AllocKind::UncachedGtt | AllocKind::QueueDescriptor => AllocTag::Gtt,
+        AllocKind::DeviceVram => AllocTag::Vram,
+        AllocKind::UncachedGtt => AllocTag::Gtt,
     };
     let r = dev.core().iface().alloc_raw(size, kind, tag, cpu_accessible, zero_init)?;
     Ok(RawBuffer::AmdDevice {

--- a/device/src/amd/allocator.rs
+++ b/device/src/amd/allocator.rs
@@ -56,6 +56,15 @@ impl AmdAllocator {
     pub fn alloc_uncached(&self, size: usize) -> Result<RawBuffer> {
         do_alloc(&self.dev, size, AllocKind::UncachedGtt, /*cpu_accessible=*/ true, /*zero_init=*/ true)
     }
+
+    /// Allocate the queue-descriptor page (`amd_queue_t`) with ROCr's minimal
+    /// non-MES flags: GTT, host-visible, uncached — without the fine-grained
+    /// `COHERENT`/`EXECUTABLE` bits that [`alloc_uncached`] carries. The CP reads
+    /// rptr/wptr from this page; on RDNA2 APUs the extra MTYPE bits make that
+    /// read permission-fault. See [`AllocKind::QueueDescriptor`].
+    pub fn alloc_queue_descriptor(&self, size: usize) -> Result<RawBuffer> {
+        do_alloc(&self.dev, size, AllocKind::QueueDescriptor, /*cpu_accessible=*/ true, /*zero_init=*/ true)
+    }
 }
 
 impl std::fmt::Debug for AmdAllocator {
@@ -241,7 +250,7 @@ fn do_alloc(
     // VRAM data/code/kernarg buffer or GTT control memory.
     let tag = match kind {
         AllocKind::DeviceVram { .. } => AllocTag::Vram,
-        AllocKind::UncachedGtt => AllocTag::Gtt,
+        AllocKind::UncachedGtt | AllocKind::QueueDescriptor => AllocTag::Gtt,
     };
     let r = dev.core().iface().alloc_raw(size, kind, tag, cpu_accessible, zero_init)?;
     Ok(RawBuffer::AmdDevice {

--- a/device/src/amd/connector.rs
+++ b/device/src/amd/connector.rs
@@ -120,6 +120,7 @@ impl PoolQueue {
                 tmpring_size,
                 handle: scratch_handle,
                 size: scratch_size,
+                aql_desc,
             }),
             pm4_counter,
             dispatch_lock: Mutex::new(()),
@@ -192,6 +193,13 @@ impl PoolQueue {
     /// Packed `COMPUTE_TMPRING_SIZE` for the current scratch buffer.
     pub fn tmpring_size(&self) -> u32 {
         self.scratch_state.lock().tmpring_size
+    }
+
+    /// Atomic snapshot of the scratch state — one lock window, so the PM4
+    /// dispatch's VA, tmpring, and SRD words all describe the same buffer
+    /// even when a concurrent grow swaps it.
+    pub(crate) fn scratch_snapshot(&self) -> crate::amd::device::ScratchState {
+        *self.scratch_state.lock()
     }
 
     /// Drain ALL submitted GPU work on this queue (every owner's). Blocks until
@@ -334,7 +342,14 @@ impl PoolQueue {
             let mut state = self.scratch_state.lock();
             if rounded > state.size_per_thread {
                 let old = (state.gpu_va, state.size, state.handle);
-                *state = ScratchState { gpu_va: va, size_per_thread: rounded, tmpring_size: tmpring, handle, size };
+                *state = ScratchState {
+                    gpu_va: va,
+                    size_per_thread: rounded,
+                    tmpring_size: tmpring,
+                    handle,
+                    size,
+                    aql_desc,
+                };
                 Some(old)
             } else {
                 None

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -436,6 +436,20 @@ impl AmdDeviceCore {
     pub fn install_signal_pool(&self, pool: Arc<crate::amd::signal::SignalPool>) {
         let _ = self.signal_pool.set(pool);
     }
+
+    /// Seed the queue pool with its first compute queue. gfx10.3 (RDNA2) HWS
+    /// faults reading an SDMA queue's GART descriptor when the process run-list
+    /// holds no compute queue, so the factory calls this BEFORE creating the
+    /// SDMA copy queue on RDNA2. Pool queues live for the device lifetime, so
+    /// the compute-first run-list invariant holds permanently; the seeded queue
+    /// is a normal pool member that `assign_owner` hands out as usual.
+    pub fn seed_compute_queue(self: &Arc<Self>, allocator: &crate::amd::AmdAllocator) -> Result<()> {
+        let mut queues = self.queue_pool.lock();
+        if queues.is_empty() {
+            queues.push(crate::amd::connector::PoolQueue::new_with_resources(Arc::clone(self), allocator)?);
+        }
+        Ok(())
+    }
 }
 
 impl AmdDeviceCore {
@@ -614,17 +628,6 @@ fn alloc_event_page(kfd_fd: &OwnedFd, drm_fd: &OwnedFd, node: &AmdNode) -> Resul
         return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_MAP_MEMORY_TO_GPU(event page)", errno: e as i32 });
     }
 
-    // Diagnostic: the event page is allocated outside `alloc_raw`, so it is
-    // absent from both the VA registry and the "AmdAllocator alloc done" logs.
-    // Log its range explicitly so a fault VA can be resolved back to it.
-    tracing::debug!(
-        target: "svod_device::amd::device",
-        base = va as u64,
-        size,
-        end = va as u64 + size as u64,
-        "event page allocated (GPU-mapped, COHERENT|EXECUTABLE GTT)"
-    );
-
     Ok((va as u64, size, handle))
 }
 
@@ -681,12 +684,11 @@ pub(crate) fn alloc_scratch(
         (size_per_thread as usize) * (LANES_PER_WAVE as usize) * (max_slots as usize) * (cu_slots as usize);
     let total = (size_per_xcc * xccs as usize).next_multiple_of(PAGE);
 
-    // KFD alloc as plain VRAM (GPU-only; no host access needed — the GPU writes
-    // register spills here and reads them back). Plain VRAM = no EXECUTABLE, no
-    // PUBLIC (`cpu_access=false` keeps PUBLIC off); see `AllocKind::DeviceVram`.
+    // KFD alloc as plain VRAM (GPU-only; `cpu_access=false` keeps PUBLIC off);
+    // see `AllocKind::DeviceVram`.
     let r = iface.alloc_raw(
         total,
-        crate::amd::iface::AllocKind::DeviceVram { executable: false },
+        crate::amd::iface::AllocKind::DeviceVram,
         crate::amd::va_registry::AllocTag::Scratch,
         /*cpu_access=*/ false,
         /*zero=*/ false,

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -245,7 +245,8 @@ impl AmdDevice {
         let arch = AmdArch::from_gfx_target_version(node.gfx_target_version).ok_or_else(|| Error::AmdAllocFailed {
             reason: format!(
                 "unsupported gfx target {} (decoded major.minor.step = {}.{}.{}); supported families: \
-                 CDNA gfx942/950, RDNA3 gfx1100/1101/1102/1151, RDNA4 gfx1200/1201",
+                 CDNA gfx942/950, RDNA2 gfx1030/1031/1032/1034, RDNA3 gfx1100/1101/1102/1151, \
+                 RDNA4 gfx1200/1201",
                 node.gfx_target_version,
                 node.gfx_target_version / 10_000,
                 (node.gfx_target_version / 100) % 100,
@@ -632,8 +633,10 @@ pub(crate) fn alloc_scratch(
 ) -> Result<(u64, usize, u32, u32, u64, AqlScratchDesc)> {
     const LANES_PER_WAVE: u32 = 64;
     const PAGE: usize = 0x1000;
-    // gfx9 (CDNA) scratch is 1024-byte aligned; gfx11/12 (RDNA) use 256.
-    let mem_alignment_size: u32 = if arch.is_cdna() { 1024 } else { 256 };
+    // Pre-gfx11 (CDNA gfx9 + RDNA2 gfx10) scratch is 1024-byte aligned; gfx11/12
+    // (RDNA3/4) use 256 (tinygrad ops_amd `_ensure_has_local_memory`:
+    // `256 if target >= (11,0,0) else 1024`).
+    let mem_alignment_size: u32 = if arch.is_cdna() || arch.is_rdna2() { 1024 } else { 256 };
 
     let xccs = node.num_xcc.max(1);
     let simd_per_cu = node.simd_per_cu.max(1);
@@ -669,10 +672,12 @@ pub(crate) fn alloc_scratch(
     let total = r.size;
     let handle = r.handle;
 
-    // gfx9 divides scratch evenly across SEs (1); gfx11/12 divide by se_cnt.
+    // Pre-gfx11 (CDNA gfx9 + RDNA2 gfx10) divides scratch evenly across SEs (1);
+    // gfx11/12 wavesize is per-SE, so divide by se_cnt (tinygrad ops_amd:
+    // `wave_scratch_len * se_cnt if target >= (11,0,0) else wave_scratch_len`).
     let wave_scratch = (LANES_PER_WAVE * size_per_thread).div_ceil(mem_alignment_size);
     let max_scratch_waves = cu_slots * max_slots * xccs;
-    let se_div = if arch.is_cdna() { 1 } else { se_cnt };
+    let se_div = if arch.is_cdna() || arch.is_rdna2() { 1 } else { se_cnt };
     let num_waves = ((size_per_xcc as u32) / (wave_scratch * mem_alignment_size)) / se_div;
     // COMPUTE_TMPRING_SIZE.WAVES must be a multiple of the per-XCC shader-engine
     // count (amd_aql_queue.cpp asserts `WAVES % (banks/xcc) == 0`); round down to
@@ -692,9 +697,11 @@ pub(crate) fn alloc_scratch(
 }
 
 /// Pack `COMPUTE_TMPRING_SIZE`: WAVES in bits 0..12, WAVESIZE at bit 12 with an
-/// arch-specific field width — gfx9 13b, gfx11 15b, gfx12 18b.
+/// arch-specific field width — gfx9/gfx10 13b, gfx11 15b, gfx12 18b (per the
+/// `COMPUTE_TMPRING_SIZE__WAVESIZE_MASK` asic_reg headers: gc_9_x/gc_10_3 =
+/// 0x01FFF000, gc_11_0 = 0x07FFF000, gc_12_0 = 0x3FFFF000).
 pub(crate) fn pack_tmpring(waves: u32, wave_scratch: u32, arch: &AmdArch) -> u32 {
-    let wavesize_mask: u32 = if arch.is_cdna() {
+    let wavesize_mask: u32 = if arch.is_cdna() || arch.is_rdna2() {
         0x1FFF
     } else if arch.is_rdna4() {
         0x3FFFF

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -633,9 +633,10 @@ pub(crate) fn alloc_scratch(
 ) -> Result<(u64, usize, u32, u32, u64, AqlScratchDesc)> {
     const LANES_PER_WAVE: u32 = 64;
     const PAGE: usize = 0x1000;
-    // Pre-gfx11 (CDNA gfx9 + RDNA2 gfx10) scratch is 1024-byte aligned; gfx11/12
-    // (RDNA3/4) use 256 (tinygrad ops_amd `_ensure_has_local_memory`:
-    // `256 if target >= (11,0,0) else 1024`).
+    // gfx9 (CDNA) AND gfx10 (RDNA2) scratch is 1024-byte aligned; only gfx11+
+    // (RDNA3/4) use 256. Authority: ROCr amd_aql_queue.cpp `mem_alignment_size =
+    // (major >= 11) ? 256 : 1024`. (new tinygrad's `256 if target[0]!=9` is wrong
+    // for gfx10 — verified against the vendored production driver.)
     let mem_alignment_size: u32 = if arch.is_cdna() || arch.is_rdna2() { 1024 } else { 256 };
 
     let xccs = node.num_xcc.max(1);
@@ -672,9 +673,11 @@ pub(crate) fn alloc_scratch(
     let total = r.size;
     let handle = r.handle;
 
-    // Pre-gfx11 (CDNA gfx9 + RDNA2 gfx10) divides scratch evenly across SEs (1);
-    // gfx11/12 wavesize is per-SE, so divide by se_cnt (tinygrad ops_amd:
-    // `wave_scratch_len * se_cnt if target >= (11,0,0) else wave_scratch_len`).
+    // gfx9 (CDNA) AND gfx10 (RDNA2) compute total waves (no per-SE division);
+    // only gfx11+ divides by se_cnt. Authority: ROCr amd_aql_queue.cpp — the base
+    // FillComputeTmpRingSize (gfx9/gfx10) does NOT divide by NumShaderBanks,
+    // whereas FillComputeTmpRingSize_Gfx11 adds `num_waves /= NumShaderBanks`
+    // ("for GFX11 we specify number of waves per engine instead of total").
     let wave_scratch = (LANES_PER_WAVE * size_per_thread).div_ceil(mem_alignment_size);
     let max_scratch_waves = cu_slots * max_slots * xccs;
     let se_div = if arch.is_cdna() || arch.is_rdna2() { 1 } else { se_cnt };

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -337,6 +337,17 @@ impl AmdDeviceCore {
                 }
             }
         }
+        // The SDMA copy queue is NOT in the connector registry, but it has its
+        // own timeline of in-flight DMA. Quiesce it too, or an async graph-replay
+        // copy can still be touching a buffer the caller is about to free/read.
+        if let Some(copy) = self.copy_queue()
+            && let Err(e) = copy.drain()
+        {
+            tracing::warn!(?e, "synchronize_all: SDMA copy-queue drain failed; continuing");
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
         // Opportunistic GC of dropped queue entries. The registry is touched
         // here on every host read/free, so dead Weaks don't accumulate.
         self.connectors.lock().retain(|w| w.strong_count() > 0);

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -76,6 +76,10 @@ pub(crate) struct ScratchState {
     /// old buffer when scratch grows.
     pub handle: u64,
     pub size: usize,
+    /// Arch-specific scratch SRD + queue fields. Published into the AQL
+    /// `amd_queue_t` on AQL queues; on PM4 the SRD words feed the user-SGPR
+    /// scratch descriptor prepend.
+    pub aql_desc: AqlScratchDesc,
 }
 
 /// The private-segment (scratch) fields the AQL packet processor reads from the
@@ -101,11 +105,14 @@ pub(crate) struct AqlScratchDesc {
 /// ADD_TID_ENABLE=1, TYPE=SQ_RSRC_BUF(0).
 const SCRATCH_RSRC_WORD3_GFX9: u32 = 0x00EA_4FAC;
 
+/// gfx10 SQ_BUF_RSRC WORD3 for a scratch buffer (ROCr `FillBufRsrcWord3_Gfx10`):
+/// DST_SEL=XYZW (4,5,6,7), FORMAT=BUF_FORMAT_32_UINT(0x14)<<12, INDEX_STRIDE=0
+/// (filled in by CP), ADD_TID_ENABLE=1<<23, RESOURCE_LEVEL=1<<24,
+/// OOB_SELECT=2<<28 (no bounds check in swizzle mode), TYPE=SQ_RSRC_BUF(0).
+const SCRATCH_RSRC_WORD3_GFX10: u32 = 0x2181_4EAC;
+
 impl AqlScratchDesc {
-    /// Build the gfx9 scratch descriptor. `size_per_xcc` goes in NUM_RECORDS
-    /// (WORD2) — the per-XCC slice of the shared backing buffer — and the
-    /// SWIZZLE_ENABLE bit (WORD1 bit 31) enables the per-thread scratch swizzle.
-    pub(crate) fn gfx9(scratch_va: u64, size_per_xcc: usize, tmpring_size: u32, private_segment_size: u32) -> Self {
+    fn build(scratch_va: u64, size_per_xcc: usize, tmpring_size: u32, word3: u32, lane_bytes: u32) -> Self {
         Self {
             backing_va: scratch_va,
             tmpring_size,
@@ -113,10 +120,25 @@ impl AqlScratchDesc {
                 scratch_va as u32,
                 ((scratch_va >> 32) as u32 & 0xFFFF) | 0x8000_0000,
                 size_per_xcc as u32,
-                SCRATCH_RSRC_WORD3_GFX9,
+                word3,
             ],
-            wave64_lane_byte_size: private_segment_size,
+            wave64_lane_byte_size: lane_bytes,
         }
+    }
+
+    /// Build the gfx9 scratch descriptor. `size_per_xcc` goes in NUM_RECORDS
+    /// (WORD2) — the per-XCC slice of the shared backing buffer — and the
+    /// SWIZZLE_ENABLE bit (WORD1 bit 31) enables the per-thread scratch swizzle.
+    pub(crate) fn gfx9(scratch_va: u64, size_per_xcc: usize, tmpring_size: u32, private_segment_size: u32) -> Self {
+        Self::build(scratch_va, size_per_xcc, tmpring_size, SCRATCH_RSRC_WORD3_GFX9, private_segment_size)
+    }
+
+    /// Build the gfx10 (RDNA2 wave32) scratch descriptor. WORD0..2 match gfx9;
+    /// WORD3 uses the gfx10 SRD layout. `lane_bytes` is
+    /// `scratch_wave64_lane_byte_size` = `size_per_thread * lanes_per_wave / 64`
+    /// (ROCr halves the effective per-lane size for wave32 backing).
+    pub(crate) fn gfx10(scratch_va: u64, size_per_xcc: usize, tmpring_size: u32, lane_bytes: u32) -> Self {
+        Self::build(scratch_va, size_per_xcc, tmpring_size, SCRATCH_RSRC_WORD3_GFX10, lane_bytes)
     }
 }
 
@@ -651,8 +673,11 @@ pub(crate) fn alloc_scratch(
     arch: &AmdArch,
     private_segment_size: u32,
 ) -> Result<(u64, usize, u32, u32, u64, AqlScratchDesc)> {
-    const LANES_PER_WAVE: u32 = 64;
     const PAGE: usize = 0x1000;
+    // ROCr sizes scratch from the arch's native wave width (wave32 on RDNA2):
+    // size_per_thread aligns to mem_alignment/lanes, the per-XCC slice is
+    // lanes*slots, and tmpring WAVESIZE = lanes*size_per_thread/alignment.
+    let lanes_per_wave: u32 = arch.wave_size();
     // gfx9 (CDNA) AND gfx10 (RDNA2) scratch is 1024-byte aligned; only gfx11+
     // (RDNA3/4) use 256. Authority: ROCr amd_aql_queue.cpp `mem_alignment_size =
     // (major >= 11) ? 256 : 1024`. (new tinygrad's `256 if target[0]!=9` is wrong
@@ -674,9 +699,9 @@ pub(crate) fn alloc_scratch(
     let cu_slots = cu_cnt.next_multiple_of(se_cnt);
 
     // Round up to the per-lane alignment stride.
-    let size_per_thread = private_segment_size.max(1).next_multiple_of(mem_alignment_size / LANES_PER_WAVE);
+    let size_per_thread = private_segment_size.max(1).next_multiple_of(mem_alignment_size / lanes_per_wave);
     let size_per_xcc =
-        (size_per_thread as usize) * (LANES_PER_WAVE as usize) * (max_slots as usize) * (cu_slots as usize);
+        (size_per_thread as usize) * (lanes_per_wave as usize) * (max_slots as usize) * (cu_slots as usize);
     let total = (size_per_xcc * xccs as usize).next_multiple_of(PAGE);
 
     // KFD alloc as plain VRAM (GPU-only; `cpu_access=false` keeps PUBLIC off);
@@ -697,7 +722,7 @@ pub(crate) fn alloc_scratch(
     // FillComputeTmpRingSize (gfx9/gfx10) does NOT divide by NumShaderBanks,
     // whereas FillComputeTmpRingSize_Gfx11 adds `num_waves /= NumShaderBanks`
     // ("for GFX11 we specify number of waves per engine instead of total").
-    let wave_scratch = (LANES_PER_WAVE * size_per_thread).div_ceil(mem_alignment_size);
+    let wave_scratch = (lanes_per_wave * size_per_thread).div_ceil(mem_alignment_size);
     let max_scratch_waves = cu_slots * max_slots * xccs;
     let se_div = if arch.is_cdna() || arch.is_rdna2() { 1 } else { se_cnt };
     let num_waves = ((size_per_xcc as u32) / (wave_scratch * mem_alignment_size)) / se_div;
@@ -707,10 +732,14 @@ pub(crate) fn alloc_scratch(
     let waves = (num_waves.min(max_scratch_waves) / se_cnt).max(1) * se_cnt;
     let tmpring_size = pack_tmpring(waves, wave_scratch, arch);
 
-    // The AQL descriptor is only consumed on multi-XCC CDNA; non-CDNA arches
-    // dispatch via PM4 and never read it, so leave it zero there.
+    // CDNA consumes the descriptor through the AQL amd_queue_t; RDNA2 consumes
+    // the same words through the PM4 user-SGPR prepend (and the GART descriptor
+    // when AQL is forced). RDNA3/4 don't run this scratch path yet — zero.
     let aql_desc = if arch.is_cdna() {
         AqlScratchDesc::gfx9(va, size_per_xcc, tmpring_size, private_segment_size)
+    } else if arch.is_rdna2() {
+        let lane_bytes = size_per_thread * lanes_per_wave / 64;
+        AqlScratchDesc::gfx10(va, size_per_xcc, tmpring_size, lane_bytes)
     } else {
         AqlScratchDesc::default()
     };

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -603,6 +603,17 @@ fn alloc_event_page(kfd_fd: &OwnedFd, drm_fd: &OwnedFd, node: &AmdNode) -> Resul
         return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_MAP_MEMORY_TO_GPU(event page)", errno: e as i32 });
     }
 
+    // Diagnostic: the event page is allocated outside `alloc_raw`, so it is
+    // absent from both the VA registry and the "AmdAllocator alloc done" logs.
+    // Log its range explicitly so a fault VA can be resolved back to it.
+    tracing::debug!(
+        target: "svod_device::amd::device",
+        base = va as u64,
+        size,
+        end = va as u64 + size as u64,
+        "event page allocated (GPU-mapped, COHERENT|EXECUTABLE GTT)"
+    );
+
     Ok((va as u64, size, handle))
 }
 

--- a/device/src/amd/device.rs
+++ b/device/src/amd/device.rs
@@ -575,16 +575,11 @@ pub(crate) fn ensure_event_page(kfd_fd: &OwnedFd, drm_fd: &OwnedFd, node: &AmdNo
 /// Returns `(va, size, kfd_handle)`. The handle goes into the
 /// `event_page_offset` field of the bind `AMDKFD_IOC_CREATE_EVENT` call.
 fn alloc_event_page(kfd_fd: &OwnedFd, drm_fd: &OwnedFd, node: &AmdNode) -> Result<(u64, usize, u64)> {
-    use libc::{
-        MAP_ANONYMOUS, MAP_FIXED, MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED, PROT_NONE, PROT_READ, PROT_WRITE, mmap,
-        munmap,
-    };
+    use libc::{MAP_FIXED, MAP_SHARED, PROT_READ, PROT_WRITE, mmap, munmap};
     let size: usize = 0x8000;
-    // SAFETY: standard libc::mmap; PROT_NONE reservation.
-    let va = unsafe { mmap(std::ptr::null_mut(), size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0) };
-    if va == libc::MAP_FAILED {
-        return Err(Error::AmdAllocFailed { reason: "event-page VA reservation failed".into() });
-    }
+    // Shared VA reservation path so the SVOD_AMD_LOW_VA bisect gate covers the
+    // event page too.
+    let va = crate::amd::iface::reserve_va(size)?;
     let mut args = kfd::kfd_ioctl_alloc_memory_of_gpu_args {
         va_addr: va as u64,
         size: size as u64,

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -221,7 +221,13 @@ impl KfdIface {
         // compute) depends on; without it, an evicted-but-live BO is never
         // restored and the CP faults NotPresent on it. No TTMP (no CWSR
         // trap-debug); r_debug = 0 (no debugger attached).
-        if kfd_version >= (1, 14) {
+        // Bisect gate: KFD couples runtime-enable to per-process debug state;
+        // we pass r_debug=0 (ROCr passes a real pointer). Skip the ioctl to
+        // isolate whether the enabled-debug-runtime state perturbs queue/BO
+        // restore on gfx10.3 iGPUs.
+        if std::env::var_os("SVOD_AMD_NO_RUNTIME_ENABLE").is_some() {
+            tracing::warn!("SVOD_AMD_NO_RUNTIME_ENABLE set; skipping RUNTIME_ENABLE");
+        } else if kfd_version >= (1, 14) {
             const KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK: u32 = 1;
             let mut rt = kfd::kfd_ioctl_runtime_enable_args {
                 mode_mask: KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK,

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -199,9 +199,21 @@ impl KfdIface {
         }
 
         // RUNTIME_ENABLE — only on KFD >= 1.14; older kernels reject the
-        // ioctl with ENOTTY.
+        // ioctl with ENOTTY. KFD selects enable-vs-disable by
+        // `mode_mask & KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK` (bit 0), so a zero
+        // mask invokes runtime *disable* — the opposite of intent. ROCr always
+        // enables at init (libhsakmt `hsaKmtRuntimeEnable`, debug.c). The enabled
+        // runtime state is what registers the process for KFD eviction→restore +
+        // queue-resume, which a memory-pressured APU (iGPU driving display +
+        // compute) depends on; without it, an evicted-but-live BO is never
+        // restored and the CP faults NotPresent on it. No TTMP (no CWSR
+        // trap-debug); r_debug = 0 (no debugger attached).
         if kfd_version >= (1, 14) {
-            let mut rt = kfd::kfd_ioctl_runtime_enable_args { mode_mask: 0, ..Default::default() };
+            const KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK: u32 = 1;
+            let mut rt = kfd::kfd_ioctl_runtime_enable_args {
+                mode_mask: KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK,
+                ..Default::default()
+            };
             if let Err(e) = unsafe { ioctl::kfd_runtime_enable(kfd_fd.as_raw_fd(), &mut rt as *mut _) } {
                 return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_RUNTIME_ENABLE", errno: e as i32 });
             }

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -685,7 +685,34 @@ pub(crate) fn compose_flags(kind: AllocKind, cpu_access: bool, is_apu: bool) -> 
 }
 
 /// Reserve `size` bytes of host VA so KFD can bind VRAM into it.
-fn reserve_va(size: usize) -> Result<*mut libc::c_void> {
+///
+/// Bisect gate (SVOD_AMD_LOW_VA): place reservations under 2^40 via a bump
+/// cursor + MAP_FIXED_NOREPLACE. ROCr clamps every GPU VA to
+/// `SVM_RESERVATION_LIMIT = (1<<40)-1` (fmm.c); kernel-chosen `mmap(NULL)`
+/// VAs land at ~2^47, which RDNA2's UTCL2 may not translate for CP fetches.
+pub(crate) fn reserve_va(size: usize) -> Result<*mut libc::c_void> {
+    if std::env::var_os("SVOD_AMD_LOW_VA").is_some() {
+        static CURSOR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0x80_0000_0000);
+        // Bump-allocate; on collision (EEXIST) keep bumping. 64 KiB-align.
+        for _ in 0..1024 {
+            let len = size.next_multiple_of(0x10000);
+            let base = CURSOR.fetch_add(len as u64 + 0x10000, Ordering::Relaxed);
+            let p = unsafe {
+                mmap(
+                    base as *mut _,
+                    size,
+                    PROT_NONE,
+                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | libc::MAP_FIXED_NOREPLACE,
+                    -1,
+                    0,
+                )
+            };
+            if p != libc::MAP_FAILED {
+                return Ok(p);
+            }
+        }
+        return Err(Error::AmdAllocFailed { reason: "SVOD_AMD_LOW_VA: no low VA found after 1024 probes".into() });
+    }
     // SAFETY: standard libc::mmap signature; no aliasing concerns at this point.
     let p = unsafe { mmap(std::ptr::null_mut(), size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0) };
     if p == libc::MAP_FAILED {

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -70,20 +70,14 @@ pub trait AmdIface: Send + Sync + std::fmt::Debug {
 /// Allocation flavor — selects the KFD flag set built in [`AmdIface::alloc_raw`].
 #[derive(Clone, Copy, Debug)]
 pub enum AllocKind {
-    /// Device VRAM. `executable` adds the EXECUTABLE bit (set for general
-    /// buffers, cleared for scratch). PUBLIC is derived from `cpu_access`.
-    DeviceVram { executable: bool },
-    /// GTT-pinned, host-visible, uncached system memory (rings, signal slots,
-    /// the event page). Carries fine-grained `COHERENT`, which the completion
-    /// signal handshake relies on.
+    /// Device VRAM (GTT on APUs). WRITABLE | EXECUTABLE | NO_SUBSTITUTE, plus
+    /// PUBLIC when `cpu_access` — the tinygrad/ROCr base flag set for every
+    /// data/code/scratch buffer.
+    DeviceVram,
+    /// GTT-pinned, host-visible, uncached system memory (rings, queue GART
+    /// pages, signal slots, the event page). Carries fine-grained `COHERENT`,
+    /// which the completion signal handshake relies on.
     UncachedGtt,
-    /// The queue-descriptor page (`amd_queue_t`: rptr/wptr at +128/+56). Mirrors
-    /// ROCr's non-MES descriptor allocation (`system_allocator(AllocateQueueObject)`,
-    /// `amd_gpu_agent.cpp`): GTT, host-visible, **uncached only** — no fine-grained
-    /// `COHERENT` and no `EXECUTABLE`. Those extra MTYPE bits are harmless on
-    /// discrete/CDNA silicon but route the page through a coherence path the MEC
-    /// cannot read on RDNA2 APUs (gfx10.3), faulting the CP on the wptr read.
-    QueueDescriptor,
 }
 
 /// Result of [`AmdIface::alloc_raw`]: everything `RawBuffer::AmdDevice` needs
@@ -371,16 +365,7 @@ impl AmdIface for KfdIface {
         }
 
         self.va.insert(va as u64, size, mem_handle, tag);
-        debug!(
-            size,
-            gpu_addr = va as u64,
-            handle = mem_handle,
-            tag = ?tag,
-            is_apu = self.node.is_apu(),
-            heap = if flags & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM != 0 { "vram" } else { "gtt" },
-            cpu_accessible,
-            "AmdAllocator alloc done"
-        );
+        debug!(size, gpu_addr = va as u64, handle = mem_handle, tag = ?tag, cpu_accessible, "AmdAllocator alloc done");
 
         Ok(AllocResult { gpu_va: va as u64, host_ptr, handle: mem_handle, size })
     }
@@ -408,7 +393,9 @@ impl AmdIface for KfdIface {
         // in-kernel), so a non-error return means the mapping is gone — surface
         // any failure loudly instead of silently recycling a half-mapped VA.
         match unmap_rc {
-            Err(e) => tracing::warn!(?e, gpu_va, handle, "free_raw: UNMAP_MEMORY_FROM_GPU failed — VA recycle may fault"),
+            Err(e) => {
+                tracing::warn!(?e, gpu_va, handle, "free_raw: UNMAP_MEMORY_FROM_GPU failed — VA recycle may fault")
+            }
             Ok(_) if unmap_args.n_success != 1 => {
                 tracing::warn!(n_success = unmap_args.n_success, gpu_va, handle, "free_raw: UNMAP partial")
             }
@@ -421,10 +408,19 @@ impl AmdIface for KfdIface {
         let mut free_args = kfd::kfd_ioctl_free_memory_of_gpu_args { handle };
         // SAFETY: fd alive; handle from a successful alloc.
         let _ = unsafe { ioctl::kfd_free_memory_of_gpu(self.kfd_fd.as_raw_fd(), &mut free_args as *mut _) };
-        // 3. Drop the host mapping / VA reservation LAST (PROT_READ|PROT_WRITE for
-        //    host-visible, or the PROT_NONE reservation for device-only).
+        // 3. Quarantine the VA instead of releasing it (ROCr `reserved_aperture_release`,
+        //    fmm.c): re-mmap PROT_NONE drops the host pages but keeps the range
+        //    reserved, so neither the OS nor a later alloc can recycle a VA the GPU
+        //    might still reference through a stale PTE or in-flight packet. The
+        //    cost is bounded by total bytes ever freed in 47-bit address space;
+        //    only on ENOMEM fall back to a real munmap.
         // SAFETY: gpu_va is the VA returned by our own mmap.
-        unsafe { munmap(gpu_va as *mut _, size) };
+        let p = unsafe {
+            mmap(gpu_va as *mut _, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED, -1, 0)
+        };
+        if p == libc::MAP_FAILED {
+            unsafe { munmap(gpu_va as *mut _, size) };
+        }
     }
 
     fn setup_ring(&self, desc: &RingDesc) -> Result<QueueHandle> {
@@ -604,12 +600,12 @@ impl KfdIface {
 /// arch-independent.
 pub(crate) fn compose_flags(kind: AllocKind, cpu_access: bool, is_apu: bool) -> u32 {
     match kind {
-        AllocKind::DeviceVram { executable } => {
+        AllocKind::DeviceVram => {
             let heap = if is_apu { kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT } else { kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM };
-            let mut flags = heap | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE;
-            if executable {
-                flags |= kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE;
-            }
+            let mut flags = heap
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE;
             if cpu_access {
                 flags |= kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC;
             }
@@ -622,13 +618,6 @@ pub(crate) fn compose_flags(kind: AllocKind, cpu_access: bool, is_apu: bool) -> 
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT
-                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED
-        }
-        AllocKind::QueueDescriptor => {
-            kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT
-                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE
-                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE
-                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED
         }
     }

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -269,7 +269,7 @@ impl AmdIface for KfdIface {
     ) -> Result<AllocResult> {
         // KFD VA reservation + map are page-granular; a 0-byte mmap is EINVAL.
         let size = size.max(1).next_multiple_of(0x1000);
-        let flags = compose_flags(kind, cpu_accessible);
+        let flags = compose_flags(kind, cpu_accessible, self.node.is_apu());
         let va = reserve_va(size)?;
         let mut args = kfd::kfd_ioctl_alloc_memory_of_gpu_args {
             va_addr: va as u64,
@@ -550,12 +550,19 @@ impl KfdIface {
 /// Compose the KFD `KFD_IOC_ALLOC_MEM_FLAGS_*` set for an allocation. This is
 /// the ONLY place the flags are built; it reproduces the four pre-refactor flag
 /// sets bit-for-bit (see the module doc / call sites).
-fn compose_flags(kind: AllocKind, cpu_access: bool) -> u32 {
+///
+/// `is_apu` selects the device-memory backing: discrete GPUs use dedicated VRAM,
+/// but APUs (integrated, unified memory) have none, so `DeviceVram` is allocated
+/// from GTT (system memory the GPU reaches via the GART). The modifier bits are
+/// otherwise identical, so the coherence contract the copy paths rely on (the
+/// GPU's L2-acquire dispatch prologue) is unchanged — GTT just replaces VRAM as
+/// the heap. The control-structure (`UncachedGtt`) set is already GTT and
+/// arch-independent.
+pub(crate) fn compose_flags(kind: AllocKind, cpu_access: bool, is_apu: bool) -> u32 {
     match kind {
         AllocKind::DeviceVram { executable } => {
-            let mut flags = kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM
-                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE
-                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE;
+            let heap = if is_apu { kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT } else { kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM };
+            let mut flags = heap | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE;
             if executable {
                 flags |= kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE;
             }

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -74,10 +74,15 @@ pub enum AllocKind {
     /// PUBLIC when `cpu_access` — the tinygrad/ROCr base flag set for every
     /// data/code/scratch buffer.
     DeviceVram,
-    /// GTT-pinned, host-visible, uncached system memory (rings, queue GART
-    /// pages, signal slots, the event page). Carries fine-grained `COHERENT`,
-    /// which the completion signal handshake relies on.
+    /// GTT-pinned, host-visible, uncached system memory (rings, signal slots,
+    /// the event page). Carries fine-grained `COHERENT`, which the completion
+    /// signal handshake relies on.
     UncachedGtt,
+    /// GTT-pinned, host-visible, *cached* coherent memory — ROCr's flag set for
+    /// the queue rptr/wptr control page and CWSR ctx-save (`queues.c`
+    /// `allocate_exec_aligned_memory_gpu`, Uncached=0). Same as `UncachedGtt`
+    /// minus the UNCACHED bit.
+    CoherentGtt,
 }
 
 /// Result of [`AmdIface::alloc_raw`]: everything `RawBuffer::AmdDevice` needs
@@ -190,6 +195,20 @@ impl KfdIface {
         let rc = unsafe { ioctl::kfd_acquire_vm(kfd_fd.as_raw_fd(), &mut args as *mut _) };
         if let Err(e) = rc {
             return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_ACQUIRE_VM", errno: e as i32 });
+        }
+
+        // SET_MEMORY_POLICY — ROCr issues this once per GPU right after
+        // ACQUIRE_VM (fmm_init_process_apertures): default NONCOHERENT cache
+        // policy, COHERENT alternate. We carve no alternate aperture (per-alloc
+        // COHERENT flags select fine-grain instead), so base/size stay 0.
+        let mut policy = kfd::kfd_ioctl_set_memory_policy_args {
+            gpu_id: node.gpu_id,
+            default_policy: kfd::KFD_IOC_CACHE_POLICY_NONCOHERENT,
+            alternate_policy: kfd::KFD_IOC_CACHE_POLICY_COHERENT,
+            ..Default::default()
+        };
+        if let Err(e) = unsafe { ioctl::kfd_set_memory_policy(kfd_fd.as_raw_fd(), &mut policy as *mut _) } {
+            return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_SET_MEMORY_POLICY", errno: e as i32 });
         }
 
         // RUNTIME_ENABLE — only on KFD >= 1.14; older kernels reject the
@@ -619,6 +638,14 @@ pub(crate) fn compose_flags(kind: AllocKind, cpu_access: bool, is_apu: bool) -> 
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED
+        }
+        AllocKind::CoherentGtt => {
+            kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT
         }
     }
 }

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -65,6 +65,12 @@ pub trait AmdIface: Send + Sync + std::fmt::Debug {
     /// `Ok(Some(Error::Runtime{..}))` on a fault, `Ok(None)` on a normal
     /// wake-up/timeout, `Err` if the WAIT_EVENTS ioctl itself failed.
     fn wait_events(&self, timeout_ms: u32) -> Result<Option<Error>>;
+    /// `(group/LDS, private/scratch)` aperture base hi32 from
+    /// GET_PROCESS_APERTURES — written into the AQL `amd_queue_t` (the CWSR
+    /// trap path walks the struct and ROCr asserts these non-zero).
+    fn aperture_base_hi(&self) -> (u32, u32) {
+        (0, 0)
+    }
 }
 
 /// Allocation flavor — selects the KFD flag set built in [`AmdIface::alloc_raw`].
@@ -168,6 +174,9 @@ pub struct KfdIface {
     /// even though `wait_events(0)` may re-observe the (non-auto-reset) fault
     /// event on subsequent poll-fault calls.
     fault_logged: AtomicBool,
+    /// `(group/LDS, private/scratch)` aperture base hi32 from
+    /// GET_PROCESS_APERTURES, captured at open for the AQL queue descriptor.
+    aperture_base_hi: (u32, u32),
 }
 
 impl KfdIface {
@@ -219,11 +228,11 @@ impl KfdIface {
         if let Err(e) = unsafe { ioctl::kfd_get_process_apertures(kfd_fd.as_raw_fd(), &mut apertures as *mut _) } {
             return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_GET_PROCESS_APERTURES", errno: e as i32 });
         }
-        let scratch_base = apertures.process_apertures[..apertures.num_of_nodes.min(7) as usize]
+        let node_apertures = apertures.process_apertures[..apertures.num_of_nodes.min(7) as usize]
             .iter()
-            .find(|a| a.gpu_id == node.gpu_id)
-            .map(|a| a.scratch_base)
-            .unwrap_or(0);
+            .find(|a| a.gpu_id == node.gpu_id);
+        let scratch_base = node_apertures.map(|a| a.scratch_base).unwrap_or(0);
+        let lds_base = node_apertures.map(|a| a.lds_base).unwrap_or(0);
         if scratch_base != 0 {
             let mut sb =
                 kfd::kfd_ioctl_set_scratch_backing_va_args { va_addr: scratch_base, gpu_id: node.gpu_id, pad: 0 };
@@ -321,6 +330,7 @@ impl KfdIface {
             hw_fault_event_id: hw_event.event_id,
             va: VaRegistry::default(),
             fault_logged: AtomicBool::new(false),
+            aperture_base_hi: ((lds_base >> 32) as u32, (scratch_base >> 32) as u32),
         })
     }
 }
@@ -507,6 +517,10 @@ impl AmdIface for KfdIface {
         let (doorbell_base, doorbell) = self.doorbell_mmap(args.doorbell_offset)?;
         debug!(queue_id = args.queue_id, doorbell_offset = args.doorbell_offset, "AMD queue created");
         Ok(QueueHandle { queue_id: args.queue_id, doorbell_base, doorbell })
+    }
+
+    fn aperture_base_hi(&self) -> (u32, u32) {
+        self.aperture_base_hi
     }
 
     fn teardown_ring(&self, queue_id: u32, doorbell_base: NonNull<u8>) {

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -388,16 +388,31 @@ impl AmdIface for KfdIface {
             n_success: 0,
         };
         // SAFETY: fd is alive; handle is from a successful alloc.
-        let _ = unsafe { ioctl::kfd_unmap_memory_from_gpu(self.kfd_fd.as_raw_fd(), &mut unmap_args as *mut _) };
-        // 2. Drop host mapping (PROT_READ|PROT_WRITE for host-visible, or the
-        //    PROT_NONE reservation for device-only). Both cases munmap the
-        //    same VA region.
+        let unmap_rc = unsafe { ioctl::kfd_unmap_memory_from_gpu(self.kfd_fd.as_raw_fd(), &mut unmap_args as *mut _) };
+        // A failed/partial unmap leaves the GPU PTEs for `gpu_va` intact while we
+        // go on to free the handle and (below) release the VA. If the VA is then
+        // recycled by a later alloc, those stale PTEs surface as a live-but-
+        // `NotPresent` fault. KFD's unmap is synchronous (PTE clear + TLB flush
+        // in-kernel), so a non-error return means the mapping is gone — surface
+        // any failure loudly instead of silently recycling a half-mapped VA.
+        match unmap_rc {
+            Err(e) => tracing::warn!(?e, gpu_va, handle, "free_raw: UNMAP_MEMORY_FROM_GPU failed — VA recycle may fault"),
+            Ok(_) if unmap_args.n_success != 1 => {
+                tracing::warn!(n_success = unmap_args.n_success, gpu_va, handle, "free_raw: UNMAP partial")
+            }
+            Ok(_) => {}
+        }
+        // 2. Free the KFD allocation BEFORE releasing the VA (ROCr `__fmm_release`
+        //    order, fmm.c: free the BO — which finalizes PTE teardown — then let
+        //    the VA become reusable). Releasing the VA first would let a
+        //    concurrent alloc map a fresh BO over a VA whose old BO isn't freed.
+        let mut free_args = kfd::kfd_ioctl_free_memory_of_gpu_args { handle };
+        // SAFETY: fd alive; handle from a successful alloc.
+        let _ = unsafe { ioctl::kfd_free_memory_of_gpu(self.kfd_fd.as_raw_fd(), &mut free_args as *mut _) };
+        // 3. Drop the host mapping / VA reservation LAST (PROT_READ|PROT_WRITE for
+        //    host-visible, or the PROT_NONE reservation for device-only).
         // SAFETY: gpu_va is the VA returned by our own mmap.
         unsafe { munmap(gpu_va as *mut _, size) };
-        // 3. Free the KFD allocation.
-        let mut free_args = kfd::kfd_ioctl_free_memory_of_gpu_args { handle };
-        // SAFETY: same as above.
-        let _ = unsafe { ioctl::kfd_free_memory_of_gpu(self.kfd_fd.as_raw_fd(), &mut free_args as *mut _) };
     }
 
     fn setup_ring(&self, desc: &RingDesc) -> Result<QueueHandle> {

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -351,7 +351,16 @@ impl AmdIface for KfdIface {
         }
 
         self.va.insert(va as u64, size, mem_handle, tag);
-        debug!(size, gpu_addr = va as u64, handle = mem_handle, tag = ?tag, "AmdAllocator alloc done");
+        debug!(
+            size,
+            gpu_addr = va as u64,
+            handle = mem_handle,
+            tag = ?tag,
+            is_apu = self.node.is_apu(),
+            heap = if flags & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM != 0 { "vram" } else { "gtt" },
+            cpu_accessible,
+            "AmdAllocator alloc done"
+        );
 
         Ok(AllocResult { gpu_va: va as u64, host_ptr, handle: mem_handle, size })
     }

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -211,6 +211,34 @@ impl KfdIface {
             return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_SET_MEMORY_POLICY", errno: e as i32 });
         }
 
+        // SCRATCH_BACKING_VA — ROCr programs the per-VMID scratch aperture base
+        // (SH_HIDDEN_PRIVATE_BASE) before any queue exists; KFD reports the
+        // process scratch aperture in GET_PROCESS_APERTURES. Without it, gfx10
+        // dispatches that spill resolve scratch against an unprogrammed base.
+        let mut apertures = kfd::kfd_ioctl_get_process_apertures_args::default();
+        if let Err(e) = unsafe { ioctl::kfd_get_process_apertures(kfd_fd.as_raw_fd(), &mut apertures as *mut _) } {
+            return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_GET_PROCESS_APERTURES", errno: e as i32 });
+        }
+        let scratch_base = apertures.process_apertures[..apertures.num_of_nodes.min(7) as usize]
+            .iter()
+            .find(|a| a.gpu_id == node.gpu_id)
+            .map(|a| a.scratch_base)
+            .unwrap_or(0);
+        if scratch_base != 0 {
+            let mut sb =
+                kfd::kfd_ioctl_set_scratch_backing_va_args { va_addr: scratch_base, gpu_id: node.gpu_id, pad: 0 };
+            if let Err(e) = unsafe { ioctl::kfd_set_scratch_backing_va(kfd_fd.as_raw_fd(), &mut sb as *mut _) } {
+                return Err(Error::AmdIoctl { ioctl: "AMDKFD_IOC_SET_SCRATCH_BACKING_VA", errno: e as i32 });
+            }
+        }
+
+        // XNACK off — explicit, matching ROCr's init on non-XNACK parts. Old
+        // kernels reject the ioctl (ENOTTY); best-effort.
+        let mut xnack = kfd::kfd_ioctl_set_xnack_mode_args { xnack_enabled: 0 };
+        if let Err(e) = unsafe { ioctl::kfd_set_xnack_mode(kfd_fd.as_raw_fd(), &mut xnack as *mut _) } {
+            tracing::warn!(?e, "SET_XNACK_MODE(0) rejected; continuing with kernel default");
+        }
+
         // RUNTIME_ENABLE — only on KFD >= 1.14; older kernels reject the
         // ioctl with ENOTTY. KFD selects enable-vs-disable by
         // `mode_mask & KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK` (bit 0), so a zero

--- a/device/src/amd/iface.rs
+++ b/device/src/amd/iface.rs
@@ -73,9 +73,17 @@ pub enum AllocKind {
     /// Device VRAM. `executable` adds the EXECUTABLE bit (set for general
     /// buffers, cleared for scratch). PUBLIC is derived from `cpu_access`.
     DeviceVram { executable: bool },
-    /// GTT-pinned, host-visible, uncached system memory (rings, GART, signal
-    /// slots, the event page).
+    /// GTT-pinned, host-visible, uncached system memory (rings, signal slots,
+    /// the event page). Carries fine-grained `COHERENT`, which the completion
+    /// signal handshake relies on.
     UncachedGtt,
+    /// The queue-descriptor page (`amd_queue_t`: rptr/wptr at +128/+56). Mirrors
+    /// ROCr's non-MES descriptor allocation (`system_allocator(AllocateQueueObject)`,
+    /// `amd_gpu_agent.cpp`): GTT, host-visible, **uncached only** — no fine-grained
+    /// `COHERENT` and no `EXECUTABLE`. Those extra MTYPE bits are harmless on
+    /// discrete/CDNA silicon but route the page through a coherence path the MEC
+    /// cannot read on RDNA2 APUs (gfx10.3), faulting the CP on the wptr read.
+    QueueDescriptor,
 }
 
 /// Result of [`AmdIface::alloc_raw`]: everything `RawBuffer::AmdDevice` needs
@@ -587,6 +595,13 @@ pub(crate) fn compose_flags(kind: AllocKind, cpu_access: bool, is_apu: bool) -> 
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED
+        }
+        AllocKind::QueueDescriptor => {
+            kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE
+                | kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC
                 | kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED
         }
     }

--- a/device/src/amd/program.rs
+++ b/device/src/amd/program.rs
@@ -652,6 +652,8 @@ impl AmdProgram {
         // ring hazard between co-tenant owners). Lock order: dispatch_lock →
         // queue inner Mutex (taken inside dispatch_*).
         let _disp = pool.dispatch_guard();
+        let private_seg = self.private_segment_size();
+        tracing::debug!(kernel = %self.name, private_seg, wait, "dispatch");
 
         // 1. Bump the queue's kernarg arena under the dispatch lock — the
         // ordering above guarantees the slot stays valid through dispatch.

--- a/device/src/amd/program.rs
+++ b/device/src/amd/program.rs
@@ -256,9 +256,10 @@ pub struct AmdProgram {
     rsrc2: u32,
     rsrc3: u32,
     /// `(kd.kernel_code_properties & 0x400) != 0` — true for wave32 kernels
-    /// (RDNA3/4 default). Controls the `cs_w32_en` bit in DISPATCH_INITIATOR.
+    /// (RDNA2/3/4 default). Controls the `cs_w32_en` bit in DISPATCH_INITIATOR.
     wave32: bool,
-    /// gfx major version (9, 11, or 12). gfx9 (CDNA) ignores `cs_w32_en`.
+    /// gfx major version (9, 10, 11, or 12). gfx9 (CDNA) ignores `cs_w32_en`;
+    /// gfx10 (RDNA2) additionally lacks the COMPUTE_DISPATCH_SCRATCH_BASE regs.
     target_major: u32,
     /// `kernel_code_properties & ENABLE_SGPR_PRIVATE_SEGMENT_BUFFER` — kernel
     /// reads a 4-dword scratch descriptor from user SGPRs 0-3. We prepend
@@ -311,8 +312,9 @@ impl AmdProgram {
 
         // Derive PM4-path fields from the kernel descriptor:
         //   lds_size = round_up(group_segment_fixed_size, 512) / 512 (clamped 9 bits)
-        //   target_major: 9 = CDNA, 11/12 = RDNA3/4
-        //   rsrc1 |= 1<<20 on gfx11 (cwsr-priv shim)
+        //   target_major: 9 = CDNA, 10 = RDNA2, 11/12 = RDNA3/4
+        //   rsrc1 |= 1<<20 on gfx11 ONLY (cwsr-priv shim; tinygrad ops_amd gates
+        //     it `(11,0,0) <= target < (12,0,0)` — not gfx9/gfx10/gfx12)
         //   rsrc2 |= lds_size << 15
         //   wave32 = kd.kernel_code_properties bit 10
         //   pm4_prog_addr = aql_prog_addr + kernel_code_entry_byte_offset

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -48,6 +48,9 @@ pub const AQL_PACKET_BYTES: usize = 64;
 const INVALID_AQL_HEADER: u32 = hsa_packet_type_t_HSA_PACKET_TYPE_INVALID << hsa_packet_header_t_HSA_PACKET_HEADER_TYPE;
 /// 16 MiB ring — the compute-ring default size.
 pub const COMPUTE_RING_BYTES: usize = 16 * 1024 * 1024;
+/// RDNA2 compute ring — ROCr never creates user queues above 1 MiB on gfx10.3
+/// (HW-confirmed: the 16 MiB ring's GART wptr poll faults the CPF mid-run).
+pub const COMPUTE_RING_BYTES_RDNA2: usize = 1024 * 1024;
 /// SDMA ring is smaller; 1 MiB is plenty for short copy bursts.
 pub const COPY_RING_BYTES: usize = 1024 * 1024;
 
@@ -60,7 +63,9 @@ const MAX_DISPATCH_DWORDS: usize = 1024;
 /// Chosen so the combined ring footprint stays at half the ring even in the
 /// worst case (`* MAX_DISPATCH_DWORDS`), leaving generous margin while still
 /// letting the host run thousands of dispatches ahead of the GPU.
-const RING_MAX_INFLIGHT: u64 = (COMPUTE_RING_BYTES / 4 / MAX_DISPATCH_DWORDS / 2) as u64;
+const fn ring_max_inflight(ring_bytes: usize) -> u64 {
+    (ring_bytes / 4 / MAX_DISPATCH_DWORDS / 2) as u64
+}
 
 /// Build an AQL `hsa_barrier_and_packet_t` (64 bytes) with no dependencies and
 /// the given `completion_signal` handle. Used as a graph batch's terminator:
@@ -434,7 +439,8 @@ impl AmdComputeQueue {
         // bisecting PM4 vs AQL bring-up issues.
         let is_pm4 = Self::will_use_pm4(core);
         let queue_type = if is_pm4 { kfd::KFD_IOC_QUEUE_TYPE_COMPUTE } else { kfd::KFD_IOC_QUEUE_TYPE_COMPUTE_AQL };
-        let inner = create_queue(allocator, queue_type, COMPUTE_RING_BYTES, !is_pm4, /*needs_cwsr=*/ true)?;
+        let ring_bytes = if core.arch.is_rdna2() { COMPUTE_RING_BYTES_RDNA2 } else { COMPUTE_RING_BYTES };
+        let inner = create_queue(allocator, queue_type, ring_bytes, !is_pm4, /*needs_cwsr=*/ true)?;
         debug!(gpu_id = core.node.gpu_id, num_xcc = core.node.num_xcc, is_pm4 = is_pm4, "AmdComputeQueue created");
         Ok(Box::new(Self { inner: Mutex::new(inner), core: Arc::clone(core), is_pm4 }))
     }
@@ -457,9 +463,10 @@ impl AmdComputeQueue {
     /// The dispatches we wait on were submitted (doorbell rung) in prior calls,
     /// so the GPU will signal them; the wait always makes progress.
     fn wait_dispatch_headroom(&self, pool: &PoolQueue) -> Result<()> {
+        let max_inflight = ring_max_inflight(self.inner.lock().ring_size);
         let last_reserved = pool.pm4_value().saturating_sub(1);
-        if last_reserved > RING_MAX_INFLIGHT {
-            let target = last_reserved - RING_MAX_INFLIGHT;
+        if last_reserved > max_inflight {
+            let target = last_reserved - max_inflight;
             pool.pm4_signal().wait_signal_value(target, 30_000).inspect_err(|e| self.core.poison(&e.to_string()))?;
         }
         Ok(())

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -431,7 +431,10 @@ impl AmdComputeQueue {
     /// path is unsupported anyway. Same logic as `create`'s `is_pm4` decision.
     pub fn will_use_pm4(core: &AmdDeviceCore) -> bool {
         let force_aql = std::env::var("SVOD_AMD_AQL").ok().map(|s| s != "0").unwrap_or(false);
-        !force_aql && core.node.num_xcc.max(1) == 1
+        // RDNA2 (gfx10.3) runs AQL like ROCr: PM4 user compute queues have zero
+        // production users on this generation, and the HWS preempt path is only
+        // validated against an AQL `amd_queue_t`.
+        !force_aql && !core.arch.is_rdna2() && core.node.num_xcc.max(1) == 1
     }
 
     pub fn create(allocator: &AmdAllocator) -> Result<Box<Self>> {
@@ -1119,13 +1122,28 @@ fn create_queue(
                 crate::amd::sys::hsa::amd_signal_kind_t_AMD_SIGNAL_KIND_USER as i64,
             );
         }
-        // Initialize the GART descriptor.
+        // Initialize the GART descriptor with the FULL ROCr field set
+        // (amd_aql_queue.cpp ctor). The CWSR trap path walks the struct at
+        // preemption: hsa_queue.base_address/size and the aperture base_hi
+        // words must be valid (ROCr asserts them non-zero) — publishing a
+        // partial struct corrupts the context save and the resumed CPF fetch
+        // faults on the queue's control pages.
         // max_cu_id is total CUs across all XCCs - 1 (cu_cnt*xccs-1).
         let cu_cnt = dev.node.simd_count.max(1) / dev.node.simd_per_cu.max(1);
         let waves_per_cu = dev.node.max_waves_per_simd * dev.node.simd_per_cu;
+        let (group_hi, private_hi) = dev.iface().aperture_base_hi();
         // `queue_properties` is the u32 storage field; the generated property
         // constants are `amd_queue_properties_t` (c_int), narrowed here.
         let desc = crate::amd::sys::hsa::amd_queue_t {
+            hsa_queue: crate::amd::sys::hsa::hsa_queue_t {
+                type_: 0,    // HSA_QUEUE_TYPE_MULTI
+                features: 1, // HSA_QUEUE_FEATURE_KERNEL_DISPATCH
+                base_address: ring_gpu as *mut _,
+                size: (ring_size / AQL_PACKET_BYTES) as u32,
+                ..Default::default()
+            },
+            group_segment_aperture_base_hi: group_hi,
+            private_segment_aperture_base_hi: private_hi,
             queue_properties: (crate::amd::sys::hsa::amd_queue_properties_t_AMD_QUEUE_PROPERTIES_IS_PTR64
                 | crate::amd::sys::hsa::amd_queue_properties_t_AMD_QUEUE_PROPERTIES_ENABLE_PROFILING)
                 as u32,

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -1074,9 +1074,9 @@ fn create_queue(
     }
     // GART page holds the AQL queue descriptor (`amd_queue_t`, 256 bytes).
     // rptr/wptr live at fixed offsets inside it; the CP reads them to drive the
-    // queue. Same coherent+uncached GTT flags as the ring — field-for-field with
-    // tinygrad's GART page and ROCr's queue control page.
-    let gart_buf = allocator.alloc_uncached(0x100)?;
+    // queue. ROCr allocates this page cached-coherent (no UNCACHED bit) — the
+    // only working gfx10.3 reference, so match it exactly.
+    let gart_buf = allocator.alloc_coherent(0x100)?;
     let (gart_gpu, gart_host) = match &gart_buf {
         crate::allocator::RawBuffer::AmdDevice { gpu_addr, host_ptr: Some(h), .. } => (*gpu_addr, *h),
         _ => return Err(Error::AmdAllocFailed { reason: "GART page requires host-visible buffer".into() }),
@@ -1150,9 +1150,8 @@ fn create_queue(
     // KFD writes debug-trap state. Undersizing causes corruption when CWSR
     // fires; oversizing is harmless.
     //
-    // EOP and ctx-save are *plain VRAM* (no PUBLIC/COHERENT/UNCACHED flags):
-    // they're written by the GPU during preemption and never read from the
-    // CPU, so the default allocation flags suffice.
+    // EOP is plain VRAM (GPU-only, ROCr device-local); ctx-save is coherent
+    // GTT (host writes the CWSR header, ROCr's CWSR heap).
     // SDMA queues take no EOP/ctx-save buffers (CWSR is a compute-shader
     // preemption mechanism) — both are zero for SDMA. Compute queues
     // size them per the CWSR contract below.
@@ -1168,9 +1167,11 @@ fn create_queue(
         // save/restore (MES preempts a busy queue as routine runlist scheduling).
         // Without the header, a restore reads garbage `DebugOffset`/`DebugSize`
         // and the queue silently strands (rptr frozen, no fault) — the exact
-        // multi-XCC wedge. Mirrors libhsakmt `fill_cwsr_header`.
-        let ctx_spec = BufferSpec { cpu_access: true, nolru: true, ..Default::default() };
-        let ctx_buf = allocator.alloc(cwsr_buffer_size, &ctx_spec, /*zero=*/ true)?;
+        // multi-XCC wedge. Mirrors libhsakmt `fill_cwsr_header`. Backing is
+        // cached-coherent GTT, ROCr's CWSR fallback heap (`queues.c`
+        // `allocate_exec_aligned_memory` nonPaged=false DeviceLocal=false) —
+        // never VRAM.
+        let ctx_buf = allocator.alloc_coherent(cwsr_buffer_size)?;
         let eop_gpu = match &eop_buf {
             crate::allocator::RawBuffer::AmdDevice { gpu_addr, .. } => *gpu_addr,
             _ => 0,

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -412,6 +412,7 @@ impl QueueInner {
         // ring packet / kernarg stores are still buffered (stale read → wedge).
         std::sync::atomic::fence(std::sync::atomic::Ordering::SeqCst);
         let doorbell_value = if is_pm4 { self.write_idx } else { self.write_idx - 1 };
+        tracing::debug!(write_idx = self.write_idx, doorbell_value, ring_size = self.ring_size, "ring_doorbell");
         // SAFETY: doorbell is mmapped MMIO; aligned 64-bit store.
         unsafe { std::ptr::write_volatile(self.doorbell.as_ptr(), doorbell_value) };
     }

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -808,7 +808,8 @@ fn dwords_as_bytes(p: &[u32; 16]) -> &[u8] {
 /// appending into `q` (minus SQTT/PMC/dispatch_ptr).
 /// The shader entry point is pre-shifted right by 8 (COMPUTE_PGM_LO/HI hold the
 /// upper bits of a 256-byte-aligned address). `wave32` comes from
-/// `kd.kernel_code_properties & 0x400`; `cs_w32_en` is gfx11/12-only.
+/// `kd.kernel_code_properties & 0x400`; `cs_w32_en` applies to gfx10+ (every
+/// non-CDNA arch — RDNA2/3/4), gfx9 (CDNA, wave64) ignores it.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_exec_pm4(
     q: &mut Vec<u32>,
@@ -844,10 +845,19 @@ pub(crate) fn build_exec_pm4(
     q.extend(pm4::set_sh_reg(rsrc3_reg, &[rsrc3]));
 
     // 4. Scratch / tmpring (valid base required for wave init on RDNA3+ even
-    //    when SCRATCH_EN=0).
+    //    when SCRATCH_EN=0). COMPUTE_DISPATCH_SCRATCH_BASE registers exist on
+    //    gfx11+ and CDNA (gfx942/950) but were removed on gfx10/RDNA2 (tinygrad
+    //    `has_scratch_base_registers = target >= (11,0,0) or {(9,4,2),(9,5,0)}`);
+    //    on gfx10 the scratch base rides the private-segment-buffer V# in user
+    //    SGPRs, so skip the register write there.
     q.extend(pm4::set_sh_reg(pm4::COMPUTE_TMPRING_SIZE, &[tmpring_size]));
-    let scratch_shr = scratch_addr >> 8;
-    q.extend(pm4::set_sh_reg(pm4::COMPUTE_DISPATCH_SCRATCH_BASE_LO, &[scratch_shr as u32, (scratch_shr >> 32) as u32]));
+    if target_major != 10 {
+        let scratch_shr = scratch_addr >> 8;
+        q.extend(pm4::set_sh_reg(
+            pm4::COMPUTE_DISPATCH_SCRATCH_BASE_LO,
+            &[scratch_shr as u32, (scratch_shr >> 32) as u32],
+        ));
+    }
 
     // 5. Restart points always zero (no preempt-resume).
     q.extend(pm4::set_sh_reg(pm4::COMPUTE_RESTART_X, &[0, 0, 0]));
@@ -1235,9 +1245,11 @@ fn compute_ctx_sizes(dev: &AmdDeviceCore) -> (usize, usize, usize) {
     let is_cdna4 = dev.arch == svod_dtype::AmdArch::Gfx950;
     let lds_per_cu: usize = if is_cdna4 { (dev.node.lds_size_in_kb as usize) << 10 } else { 0x10000 };
 
-    // VGPR-per-CU branches on a small whitelist of gfx-target
-    // tuples: CDNA (gfx9.x) uses 0x80000, the listed
-    // RDNA3/RDNA4 tuples use 0x60000, Gfx1102 alone uses 0x40000.
+    // VGPR-per-CU, mirroring ROCr's `hsakmt_get_vgpr_size_per_cu` (libhsakmt
+    // queues.c): CDNA (gfx9.x) uses 0x80000, the listed RDNA3/RDNA4 tuples use
+    // 0x60000, and everything below gfx1100 — all RDNA2 (gfx10.3) — plus Gfx1102
+    // use the 0x40000 default. The kernel rejects CREATE_QUEUE with EINVAL if the
+    // CWSR buffer derived from this is short, so it must match the runtime.
     let vgpr_per_cu: usize = match dev.arch {
         svod_dtype::AmdArch::Gfx942 | svod_dtype::AmdArch::Gfx950 => 0x80000,
         svod_dtype::AmdArch::Gfx1100
@@ -1245,7 +1257,11 @@ fn compute_ctx_sizes(dev: &AmdDeviceCore) -> (usize, usize, usize) {
         | svod_dtype::AmdArch::Gfx1151
         | svod_dtype::AmdArch::Gfx1200
         | svod_dtype::AmdArch::Gfx1201 => 0x60000,
-        svod_dtype::AmdArch::Gfx1102 => 0x40000,
+        svod_dtype::AmdArch::Gfx1030
+        | svod_dtype::AmdArch::Gfx1031
+        | svod_dtype::AmdArch::Gfx1032
+        | svod_dtype::AmdArch::Gfx1034
+        | svod_dtype::AmdArch::Gfx1102 => 0x40000,
     };
 
     let xccs = dev.node.num_xcc.max(1) as usize;
@@ -1267,7 +1283,14 @@ fn compute_ctx_sizes(dev: &AmdDeviceCore) -> (usize, usize, usize) {
     let wg_data_size = wg_data_size.next_multiple_of(PAGE);
 
     let waves_factor = if dev.arch.is_cdna() { 8 } else { 12 };
-    let ctl_stack_size = (waves_factor * wave_cnt + 8 + 40).next_multiple_of(PAGE);
+    let mut ctl_stack_size = (waves_factor * wave_cnt + 8 + 40).next_multiple_of(PAGE);
+    // gfx10 (RDNA2) HW design caps the control stack at 0x7000 (sufficient for
+    // AQL, limited by SPI events). ROCr clamps it for `(gfxv & 0x3f0000) ==
+    // 0xA0000` (queues.c), tinygrad for `target[0] == 10`; an unclamped larger
+    // value risks CREATE_QUEUE rejection on gfx10.
+    if dev.arch.is_rdna2() {
+        ctl_stack_size = ctl_stack_size.min(0x7000);
+    }
     // `debug_memory_size = round_up(wave_cnt * 32, 64)`.
     let debug_memory_size = (wave_cnt * 32).next_multiple_of(64);
 

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -1260,7 +1260,10 @@ fn compute_ctx_sizes(dev: &AmdDeviceCore) -> (usize, usize, usize) {
         svod_dtype::AmdArch::Gfx1030
         | svod_dtype::AmdArch::Gfx1031
         | svod_dtype::AmdArch::Gfx1032
+        | svod_dtype::AmdArch::Gfx1033
         | svod_dtype::AmdArch::Gfx1034
+        | svod_dtype::AmdArch::Gfx1035
+        | svod_dtype::AmdArch::Gfx1036
         | svod_dtype::AmdArch::Gfx1102 => 0x40000,
     };
 

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -526,6 +526,21 @@ impl AmdComputeQueue {
             full_user_data.push(0x20c1_4000);
         }
         full_user_data.extend_from_slice(user_data);
+        // TEMP gfx10 bring-up: dump the exact VAs the CP/shader touch so a page
+        // fault address (dmesg "in page starting at ...") can be matched to a
+        // specific buffer in a single run.
+        {
+            let kernarg_ptr = (user_data.first().copied().unwrap_or(0) as u64)
+                | ((user_data.get(1).copied().unwrap_or(0) as u64) << 32);
+            tracing::debug!(
+                counter_addr,
+                prog_addr,
+                scratch_addr,
+                kernarg_ptr,
+                enable_private_segment_sgpr,
+                "dispatch_pm4 VAs"
+            );
+        }
         let mut g = self.inner.lock();
         let prev = pool.pm4_value().saturating_sub(1);
         let next = pool.next_pm4();

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -845,19 +845,15 @@ pub(crate) fn build_exec_pm4(
     q.extend(pm4::set_sh_reg(rsrc3_reg, &[rsrc3]));
 
     // 4. Scratch / tmpring (valid base required for wave init on RDNA3+ even
-    //    when SCRATCH_EN=0). COMPUTE_DISPATCH_SCRATCH_BASE registers exist on
-    //    gfx11+ and CDNA (gfx942/950) but were removed on gfx10/RDNA2 (tinygrad
-    //    `has_scratch_base_registers = target >= (11,0,0) or {(9,4,2),(9,5,0)}`);
-    //    on gfx10 the scratch base rides the private-segment-buffer V# in user
-    //    SGPRs, so skip the register write there.
+    //    when SCRATCH_EN=0). COMPUTE_DISPATCH_SCRATCH_BASE is written on ALL
+    //    arches incl. gfx10.3 (RDNA2): RDNA2 uses "architected flat scratch" —
+    //    LLVM emits scratch accesses relative to FLAT_SCRATCH, which HW
+    //    initialises from this register, so it MUST be set. tinygrad ops_amd
+    //    writes it unconditionally; the old `has_scratch_base_registers` gate
+    //    (gfx11+/CDNA only) was wrong for gfx10.3 and left FLAT_SCRATCH unset.
     q.extend(pm4::set_sh_reg(pm4::COMPUTE_TMPRING_SIZE, &[tmpring_size]));
-    if target_major != 10 {
-        let scratch_shr = scratch_addr >> 8;
-        q.extend(pm4::set_sh_reg(
-            pm4::COMPUTE_DISPATCH_SCRATCH_BASE_LO,
-            &[scratch_shr as u32, (scratch_shr >> 32) as u32],
-        ));
-    }
+    let scratch_shr = scratch_addr >> 8;
+    q.extend(pm4::set_sh_reg(pm4::COMPUTE_DISPATCH_SCRATCH_BASE_LO, &[scratch_shr as u32, (scratch_shr >> 32) as u32]));
 
     // 5. Restart points always zero (no preempt-resume).
     q.extend(pm4::set_sh_reg(pm4::COMPUTE_RESTART_X, &[0, 0, 0]));

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -516,21 +516,27 @@ impl AmdComputeQueue {
         // async (`wait=false`) burst can't lap the ring. Outside the inner lock.
         self.wait_dispatch_headroom(pool)?;
         let counter_addr = pool.pm4_signal().value_addr();
-        let scratch_addr = pool.scratch_gpu_va();
-        let tmpring_size = pool.tmpring_size();
-        // Assemble the full USER_DATA prefix here, under the lock, so the scratch
-        // SGPR descriptor (words 0-3) is derived from the SAME `scratch_addr` as
-        // the `COMPUTE_DISPATCH_SCRATCH_BASE` register below. Building it in
-        // `AmdProgram::execute` (outside the lock) let a concurrent scratch
-        // realloc slip in between the two reads, so the descriptor and the
-        // register could point at different buffers. The scratch base address
-        // is read exactly once and reused for the descriptor and the register.
+        // One snapshot under one lock window, so the scratch SGPR descriptor
+        // (words 0-3), the tmpring, and the `COMPUTE_DISPATCH_SCRATCH_BASE`
+        // register below all describe the SAME buffer even when a concurrent
+        // grow swaps the scratch state mid-dispatch.
+        let scratch = pool.scratch_snapshot();
+        let scratch_addr = scratch.gpu_va;
+        let tmpring_size = scratch.tmpring_size;
         let mut full_user_data: Vec<u32> = Vec::with_capacity(user_data.len() + 4);
         if enable_private_segment_sgpr {
             full_user_data.push(scratch_addr as u32);
             full_user_data.push((scratch_addr >> 32) as u32 | (1u32 << 31));
-            full_user_data.push(0xFFFF_FFFF);
-            full_user_data.push(0x20c1_4000);
+            if scratch.aql_desc.resource_descriptor[3] != 0 {
+                // Arch-built SRD (gfx9 on CDNA, gfx10 on RDNA2): NUM_RECORDS =
+                // per-XCC scratch size, WORD3 per `AqlScratchDesc::gfx9/gfx10`.
+                full_user_data.push(scratch.aql_desc.resource_descriptor[2]);
+                full_user_data.push(scratch.aql_desc.resource_descriptor[3]);
+            } else {
+                // gfx11+ literals (tinygrad's working RDNA3 values).
+                full_user_data.push(0xFFFF_FFFF);
+                full_user_data.push(0x20c1_4000);
+            }
         }
         full_user_data.extend_from_slice(user_data);
         let mut g = self.inner.lock();

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -1056,9 +1056,9 @@ fn create_queue(
     needs_cwsr: bool,
 ) -> Result<QueueInner> {
     let dev = allocator.dev.core();
-    // Ring + GART are both VRAM with COHERENT | UNCACHED | PUBLIC flags
-    // (uncached + cpu-accessible). Using plain VRAM (no UNCACHED) makes
-    // KFD reject the create_queue ioctl with EINVAL.
+    // The ring is GTT, host-visible, uncached (COHERENT | UNCACHED | PUBLIC):
+    // plain VRAM (no UNCACHED) makes KFD reject the create_queue ioctl with
+    // EINVAL. The descriptor page below uses tighter ROCr flags (no COHERENT).
     let ring_buf = allocator.alloc_uncached(ring_size)?;
     let (ring_gpu, ring_host) = match &ring_buf {
         crate::allocator::RawBuffer::AmdDevice { gpu_addr, host_ptr: Some(h), .. } => (*gpu_addr, *h),
@@ -1079,10 +1079,11 @@ fn create_queue(
         }
     }
     // GART page holds the AQL queue descriptor (`amd_queue_t`, 256 bytes).
-    // rptr/wptr live at fixed offsets inside it; KFD reads the descriptor
-    // when wiring up the queue. The GART page is a 0x100-byte uncached,
-    // cpu-accessible allocation.
-    let gart_buf = allocator.alloc_uncached(0x100)?;
+    // rptr/wptr live at fixed offsets inside it; the CP reads them to drive the
+    // queue. Allocated with ROCr's minimal non-MES descriptor flags (GTT,
+    // host-visible, uncached — no COHERENT/EXECUTABLE), so the MEC can read the
+    // wptr on RDNA2 APUs (gfx10.3) where the extra MTYPE bits fault the CP.
+    let gart_buf = allocator.alloc_queue_descriptor(0x100)?;
     let (gart_gpu, gart_host) = match &gart_buf {
         crate::allocator::RawBuffer::AmdDevice { gpu_addr, host_ptr: Some(h), .. } => (*gpu_addr, *h),
         _ => return Err(Error::AmdAllocFailed { reason: "GART page requires host-visible buffer".into() }),

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -526,21 +526,6 @@ impl AmdComputeQueue {
             full_user_data.push(0x20c1_4000);
         }
         full_user_data.extend_from_slice(user_data);
-        // TEMP gfx10 bring-up: dump the exact VAs the CP/shader touch so a page
-        // fault address (dmesg "in page starting at ...") can be matched to a
-        // specific buffer in a single run.
-        {
-            let kernarg_ptr = (user_data.first().copied().unwrap_or(0) as u64)
-                | ((user_data.get(1).copied().unwrap_or(0) as u64) << 32);
-            tracing::debug!(
-                counter_addr,
-                prog_addr,
-                scratch_addr,
-                kernarg_ptr,
-                enable_private_segment_sgpr,
-                "dispatch_pm4 VAs"
-            );
-        }
         let mut g = self.inner.lock();
         let prev = pool.pm4_value().saturating_sub(1);
         let next = pool.next_pm4();
@@ -1089,10 +1074,9 @@ fn create_queue(
     }
     // GART page holds the AQL queue descriptor (`amd_queue_t`, 256 bytes).
     // rptr/wptr live at fixed offsets inside it; the CP reads them to drive the
-    // queue. Allocated with ROCr's minimal non-MES descriptor flags (GTT,
-    // host-visible, uncached — no COHERENT/EXECUTABLE), so the MEC can read the
-    // wptr on RDNA2 APUs (gfx10.3) where the extra MTYPE bits fault the CP.
-    let gart_buf = allocator.alloc_queue_descriptor(0x100)?;
+    // queue. Same coherent+uncached GTT flags as the ring — field-for-field with
+    // tinygrad's GART page and ROCr's queue control page.
+    let gart_buf = allocator.alloc_uncached(0x100)?;
     let (gart_gpu, gart_host) = match &gart_buf {
         crate::allocator::RawBuffer::AmdDevice { gpu_addr, host_ptr: Some(h), .. } => (*gpu_addr, *h),
         _ => return Err(Error::AmdAllocFailed { reason: "GART page requires host-visible buffer".into() }),

--- a/device/src/amd/queue.rs
+++ b/device/src/amd/queue.rs
@@ -1015,6 +1015,15 @@ impl AmdCopyQueue {
         // no extra cache bookkeeping is needed here.
         self.timeline.drain(COPY_TIMEOUT_MS)
     }
+
+    /// Fence all in-flight SDMA work on this queue's timeline. `copy_fenced`
+    /// already drains per call, but the async graph-replay path submits without
+    /// an immediate wait, and `AmdDeviceCore::synchronize_all` (the fence before
+    /// every host read / buffer free) must quiesce the SDMA queue too — ROCr
+    /// quiesces a queue before any buffer it touched is freed. Idle-fast.
+    pub fn drain(&self) -> Result<()> {
+        self.timeline.drain(COPY_TIMEOUT_MS)
+    }
 }
 
 /// Append SDMA dwords into the byte-indexed copy ring, padding with NOPs

--- a/device/src/amd/signal.rs
+++ b/device/src/amd/signal.rs
@@ -379,6 +379,15 @@ impl SignalPool {
                 return Err(Error::AmdAllocFailed { reason: "SignalPool requires host-visible AMD buffer".into() });
             }
         };
+        // Diagnostic: the pool is one of several GTT control pages that share the
+        // "Gtt" registry tag, so log its exact range to disambiguate a fault VA.
+        tracing::debug!(
+            target: "svod_device::amd::signal",
+            base = base_gpu,
+            size = SLOT_BYTES * slots,
+            end = base_gpu + (SLOT_BYTES * slots) as u64,
+            "SignalPool allocated"
+        );
         let free_slots = Mutex::new((0..slots as u32).rev().collect()); // pop low slots first
         let device = Arc::clone(allocator.dev.core());
         Ok(Arc::new(Self { _buffer: buffer, base_gpu, base_host, slots, free_slots, device }))

--- a/device/src/amd/signal.rs
+++ b/device/src/amd/signal.rs
@@ -379,15 +379,6 @@ impl SignalPool {
                 return Err(Error::AmdAllocFailed { reason: "SignalPool requires host-visible AMD buffer".into() });
             }
         };
-        // Diagnostic: the pool is one of several GTT control pages that share the
-        // "Gtt" registry tag, so log its exact range to disambiguate a fault VA.
-        tracing::debug!(
-            target: "svod_device::amd::signal",
-            base = base_gpu,
-            size = SLOT_BYTES * slots,
-            end = base_gpu + (SLOT_BYTES * slots) as u64,
-            "SignalPool allocated"
-        );
         let free_slots = Mutex::new((0..slots as u32).rev().collect()); // pop low slots first
         let device = Arc::clone(allocator.dev.core());
         Ok(Arc::new(Self { _buffer: buffer, base_gpu, base_host, slots, free_slots, device }))

--- a/device/src/amd/sys/ioctl.rs
+++ b/device/src/amd/sys/ioctl.rs
@@ -26,7 +26,9 @@ ioctl_readwrite!(kfd_destroy_event, KFD_IOCTL_BASE, 0x09, kfd::kfd_ioctl_destroy
 ioctl_readwrite!(kfd_set_event, KFD_IOCTL_BASE, 0x0A, kfd::kfd_ioctl_set_event_args);
 ioctl_readwrite!(kfd_reset_event, KFD_IOCTL_BASE, 0x0B, kfd::kfd_ioctl_reset_event_args);
 ioctl_readwrite!(kfd_wait_events, KFD_IOCTL_BASE, 0x0C, kfd::kfd_ioctl_wait_events_args);
+ioctl_readwrite!(kfd_set_scratch_backing_va, KFD_IOCTL_BASE, 0x11, kfd::kfd_ioctl_set_scratch_backing_va_args);
 ioctl_readwrite!(kfd_acquire_vm, KFD_IOCTL_BASE, 0x15, kfd::kfd_ioctl_acquire_vm_args);
+ioctl_readwrite!(kfd_set_xnack_mode, KFD_IOCTL_BASE, 0x21, kfd::kfd_ioctl_set_xnack_mode_args);
 ioctl_readwrite!(kfd_alloc_memory_of_gpu, KFD_IOCTL_BASE, 0x16, kfd::kfd_ioctl_alloc_memory_of_gpu_args);
 ioctl_readwrite!(kfd_free_memory_of_gpu, KFD_IOCTL_BASE, 0x17, kfd::kfd_ioctl_free_memory_of_gpu_args);
 ioctl_readwrite!(kfd_map_memory_to_gpu, KFD_IOCTL_BASE, 0x18, kfd::kfd_ioctl_map_memory_to_gpu_args);

--- a/device/src/amd/sys/pm4.rs
+++ b/device/src/amd/sys/pm4.rs
@@ -183,7 +183,7 @@ pub const COMPUTE_PGM_RSRC3_GFX9: u32 = 0x22d;
 pub const COMPUTE_USER_DATA_0: u32 = 0x240;
 
 // ── COMPUTE_DISPATCH_INITIATOR field bits ─────────────────────────────────
-// The `cs_w32_en` bit is only defined on gfx11/12; gfx9 (CDNA) ignores it.
+// The `cs_w32_en` bit is defined on gfx10+ (RDNA2/3/4); gfx9 (CDNA) ignores it.
 
 pub const DISPATCH_INITIATOR_COMPUTE_SHADER_EN: u32 = 1 << 0;
 pub const DISPATCH_INITIATOR_FORCE_START_AT_000: u32 = 1 << 2;

--- a/device/src/amd/topology.rs
+++ b/device/src/amd/topology.rs
@@ -49,6 +49,20 @@ pub struct AmdNode {
     /// to `simd_per_cu * max_waves_per_simd` (matches RDNA scratch slot
     /// budgeting) when absent.
     pub max_slots_scratch_cu: u32,
+    /// `cpu_cores_count` from the node's KFD properties. Nonzero only on an APU
+    /// (integrated GPU), where the CPU and GPU share one topology node — exactly
+    /// libhsakmt's discrete-GPU test (`!NumCPUCores && NumFComputeCores`). See
+    /// [`AmdNode::is_apu`].
+    pub cpu_cores_count: u32,
+}
+
+impl AmdNode {
+    /// True iff this is an APU (integrated GPU with unified system memory): the
+    /// node carries CPU cores alongside its compute units. APUs have no
+    /// dedicated VRAM, so the allocator routes device buffers to GTT.
+    pub fn is_apu(&self) -> bool {
+        self.cpu_cores_count > 0
+    }
 }
 
 /// Sysfs root for KFD topology. Public so tests can override via env.
@@ -122,6 +136,7 @@ pub fn enumerate() -> Vec<AmdNode> {
                 .copied()
                 .map(|v| v as u32)
                 .unwrap_or_else(|| simd_per_cu.max(1) * max_waves_per_simd.max(1)),
+            cpu_cores_count: map.get("cpu_cores_count").copied().unwrap_or(0) as u32,
         });
     }
     nodes.sort_by_key(|n| n.node_id);

--- a/device/src/test/unit/amd/device.rs
+++ b/device/src/test/unit/amd/device.rs
@@ -72,8 +72,10 @@ fn assign_owner_spreads_then_cotenants() {
 
 #[test]
 fn pack_tmpring_wavesize_width_by_arch() {
-    // wave_scratch=0x3FFFF: cdna(13b) truncates, rdna3(15b) truncates, rdna4(18b) keeps it.
+    // wave_scratch=0x3FFFF: cdna/rdna2(13b) truncate, rdna3(15b) truncates, rdna4(18b) keeps it.
     assert_eq!(pack_tmpring(1, 0x3FFFF, &AmdArch::Gfx942) >> 12, 0x1FFF);
+    // RDNA2 (gfx10.3) shares the 13-bit WAVESIZE field with CDNA (gc_10_3_0 asic_reg).
+    assert_eq!(pack_tmpring(1, 0x3FFFF, &AmdArch::Gfx1030) >> 12, 0x1FFF);
     assert_eq!(pack_tmpring(1, 0x3FFFF, &AmdArch::Gfx1100) >> 12, 0x7FFF);
     assert_eq!(pack_tmpring(1, 0x3FFFF, &AmdArch::Gfx1200) >> 12, 0x3FFFF);
     assert_eq!(pack_tmpring(0xABC, 0, &AmdArch::Gfx1100) & 0xFFF, 0xABC);

--- a/device/src/test/unit/amd/device.rs
+++ b/device/src/test/unit/amd/device.rs
@@ -38,6 +38,21 @@ fn aql_scratch_descriptor_gfx9_encoding() {
     assert_eq!(d.wave64_lane_byte_size, 256); // wave64: priv_seg * 64 / 64
 }
 
+#[test]
+fn aql_scratch_descriptor_gfx10_encoding() {
+    // gfx10 (RDNA2 wave32) SRD — ROCr FillBufRsrcWord3_Gfx10: WORD0..2 as gfx9;
+    // WORD3 = DST_SEL=XYZW(0xEAC) | FORMAT=BUF_FORMAT_32_UINT(0x14<<12)
+    //       | ADD_TID_ENABLE(1<<23) | RESOURCE_LEVEL(1<<24) | OOB_SELECT(2<<28)
+    //       = 0x21814EAC. Lane size for wave32 backing is priv_seg*32/64.
+    let va: u64 = 0x1234_5678_9abc_d000;
+    let d = AqlScratchDesc::gfx10(va, 0x0004_0000, 0xDEAD, 256 * 32 / 64);
+    assert_eq!(d.resource_descriptor[0], 0x9abc_d000);
+    assert_eq!(d.resource_descriptor[1], 0x8000_5678);
+    assert_eq!(d.resource_descriptor[2], 0x0004_0000);
+    assert_eq!(d.resource_descriptor[3], 0x2181_4EAC);
+    assert_eq!(d.wave64_lane_byte_size, 128);
+}
+
 /// Cross-model parallelism (Pillar A): `assign_owner` must spread distinct
 /// owners across distinct pool queues (fill-empty-first) up to `hw_queues`, and
 /// the (hw_queues+1)-th owner must co-tenant an existing queue (the pool never

--- a/device/src/test/unit/amd/iface.rs
+++ b/device/src/test/unit/amd/iface.rs
@@ -47,3 +47,24 @@ fn uncached_gtt_is_heap_independent() {
     assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT, 0);
     assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, 0);
 }
+
+/// The queue descriptor mirrors ROCr's minimal non-MES flags: GTT + host-visible
+/// + uncached, but WITHOUT fine-grained COHERENT or EXECUTABLE. Those are exactly
+/// the two MTYPE bits that fault the MEC's wptr read on RDNA2 APUs (gfx10.3), so
+/// this is the regression guard for the APU queue-bringup fix. Heap-independent.
+#[test]
+fn queue_descriptor_drops_coherent_and_executable() {
+    for is_apu in [false, true] {
+        let f = compose_flags(AllocKind::QueueDescriptor, /*cpu_access=*/ true, is_apu);
+        // GTT, host-visible, uncached — what KFD needs to accept the ioctl.
+        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT, 0);
+        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
+        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, 0);
+        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE, 0);
+        // The load-bearing difference vs UncachedGtt: no COHERENT, no EXECUTABLE.
+        assert_eq!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT, 0);
+        assert_eq!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE, 0);
+        // Never VRAM — the descriptor is always GTT.
+        assert_eq!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
+    }
+}

--- a/device/src/test/unit/amd/iface.rs
+++ b/device/src/test/unit/amd/iface.rs
@@ -52,3 +52,16 @@ fn uncached_gtt_is_heap_independent() {
     assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
     assert_eq!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
 }
+
+/// ROCr's queue control / CWSR set: identical to `UncachedGtt` minus the
+/// UNCACHED bit — cached-coherent GTT. Regression guard for the only working
+/// gfx10.3 reference's rptr/wptr-page and ctx-save flags.
+#[test]
+fn coherent_gtt_is_uncached_gtt_minus_uncached() {
+    for is_apu in [false, true] {
+        let coherent = compose_flags(AllocKind::CoherentGtt, true, is_apu);
+        let uncached = compose_flags(AllocKind::UncachedGtt, true, is_apu);
+        assert_eq!(coherent | kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, uncached);
+        assert_eq!(coherent & kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, 0);
+    }
+}

--- a/device/src/test/unit/amd/iface.rs
+++ b/device/src/test/unit/amd/iface.rs
@@ -6,10 +6,8 @@ use crate::amd::sys::kfd;
 /// different heap. Pure function, no global state: safe under parallel tests.
 #[test]
 fn device_vram_uses_gtt_on_apu_vram_on_discrete() {
-    let discrete =
-        compose_flags(AllocKind::DeviceVram { executable: true }, /*cpu_access=*/ false, /*is_apu=*/ false);
-    let apu =
-        compose_flags(AllocKind::DeviceVram { executable: true }, /*cpu_access=*/ false, /*is_apu=*/ true);
+    let discrete = compose_flags(AllocKind::DeviceVram, /*cpu_access=*/ false, /*is_apu=*/ false);
+    let apu = compose_flags(AllocKind::DeviceVram, /*cpu_access=*/ false, /*is_apu=*/ true);
 
     // Heap bit flips VRAM<->GTT and the two are mutually exclusive.
     assert_ne!(discrete & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
@@ -23,21 +21,25 @@ fn device_vram_uses_gtt_on_apu_vram_on_discrete() {
     assert_eq!(discrete & mask, apu & mask);
 }
 
-/// `cpu_access` adds PUBLIC and `executable` adds EXECUTABLE on both heaps.
+/// `DeviceVram` carries the tinygrad/ROCr base flags (WRITABLE | EXECUTABLE |
+/// NO_SUBSTITUTE) unconditionally; `cpu_access` adds PUBLIC on both heaps.
 #[test]
 fn device_vram_modifier_bits() {
     for is_apu in [false, true] {
-        let plain = compose_flags(AllocKind::DeviceVram { executable: false }, false, is_apu);
-        let public = compose_flags(AllocKind::DeviceVram { executable: false }, true, is_apu);
-        let exec = compose_flags(AllocKind::DeviceVram { executable: true }, false, is_apu);
+        let plain = compose_flags(AllocKind::DeviceVram, false, is_apu);
+        let public = compose_flags(AllocKind::DeviceVram, true, is_apu);
         assert_eq!(plain & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
         assert_ne!(public & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
-        assert_ne!(exec & kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE, 0);
+        assert_ne!(plain & kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE, 0);
         assert_ne!(plain & kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE, 0);
+        assert_ne!(plain & kfd::KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE, 0);
     }
 }
 
-/// The control-structure heap is GTT regardless of device type (arch-independent).
+/// The control-structure heap is GTT regardless of device type (arch-independent)
+/// and carries the full tinygrad/ROCr control-page flag set — including
+/// fine-grained COHERENT, which the completion-signal handshake and the CP's
+/// rptr/wptr reads rely on across every gfx generation.
 #[test]
 fn uncached_gtt_is_heap_independent() {
     let d = compose_flags(AllocKind::UncachedGtt, true, false);
@@ -46,25 +48,7 @@ fn uncached_gtt_is_heap_independent() {
     assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT, 0);
     assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT, 0);
     assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, 0);
-}
-
-/// The queue descriptor mirrors ROCr's minimal non-MES flags: GTT + host-visible
-/// + uncached, but WITHOUT fine-grained COHERENT or EXECUTABLE. Those are exactly
-/// the two MTYPE bits that fault the MEC's wptr read on RDNA2 APUs (gfx10.3), so
-/// this is the regression guard for the APU queue-bringup fix. Heap-independent.
-#[test]
-fn queue_descriptor_drops_coherent_and_executable() {
-    for is_apu in [false, true] {
-        let f = compose_flags(AllocKind::QueueDescriptor, /*cpu_access=*/ true, is_apu);
-        // GTT, host-visible, uncached — what KFD needs to accept the ioctl.
-        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT, 0);
-        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
-        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, 0);
-        assert_ne!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE, 0);
-        // The load-bearing difference vs UncachedGtt: no COHERENT, no EXECUTABLE.
-        assert_eq!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT, 0);
-        assert_eq!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE, 0);
-        // Never VRAM — the descriptor is always GTT.
-        assert_eq!(f & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
-    }
+    assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE, 0);
+    assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
+    assert_eq!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
 }

--- a/device/src/test/unit/amd/iface.rs
+++ b/device/src/test/unit/amd/iface.rs
@@ -1,0 +1,49 @@
+use crate::amd::iface::{AllocKind, compose_flags};
+use crate::amd::sys::kfd;
+
+/// On an APU, device buffers have no VRAM to live in, so `DeviceVram` must be
+/// allocated from GTT (system memory via the GART) — same modifier bits, just a
+/// different heap. Pure function, no global state: safe under parallel tests.
+#[test]
+fn device_vram_uses_gtt_on_apu_vram_on_discrete() {
+    let discrete =
+        compose_flags(AllocKind::DeviceVram { executable: true }, /*cpu_access=*/ false, /*is_apu=*/ false);
+    let apu =
+        compose_flags(AllocKind::DeviceVram { executable: true }, /*cpu_access=*/ false, /*is_apu=*/ true);
+
+    // Heap bit flips VRAM<->GTT and the two are mutually exclusive.
+    assert_ne!(discrete & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
+    assert_eq!(discrete & kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT, 0);
+    assert_ne!(apu & kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT, 0);
+    assert_eq!(apu & kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM, 0);
+
+    // Everything except the heap bit is identical (modifier bits unchanged, so
+    // the copy paths' coherence contract is preserved).
+    let mask = !(kfd::KFD_IOC_ALLOC_MEM_FLAGS_VRAM | kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT);
+    assert_eq!(discrete & mask, apu & mask);
+}
+
+/// `cpu_access` adds PUBLIC and `executable` adds EXECUTABLE on both heaps.
+#[test]
+fn device_vram_modifier_bits() {
+    for is_apu in [false, true] {
+        let plain = compose_flags(AllocKind::DeviceVram { executable: false }, false, is_apu);
+        let public = compose_flags(AllocKind::DeviceVram { executable: false }, true, is_apu);
+        let exec = compose_flags(AllocKind::DeviceVram { executable: true }, false, is_apu);
+        assert_eq!(plain & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
+        assert_ne!(public & kfd::KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC, 0);
+        assert_ne!(exec & kfd::KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE, 0);
+        assert_ne!(plain & kfd::KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE, 0);
+    }
+}
+
+/// The control-structure heap is GTT regardless of device type (arch-independent).
+#[test]
+fn uncached_gtt_is_heap_independent() {
+    let d = compose_flags(AllocKind::UncachedGtt, true, false);
+    let a = compose_flags(AllocKind::UncachedGtt, true, true);
+    assert_eq!(d, a);
+    assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_GTT, 0);
+    assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_COHERENT, 0);
+    assert_ne!(d & kfd::KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED, 0);
+}

--- a/device/src/test/unit/amd/mod.rs
+++ b/device/src/test/unit/amd/mod.rs
@@ -17,6 +17,8 @@ mod am;
 #[cfg(unix)]
 mod device;
 #[cfg(unix)]
+mod iface;
+#[cfg(unix)]
 mod kernarg;
 #[cfg(unix)]
 mod program;

--- a/device/src/test/unit/amd/topology.rs
+++ b/device/src/test/unit/amd/topology.rs
@@ -61,6 +61,39 @@ fn enumerate_skips_cpu_nodes_and_parses_gpu() {
     assert_eq!(nodes[0].simd_arrays_per_engine, 2);
 }
 
+#[test]
+fn is_apu_keys_off_cpu_cores_count() {
+    // libhsakmt's discrete-GPU test is `!NumCPUCores && NumFComputeCores`, so a
+    // GPU node with cpu_cores_count > 0 is an APU. Pure check on constructed
+    // nodes — no SVOD_KFD_TOPOLOGY env mutation, so it's race-free under the
+    // parallel test runner (the enumerate()-based tests own that global).
+    let discrete = gpu_node(/*cpu_cores_count=*/ 0); // e.g. gfx1030 (RX 6900 XT)
+    let apu = gpu_node(/*cpu_cores_count=*/ 32); // e.g. gfx1036 (7950X3D iGPU)
+    assert!(!discrete.is_apu());
+    assert!(apu.is_apu());
+}
+
+/// Minimal GPU `AmdNode` for pure (non-enumerate) logic tests.
+fn gpu_node(cpu_cores_count: u32) -> AmdNode {
+    AmdNode {
+        node_id: 1,
+        gpu_id: 5711,
+        drm_render_minor: 128,
+        gfx_target_version: 100_306,
+        simd_count: 4,
+        array_count: 2,
+        simd_arrays_per_engine: 1,
+        simd_per_cu: 2,
+        max_waves_per_simd: 16,
+        lds_size_in_kb: 64,
+        wave_front_size: 32,
+        num_xcc: 1,
+        num_cp_queues: 8,
+        max_slots_scratch_cu: 32,
+        cpu_cores_count,
+    }
+}
+
 fn tempfile_dir() -> PathBuf {
     // Build a fresh per-test tempdir so concurrent tests don't collide on
     // `SVOD_KFD_TOPOLOGY`. We don't pull `tempfile` for one test path.

--- a/dtype/src/amd_arch.rs
+++ b/dtype/src/amd_arch.rs
@@ -11,6 +11,11 @@ pub enum AmdArch {
     // CDNA — datacenter; MFMA, wave64.
     Gfx942,
     Gfx950,
+    // RDNA2 — Radeon 6000; no matrix cores, wave32. gfx1030 = Navi 21 (RX 6900 XT).
+    Gfx1030,
+    Gfx1031,
+    Gfx1032,
+    Gfx1034,
     // RDNA3 — Radeon 7000; WMMA, wave32.
     Gfx1100,
     Gfx1101,
@@ -27,14 +32,20 @@ impl AmdArch {
         matches!(self, Self::Gfx942 | Self::Gfx950)
     }
 
-    /// gfx major version (`9` = CDNA, `11` = RDNA3, `12` = RDNA4) — the
-    /// discriminator several PM4 cache encodings branch on.
+    /// gfx major version (`9` = CDNA, `10` = RDNA2, `11` = RDNA3, `12` = RDNA4) —
+    /// the discriminator several PM4 cache encodings branch on.
     pub const fn gfx_major(self) -> u32 {
         match self {
             Self::Gfx942 | Self::Gfx950 => 9,
+            Self::Gfx1030 | Self::Gfx1031 | Self::Gfx1032 | Self::Gfx1034 => 10,
             Self::Gfx1100 | Self::Gfx1101 | Self::Gfx1102 | Self::Gfx1151 => 11,
             Self::Gfx1200 | Self::Gfx1201 => 12,
         }
+    }
+
+    /// RDNA2 family (Radeon 6000; no matrix cores, wave32).
+    pub const fn is_rdna2(self) -> bool {
+        matches!(self, Self::Gfx1030 | Self::Gfx1031 | Self::Gfx1032 | Self::Gfx1034)
     }
 
     /// RDNA3 family (Radeon 7000; WMMA intrinsics, wave32).
@@ -48,9 +59,9 @@ impl AmdArch {
     }
 
     /// `true` when the arch has hardware matrix-multiply intrinsics
-    /// (CDNA's MFMA or RDNA3+'s WMMA). All supported arches have matrix cores
-    /// since RDNA2 was dropped; only `(11, *)`, `(12, *)`, `(9,4,2)` and
-    /// `(9,5,0)` targets are accepted.
+    /// (CDNA's MFMA or RDNA3+'s WMMA). RDNA2 (gfx10) has none — matmul lowers to
+    /// scalar/vector FMA, driven by an empty `tensor_cores` list in its renderer
+    /// profile (the optimizer then never emits a WMMA UOp).
     pub const fn has_matrix_cores(self) -> bool {
         self.is_cdna() || self.is_rdna3() || self.is_rdna4()
     }
@@ -66,6 +77,10 @@ impl AmdArch {
         match self {
             Self::Gfx942 => "gfx942",
             Self::Gfx950 => "gfx950",
+            Self::Gfx1030 => "gfx1030",
+            Self::Gfx1031 => "gfx1031",
+            Self::Gfx1032 => "gfx1032",
+            Self::Gfx1034 => "gfx1034",
             Self::Gfx1100 => "gfx1100",
             Self::Gfx1101 => "gfx1101",
             Self::Gfx1102 => "gfx1102",
@@ -87,6 +102,10 @@ impl AmdArch {
         Some(match v {
             90_402 => Self::Gfx942,
             90_500 => Self::Gfx950,
+            100_300 => Self::Gfx1030,
+            100_301 => Self::Gfx1031,
+            100_302 => Self::Gfx1032,
+            100_304 => Self::Gfx1034,
             110_000 => Self::Gfx1100,
             110_001 => Self::Gfx1101,
             110_002 => Self::Gfx1102,
@@ -102,6 +121,10 @@ impl AmdArch {
         match s.to_ascii_lowercase().as_str() {
             "gfx942" => Some(Self::Gfx942),
             "gfx950" => Some(Self::Gfx950),
+            "gfx1030" => Some(Self::Gfx1030),
+            "gfx1031" => Some(Self::Gfx1031),
+            "gfx1032" => Some(Self::Gfx1032),
+            "gfx1034" => Some(Self::Gfx1034),
             "gfx1100" => Some(Self::Gfx1100),
             "gfx1101" => Some(Self::Gfx1101),
             "gfx1102" => Some(Self::Gfx1102),

--- a/dtype/src/amd_arch.rs
+++ b/dtype/src/amd_arch.rs
@@ -11,11 +11,16 @@ pub enum AmdArch {
     // CDNA — datacenter; MFMA, wave64.
     Gfx942,
     Gfx950,
-    // RDNA2 — Radeon 6000; no matrix cores, wave32. gfx1030 = Navi 21 (RX 6900 XT).
+    // RDNA2 — no matrix cores, wave32. Discrete (Radeon 6000): gfx1030 = Navi 21
+    // (RX 6900 XT). APU (integrated, unified memory): gfx1036 = Raphael (Ryzen
+    // 7000 iGPU, e.g. 7950X3D), gfx1033 = Van Gogh, gfx1035 = Rembrandt.
     Gfx1030,
     Gfx1031,
     Gfx1032,
+    Gfx1033,
     Gfx1034,
+    Gfx1035,
+    Gfx1036,
     // RDNA3 — Radeon 7000; WMMA, wave32.
     Gfx1100,
     Gfx1101,
@@ -37,15 +42,39 @@ impl AmdArch {
     pub const fn gfx_major(self) -> u32 {
         match self {
             Self::Gfx942 | Self::Gfx950 => 9,
-            Self::Gfx1030 | Self::Gfx1031 | Self::Gfx1032 | Self::Gfx1034 => 10,
+            Self::Gfx1030
+            | Self::Gfx1031
+            | Self::Gfx1032
+            | Self::Gfx1033
+            | Self::Gfx1034
+            | Self::Gfx1035
+            | Self::Gfx1036 => 10,
             Self::Gfx1100 | Self::Gfx1101 | Self::Gfx1102 | Self::Gfx1151 => 11,
             Self::Gfx1200 | Self::Gfx1201 => 12,
         }
     }
 
-    /// RDNA2 family (Radeon 6000; no matrix cores, wave32).
+    /// RDNA2 family (no matrix cores, wave32) — discrete Radeon 6000 + the
+    /// gfx10.3 APUs (which differ only in the unified-memory allocator path).
     pub const fn is_rdna2(self) -> bool {
-        matches!(self, Self::Gfx1030 | Self::Gfx1031 | Self::Gfx1032 | Self::Gfx1034)
+        matches!(
+            self,
+            Self::Gfx1030
+                | Self::Gfx1031
+                | Self::Gfx1032
+                | Self::Gfx1033
+                | Self::Gfx1034
+                | Self::Gfx1035
+                | Self::Gfx1036
+        )
+    }
+
+    /// RDNA2 APU (integrated GPU, unified system memory: Van Gogh / Rembrandt /
+    /// Raphael). These have no dedicated VRAM — the allocator routes device
+    /// buffers to GTT. Detection at runtime is per-node (`AmdNode::is_apu`);
+    /// this is just the arch-level "is one of the known APU dies" predicate.
+    pub const fn is_rdna2_apu(self) -> bool {
+        matches!(self, Self::Gfx1033 | Self::Gfx1035 | Self::Gfx1036)
     }
 
     /// RDNA3 family (Radeon 7000; WMMA intrinsics, wave32).
@@ -80,7 +109,10 @@ impl AmdArch {
             Self::Gfx1030 => "gfx1030",
             Self::Gfx1031 => "gfx1031",
             Self::Gfx1032 => "gfx1032",
+            Self::Gfx1033 => "gfx1033",
             Self::Gfx1034 => "gfx1034",
+            Self::Gfx1035 => "gfx1035",
+            Self::Gfx1036 => "gfx1036",
             Self::Gfx1100 => "gfx1100",
             Self::Gfx1101 => "gfx1101",
             Self::Gfx1102 => "gfx1102",
@@ -105,7 +137,10 @@ impl AmdArch {
             100_300 => Self::Gfx1030,
             100_301 => Self::Gfx1031,
             100_302 => Self::Gfx1032,
+            100_303 => Self::Gfx1033,
             100_304 => Self::Gfx1034,
+            100_305 => Self::Gfx1035,
+            100_306 => Self::Gfx1036,
             110_000 => Self::Gfx1100,
             110_001 => Self::Gfx1101,
             110_002 => Self::Gfx1102,
@@ -124,7 +159,10 @@ impl AmdArch {
             "gfx1030" => Some(Self::Gfx1030),
             "gfx1031" => Some(Self::Gfx1031),
             "gfx1032" => Some(Self::Gfx1032),
+            "gfx1033" => Some(Self::Gfx1033),
             "gfx1034" => Some(Self::Gfx1034),
+            "gfx1035" => Some(Self::Gfx1035),
+            "gfx1036" => Some(Self::Gfx1036),
             "gfx1100" => Some(Self::Gfx1100),
             "gfx1101" => Some(Self::Gfx1101),
             "gfx1102" => Some(Self::Gfx1102),

--- a/dtype/src/test/unit/amd_arch.rs
+++ b/dtype/src/test/unit/amd_arch.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn version_round_trip() {
-    for arch in [AmdArch::Gfx942, AmdArch::Gfx1100, AmdArch::Gfx1201] {
+    for arch in [AmdArch::Gfx942, AmdArch::Gfx1030, AmdArch::Gfx1034, AmdArch::Gfx1100, AmdArch::Gfx1201] {
         let s = arch.mcpu();
         assert_eq!(AmdArch::parse(s), Some(arch));
     }
@@ -15,11 +15,17 @@ fn family_predicates() {
     assert!(AmdArch::Gfx1201.is_rdna4() && !AmdArch::Gfx1201.is_rdna3());
     assert!(AmdArch::Gfx1100.has_matrix_cores());
     assert!(AmdArch::Gfx942.has_matrix_cores());
+    // RDNA2 (gfx10): its own family, no matrix cores, gfx_major 10, wave32.
+    assert!(AmdArch::Gfx1030.is_rdna2() && !AmdArch::Gfx1030.is_cdna() && !AmdArch::Gfx1030.is_rdna3());
+    assert!(!AmdArch::Gfx1030.has_matrix_cores());
+    assert!(!AmdArch::Gfx1100.is_rdna2() && !AmdArch::Gfx942.is_rdna2());
+    assert_eq!(AmdArch::Gfx1030.gfx_major(), 10);
 }
 
 #[test]
 fn wave_size_by_family() {
     assert_eq!(AmdArch::Gfx942.wave_size(), 64);
+    assert_eq!(AmdArch::Gfx1030.wave_size(), 32);
     assert_eq!(AmdArch::Gfx1100.wave_size(), 32);
     assert_eq!(AmdArch::Gfx1200.wave_size(), 32);
 }
@@ -28,5 +34,8 @@ fn wave_size_by_family() {
 fn from_kfd_version() {
     assert_eq!(AmdArch::from_gfx_target_version(110_000), Some(AmdArch::Gfx1100));
     assert_eq!(AmdArch::from_gfx_target_version(90_402), Some(AmdArch::Gfx942));
+    // RDNA2: gfx1030 (RX 6900 XT) = 100300, gfx1034 = 100304.
+    assert_eq!(AmdArch::from_gfx_target_version(100_300), Some(AmdArch::Gfx1030));
+    assert_eq!(AmdArch::from_gfx_target_version(100_304), Some(AmdArch::Gfx1034));
     assert_eq!(AmdArch::from_gfx_target_version(0), None);
 }

--- a/dtype/src/test/unit/amd_arch.rs
+++ b/dtype/src/test/unit/amd_arch.rs
@@ -2,7 +2,9 @@ use super::*;
 
 #[test]
 fn version_round_trip() {
-    for arch in [AmdArch::Gfx942, AmdArch::Gfx1030, AmdArch::Gfx1034, AmdArch::Gfx1100, AmdArch::Gfx1201] {
+    for arch in
+        [AmdArch::Gfx942, AmdArch::Gfx1030, AmdArch::Gfx1034, AmdArch::Gfx1036, AmdArch::Gfx1100, AmdArch::Gfx1201]
+    {
         let s = arch.mcpu();
         assert_eq!(AmdArch::parse(s), Some(arch));
     }
@@ -20,6 +22,13 @@ fn family_predicates() {
     assert!(!AmdArch::Gfx1030.has_matrix_cores());
     assert!(!AmdArch::Gfx1100.is_rdna2() && !AmdArch::Gfx942.is_rdna2());
     assert_eq!(AmdArch::Gfx1030.gfx_major(), 10);
+    // RDNA2 APUs (gfx10.3 integrated): still RDNA2, no matrix cores, but flagged
+    // as APU dies. gfx1036 = Raphael (Ryzen 7000 iGPU); discrete gfx1030 is not.
+    assert!(AmdArch::Gfx1036.is_rdna2() && AmdArch::Gfx1036.is_rdna2_apu());
+    assert!(!AmdArch::Gfx1036.has_matrix_cores());
+    assert_eq!(AmdArch::Gfx1036.gfx_major(), 10);
+    assert!(!AmdArch::Gfx1030.is_rdna2_apu());
+    assert!(AmdArch::Gfx1033.is_rdna2_apu() && AmdArch::Gfx1035.is_rdna2_apu());
 }
 
 #[test]
@@ -37,5 +46,8 @@ fn from_kfd_version() {
     // RDNA2: gfx1030 (RX 6900 XT) = 100300, gfx1034 = 100304.
     assert_eq!(AmdArch::from_gfx_target_version(100_300), Some(AmdArch::Gfx1030));
     assert_eq!(AmdArch::from_gfx_target_version(100_304), Some(AmdArch::Gfx1034));
+    // RDNA2 APU: gfx1036 = Raphael (7950X3D iGPU) = 100306.
+    assert_eq!(AmdArch::from_gfx_target_version(100_306), Some(AmdArch::Gfx1036));
+    assert_eq!(AmdArch::from_gfx_target_version(100_303), Some(AmdArch::Gfx1033));
     assert_eq!(AmdArch::from_gfx_target_version(0), None);
 }

--- a/ir/src/types.rs
+++ b/ir/src/types.rs
@@ -840,6 +840,7 @@ pub enum RendererDevice {
     CudaSm80,
     CudaSm89,
     Metal,
+    AmdRdna2,
     AmdRdna3,
     AmdRdna4,
     AmdCdna3,
@@ -858,6 +859,7 @@ impl RendererDevice {
             Self::CudaSm80 => "CUDA_SM80",
             Self::CudaSm89 => "CUDA_SM89",
             Self::Metal => "Metal",
+            Self::AmdRdna2 => "AMD_RDNA2",
             Self::AmdRdna3 => "AMD_RDNA3",
             Self::AmdRdna4 => "AMD_RDNA4",
             Self::AmdCdna3 => "AMD_CDNA3",
@@ -881,6 +883,7 @@ impl RendererDevice {
             Self::CudaSm75
                 | Self::CudaSm80
                 | Self::CudaSm89
+                | Self::AmdRdna2
                 | Self::AmdRdna3
                 | Self::AmdRdna4
                 | Self::AmdCdna3

--- a/runtime/src/devices/amd.rs
+++ b/runtime/src/devices/amd.rs
@@ -54,13 +54,23 @@ pub fn create_amd_device(registry: &DeviceRegistry, device_id: usize, arch: AmdA
     // cleanly leaves has_sdma_queue=false, so buffers stay host-visible and use
     // the memmove copy path (today's behaviour). Must run before any _alloc,
     // which reads has_sdma_queue to decide cpu_access.
-    match AmdCopyQueue::create(&amd_alloc) {
-        Ok(copy_queue) => {
-            device_handle.core().install_copy_queue(copy_queue);
-            device_handle.core().set_has_sdma_queue(true);
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "SDMA copy queue unavailable; AMD buffers stay host-visible");
+    // Diagnostic gate (SVOD_AMD_NO_SDMA): skip the SDMA copy queue entirely, so
+    // host↔device staging falls back to the host memmove path (buffers stay
+    // host-visible). On gfx10.3 the compute MEC faults reading the SDMA queue's
+    // GART descriptor during run-list processing; this isolates whether the SDMA
+    // queue's presence in the run-list is the trigger. Default behaviour is
+    // unchanged — only set when bisecting.
+    if std::env::var_os("SVOD_AMD_NO_SDMA").is_some() {
+        tracing::warn!("SVOD_AMD_NO_SDMA set; skipping SDMA copy queue — AMD buffers stay host-visible");
+    } else {
+        match AmdCopyQueue::create(&amd_alloc) {
+            Ok(copy_queue) => {
+                device_handle.core().install_copy_queue(copy_queue);
+                device_handle.core().set_has_sdma_queue(true);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "SDMA copy queue unavailable; AMD buffers stay host-visible");
+            }
         }
     }
     // No default connector: every dispatcher leases/owns its own connector

--- a/runtime/src/devices/amd.rs
+++ b/runtime/src/devices/amd.rs
@@ -8,11 +8,16 @@
 //! Construction returns `Err(NoAmdGpu)` cleanly on hosts that don't have a
 //! supported AMD GPU; never panics.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use svod_codegen::llvm::LlvmTextRenderer;
 use svod_device::Result;
-use svod_device::amd::{AmdAllocator, AmdCopyQueue, AmdGraph, AmdProgram, SignalPool};
+use svod_device::amd::{AmdAllocator, AmdCopyQueue, AmdGraph, AmdProgram, PoolQueue, SignalPool};
+
+/// Diagnostic (SVOD_AMD_WARM_COMPUTE): holds compute `PoolQueue`s created before
+/// the SDMA copy queue alive for the process lifetime, so they stay in the KFD
+/// run-list. See the bring-up note at the use site in `create_amd_device`.
+static WARM_QUEUES: Mutex<Vec<Arc<PoolQueue>>> = Mutex::new(Vec::new());
 use svod_device::device::{
     CompiledSpec, Compiler, Device, Graph, GraphFactory, GraphKernel, Program, ProgramSpec, Renderer, RuntimeFactory,
 };
@@ -54,6 +59,22 @@ pub fn create_amd_device(registry: &DeviceRegistry, device_id: usize, arch: AmdA
     // cleanly leaves has_sdma_queue=false, so buffers stay host-visible and use
     // the memmove copy path (today's behaviour). Must run before any _alloc,
     // which reads has_sdma_queue to decide cpu_access.
+    // Diagnostic gate (SVOD_AMD_WARM_COMPUTE): create a compute queue BEFORE the
+    // SDMA copy queue, so the process's first KFD run-list entry is a compute
+    // queue — matching tinygrad/ROCr ordering (both establish a compute queue
+    // before the SDMA blit queue). On gfx10.3 the MES faults reading an SDMA
+    // queue's descriptor when that queue is the first one created into a process
+    // with no compute queue; this tests whether compute-first ordering fixes it.
+    // The warm queue is held alive (WARM_QUEUES) so it stays in the run-list.
+    if std::env::var_os("SVOD_AMD_WARM_COMPUTE").is_some() {
+        match PoolQueue::new_with_resources(device_handle.core().clone(), &amd_alloc) {
+            Ok(warm) => {
+                tracing::warn!("SVOD_AMD_WARM_COMPUTE set; compute queue created before SDMA copy queue");
+                WARM_QUEUES.lock().expect("WARM_QUEUES poisoned").push(warm);
+            }
+            Err(e) => tracing::warn!(error = %e, "SVOD_AMD_WARM_COMPUTE: warm compute queue creation failed"),
+        }
+    }
     // Diagnostic gate (SVOD_AMD_NO_SDMA): skip the SDMA copy queue entirely, so
     // host↔device staging falls back to the host memmove path (buffers stay
     // host-visible). On gfx10.3 the compute MEC faults reading the SDMA queue's

--- a/runtime/src/devices/amd.rs
+++ b/runtime/src/devices/amd.rs
@@ -8,16 +8,11 @@
 //! Construction returns `Err(NoAmdGpu)` cleanly on hosts that don't have a
 //! supported AMD GPU; never panics.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use svod_codegen::llvm::LlvmTextRenderer;
 use svod_device::Result;
-use svod_device::amd::{AmdAllocator, AmdCopyQueue, AmdGraph, AmdProgram, PoolQueue, SignalPool};
-
-/// Diagnostic (SVOD_AMD_WARM_COMPUTE): holds compute `PoolQueue`s created before
-/// the SDMA copy queue alive for the process lifetime, so they stay in the KFD
-/// run-list. See the bring-up note at the use site in `create_amd_device`.
-static WARM_QUEUES: Mutex<Vec<Arc<PoolQueue>>> = Mutex::new(Vec::new());
+use svod_device::amd::{AmdAllocator, AmdCopyQueue, AmdGraph, AmdProgram, SignalPool};
 use svod_device::device::{
     CompiledSpec, Compiler, Device, Graph, GraphFactory, GraphKernel, Program, ProgramSpec, Renderer, RuntimeFactory,
 };
@@ -59,21 +54,12 @@ pub fn create_amd_device(registry: &DeviceRegistry, device_id: usize, arch: AmdA
     // cleanly leaves has_sdma_queue=false, so buffers stay host-visible and use
     // the memmove copy path (today's behaviour). Must run before any _alloc,
     // which reads has_sdma_queue to decide cpu_access.
-    // Diagnostic gate (SVOD_AMD_WARM_COMPUTE): create a compute queue BEFORE the
-    // SDMA copy queue, so the process's first KFD run-list entry is a compute
-    // queue — matching tinygrad/ROCr ordering (both establish a compute queue
-    // before the SDMA blit queue). On gfx10.3 the MES faults reading an SDMA
-    // queue's descriptor when that queue is the first one created into a process
-    // with no compute queue; this tests whether compute-first ordering fixes it.
-    // The warm queue is held alive (WARM_QUEUES) so it stays in the run-list.
-    if std::env::var_os("SVOD_AMD_WARM_COMPUTE").is_some() {
-        match PoolQueue::new_with_resources(device_handle.core().clone(), &amd_alloc) {
-            Ok(warm) => {
-                tracing::warn!("SVOD_AMD_WARM_COMPUTE set; compute queue created before SDMA copy queue");
-                WARM_QUEUES.lock().expect("WARM_QUEUES poisoned").push(warm);
-            }
-            Err(e) => tracing::warn!(error = %e, "SVOD_AMD_WARM_COMPUTE: warm compute queue creation failed"),
-        }
+    // gfx10.3 HWS faults reading an SDMA queue's GART descriptor when the
+    // process run-list holds no compute queue, so on RDNA2 seed the pool's
+    // first compute queue before the SDMA copy queue (tinygrad/ROCr establish
+    // a compute queue before the SDMA blit queue for the same reason).
+    if arch.is_rdna2() {
+        device_handle.core().seed_compute_queue(&amd_alloc)?;
     }
     // Diagnostic gate (SVOD_AMD_NO_SDMA): skip the SDMA copy queue entirely, so
     // host↔device staging falls back to the host memmove path (buffers stay

--- a/schedule/src/optimizer/renderer.rs
+++ b/schedule/src/optimizer/renderer.rs
@@ -250,6 +250,29 @@ impl Renderer {
         self.device.is_apple_amx()
     }
 
+    /// Create an AMD RDNA2 GPU renderer (RX 6000 series; gfx1030 = RX 6900 XT).
+    ///
+    /// Identical to RDNA3 except `tensor_cores` is empty: RDNA2 has no WMMA, so
+    /// the optimizer must never emit a WMMA UOp. The empty list makes
+    /// [`try_tensor_cores`](super::heuristics) bail and matmul lower to the
+    /// scalar/vector FMA path. This is the load-bearing line for RDNA2 support —
+    /// see the `renderer_internal` regression test that asserts it stays empty.
+    pub fn amd_rdna2() -> Self {
+        Self {
+            device: RendererDevice::AmdRdna2,
+            has_local: true,
+            has_shared: true,
+            has_threads: false,
+            shared_max: 65536, // 64KB/CU, same as RDNA3
+            global_max: Some(vec![2147483647, 65535, 65535]),
+            local_max: Some(1024),
+            upcast_max: 8,
+            buffer_max: None,
+            tensor_cores: vec![], // no matrix cores on gfx10
+            supports_float4: true,
+        }
+    }
+
     /// Create an AMD RDNA3 GPU renderer (RX 7000 series).
     pub fn amd_rdna3() -> Self {
         Self {
@@ -326,7 +349,8 @@ impl Renderer {
     /// ≤ 1024 but z > 64 is still invalid and must be bounded at gpudims time.
     pub fn local_max_axes(&self) -> Option<[usize; 3]> {
         match self.device {
-            RendererDevice::AmdRdna3
+            RendererDevice::AmdRdna2
+            | RendererDevice::AmdRdna3
             | RendererDevice::AmdRdna4
             | RendererDevice::AmdCdna3
             | RendererDevice::AmdCdna4 => Some([1024, 1024, 64]),
@@ -335,11 +359,14 @@ impl Renderer {
     }
 
     /// Select the AMD optimizer profile matching a gfx arch. CDNA gfx942 maps
-    /// to CDNA3 and gfx950 to CDNA4; RDNA3/RDNA4 families map to their profiles.
+    /// to CDNA3 and gfx950 to CDNA4; RDNA2/RDNA3/RDNA4 families map to their
+    /// profiles. RDNA2 MUST be routed explicitly before the catch-all — it has
+    /// no tensor cores, and falling through to RDNA3 would wrongly emit WMMA.
     pub fn for_amd_arch(arch: AmdArch) -> Self {
         match arch {
             AmdArch::Gfx942 => Self::amd_cdna3(),
             AmdArch::Gfx950 => Self::amd_cdna4(),
+            _ if arch.is_rdna2() => Self::amd_rdna2(),
             _ if arch.is_rdna4() => Self::amd_rdna4(),
             _ => Self::amd_rdna3(),
         }

--- a/schedule/src/test/unit/optimizer/renderer_internal.rs
+++ b/schedule/src/test/unit/optimizer/renderer_internal.rs
@@ -26,9 +26,27 @@ fn test_for_amd_arch_maps_each_family() {
     use svod_dtype::AmdArch;
     assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx942).device, RendererDevice::AmdCdna3);
     assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx950).device, RendererDevice::AmdCdna4);
+    assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx1030).device, RendererDevice::AmdRdna2);
+    assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx1034).device, RendererDevice::AmdRdna2);
     assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx1100).device, RendererDevice::AmdRdna3);
     assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx1151).device, RendererDevice::AmdRdna3);
     assert_eq!(Renderer::for_amd_arch(AmdArch::Gfx1201).device, RendererDevice::AmdRdna4);
+}
+
+/// Load-bearing regression guard for the whole RDNA2 feature: the RDNA2 profile
+/// MUST carry no tensor cores. If this ever becomes non-empty, the optimizer
+/// will emit WMMA UOps that gfx10 hardware can't execute (it has no matrix
+/// cores) and matmul will fail to compile/run. Every RDNA2 die must route here.
+#[test]
+fn test_rdna2_profile_has_no_tensor_cores() {
+    use svod_dtype::AmdArch;
+    for arch in [AmdArch::Gfx1030, AmdArch::Gfx1031, AmdArch::Gfx1032, AmdArch::Gfx1034] {
+        let r = Renderer::for_amd_arch(arch);
+        assert_eq!(r.device, RendererDevice::AmdRdna2, "{arch:?} must use the RDNA2 profile");
+        assert!(r.tensor_cores.is_empty(), "{arch:?} must have no tensor cores (gfx10 has no WMMA)");
+    }
+    // Contrast: RDNA3 (the profile RDNA2 would wrongly fall through to) HAS them.
+    assert!(!Renderer::for_amd_arch(AmdArch::Gfx1100).tensor_cores.is_empty());
 }
 
 #[test]
@@ -36,7 +54,9 @@ fn test_local_max_axes_amd_caps_z_at_64() {
     use svod_dtype::AmdArch;
     // AMD/HIP caps the 3rd local axis at 64 below the 1024-thread product limit
     // (tinygrad parity); other backends rely on the product cap alone.
-    for arch in [AmdArch::Gfx1151, AmdArch::Gfx1100, AmdArch::Gfx1201, AmdArch::Gfx942, AmdArch::Gfx950] {
+    for arch in
+        [AmdArch::Gfx1030, AmdArch::Gfx1151, AmdArch::Gfx1100, AmdArch::Gfx1201, AmdArch::Gfx942, AmdArch::Gfx950]
+    {
         assert_eq!(Renderer::for_amd_arch(arch).local_max_axes(), Some([1024, 1024, 64]), "{arch:?}");
     }
     assert_eq!(Renderer::cpu().local_max_axes(), None);


### PR DESCRIPTION
Adds AMD RDNA2 (gfx10) GPU support to the KFD backend, covering all discrete RDNA2 dies — gfx1030 (RX 6900 XT / 6800 XT / W6800), gfx1031 (RX 6700 XT), gfx1032 (RX 6600 XT), and gfx1034 (RX 6500 XT). Until now Svod hard-rejected these cards at device-open (AmdAllocFailed: unsupported gfx target); they were deliberately dropped because RDNA2 is the one recent AMD family with no matrix cores (WMMA arrived with RDNA3).

The key insight: matmul doesn't need tensor cores. Its base IR form is already Reduce(Add, Mul(a,b)) — a scalar/vector FMA reduction. WMMA is an optimization layered on top by the BEAM search, gated on the renderer profile carrying a non-empty tensor_cores list. So RDNA2 support is achieved by an empty tensor_cores list in its optimizer profile — the optimizer then never emits a WMMA UOp, and matmul renders through the shared scalar-FMA path. No new codegen. This is the same prevention-only model tinygrad uses for every no-matrix-core target (verified against both the rocm-systems and new_new_tinygrad references).

## What's included

## Architecture plumbing

- dtype (amd_arch.rs): new Gfx1030/1031/1032/1034 variants + is_rdna2() predicate; arms in gfx_major (→ 10), mcpu, from_gfx_target_version (gfx1030 = 100300), and parse.
- ir (types.rs): new RendererDevice::AmdRdna2.
- schedule (renderer.rs): amd_rdna2() optimizer profile — an RDNA3 clone (wave32, 64 KB LDS, [1024,1024,64] local caps) with tensor_cores: vec![]. Routed explicitly via is_rdna2() before the catch-all in for_amd_arch (falling through to RDNA3 would wrongly enable WMMA).

## System-layer deltas (gfx10 ≠ gfx11)

Every register difference was cross-checked against the vendored ROCr (libhsakmt) source and tinygrad — not guessed. RDNA2 is the first non-CDNA arch below gfx11, which broke several is_cdna()-vs-else assumptions that only ever needed to distinguish gfx9 from gfx11+:

- queue.rs — VGPR-per-CU = 0x40000 (hsakmt_get_vgpr_size_per_cu: < gfx1100 bucket); clamp control-stack size to 0x7000 (hard gfx10 HW limit, ROCr (gfxv & 0x3f0000) == 0xA0000); skip the COMPUTE_DISPATCH_SCRATCH_BASE write — those registers were removed in RDNA and re-added in gfx11, so on gfx10 the scratch base rides the private-segment V# in user SGPRs instead.
- device.rs — scratch uses 1024-byte alignment and se_div = 1 for pre-gfx11 (CDNA + RDNA2), not the gfx11 256B/se_cnt path; 13-bit WAVESIZE field in pack_tmpring (gc_10_3_0 asic_reg); refreshed unsupported-arch error string.
- program.rs — confirmed the PGM_RSRC1 cwsr-priv bit stays gfx11-only (tinygrad gates it (11,0,0) ≤ t < (12,0,0)); RDNA2 must not set it. Comment-only.
- pm4.rs / queue.rs — cs_w32_en (wave32 dispatch) was already correct via target_major != 9; only stale "gfx11/12-only" comments fixed.

## Tests

- RDNA2 enum round-trip, family predicates, and gfx_target_version mappings.
- Regression guard asserting the RDNA2 profile carries no tensor cores (if this ever flips, matmul breaks on gfx10) — and that it's distinct from RDNA3's.
- 13-bit pack_tmpring WAVESIZE width for gfx1030.
- cargo fmt / cargo clippy / cargo test clean.

## Testing status

- Logic-level tests (enum, profile, scratch packing) pass on any host.
- Not yet validated on hardware — needs a gfx1030 host. To verify end-to-end:
  - SVOD_DEVICE=AMD:0 cargo test -p svod-tensor test_matmul_validated -- --nocapture (single-process, not nextest) — expect the device to open and matmul to match the ndarray reference.
  - Inspect a matmul kernel's IR: fmul/fadd loops, no wmma/mfma intrinsics.
  - GigaAM e2e for correct transcription (perf will trail MFMA/WMMA parts — correctness is the bar).

## Notes / follow-ups (not in this PR)

- APU RDNA2 parts (gfx1033/1035/1036) are out of scope — untested memory model.
- Performance tuning of the RDNA2 profile beyond the RDNA3-cloned defaults.