### PR TITLE
model/rnnt: WIND windowed RN-T decoding + in-place state recycle for the GigaAM block decoderI'

### DIFF
--- a/arch/src/rnnt.rs
+++ b/arch/src/rnnt.rs
@@ -230,9 +230,17 @@ pub struct BlockTapes<'a> {
 
 /// Device-resident block decode: every state (per-lane time/prev/symbols +
 /// predictor state) lives on the device; one `run_block` advances all lanes
-/// [`block_steps`](Self::block_steps) label-looping steps and the host only
-/// reads the token tape. Greedy semantics per lane are identical to
-/// [`BatchLabelStep`].
+/// [`block_steps`](Self::block_steps) decode steps and the host only reads the
+/// token tape. Greedy semantics per lane are identical to [`BatchLabelStep`].
+///
+/// The device implementation (`svod_model::gigaam::rnnt::block::forward_block`)
+/// uses WIND windowed non-blank detection: each step evaluates the joint over a
+/// window of frames against the fixed predictor state and jumps to the first
+/// non-blank. For this static-shape, masked-execution runtime that subsumes
+/// label-looping — collapsing blank runs into a single step cuts the wasted
+/// predictor/joint evaluations a per-frame loop spends on blanks, plus host
+/// syncs — at byte-identical output (this trait's contract is unchanged: one
+/// tape entry per lane per step, `emit`-flagged emissions at `frames`).
 pub trait BatchBlockStep {
     /// Backend-specific error (typically a JIT execution error).
     type Error: std::error::Error + Send + Sync + 'static;

--- a/arch/src/rnnt.rs
+++ b/arch/src/rnnt.rs
@@ -236,11 +236,11 @@ pub struct BlockTapes<'a> {
 /// The device implementation (`svod_model::gigaam::rnnt::block::forward_block`)
 /// uses WIND windowed non-blank detection: each step evaluates the joint over a
 /// window of frames against the fixed predictor state and jumps to the first
-/// non-blank. For this static-shape, masked-execution runtime that subsumes
-/// label-looping — collapsing blank runs into a single step cuts the wasted
-/// predictor/joint evaluations a per-frame loop spends on blanks, plus host
-/// syncs — at byte-identical output (this trait's contract is unchanged: one
-/// tape entry per lane per step, `emit`-flagged emissions at `frames`).
+/// non-blank. On this static-shape, masked-execution runtime WIND subsumes
+/// label-looping — collapsing a blank run into one step cuts the predictor/joint
+/// evaluations and host syncs a per-frame loop spends on blanks — at
+/// byte-identical output. The trait contract is unchanged: one tape entry per
+/// lane per step, `emit`-flagged emissions at `frames`.
 pub trait BatchBlockStep {
     /// Backend-specific error (typically a JIT execution error).
     type Error: std::error::Error + Send + Sync + 'static;

--- a/arch/src/test/unit/rnnt.rs
+++ b/arch/src/test/unit/rnnt.rs
@@ -3,7 +3,9 @@ use std::convert::Infallible;
 
 use proptest::prelude::*;
 
-use crate::rnnt::{BatchJointStep, BatchLabelStep, JointStep, RnntDecoder, RnntOpts, TokenEmission, Word};
+use crate::rnnt::{
+    BatchBlockStep, BatchJointStep, BatchLabelStep, BlockTapes, JointStep, RnntDecoder, RnntOpts, TokenEmission, Word,
+};
 
 /// NaN-safe argmax — the device backend computes the joint argmax on-GPU and
 /// returns the index; the mock mirrors that over its scripted logits. NaN is
@@ -178,6 +180,168 @@ impl BatchLabelStep for MockBatchLabelStep {
     fn reset(&mut self) {
         self.resets += 1;
         self.cursors.fill(0);
+    }
+}
+
+/// Device-block mock: a plain-Rust transcription of the WIND device
+/// `forward_block` per-step greedy logic (`model/src/gigaam/rnnt/block.rs`),
+/// driven by the same per-lane token-id scripts as [`MockBatchLabelStep`]. Each
+/// `run_block` advances every lane `block_steps` window steps and fills the
+/// lane-major `[lanes * block_steps]` tapes the host consumer reads.
+///
+/// Per step, an in-bounds lane evaluates the joint over a window of `window`
+/// frames against the FIXED predictor state and jumps to the first non-blank:
+/// it scans the leading blanks (advancing `time`), and on the first non-blank
+/// emits one token at that frame (a jump to a fresh frame resets the same-frame
+/// run length; the `max_symbols` cap then forces a single-frame advance). An
+/// all-blank window advances `time` by the in-bounds run length. Each step
+/// produces exactly one tape entry per lane (the device's single windowed op),
+/// so the blank frames skipped within a step never cost a tape slot — the WIND
+/// win. `window == 1` reduces to the per-frame baseline.
+///
+/// The script is consumed along the greedy path: `first_nb + 1` tokens on an
+/// emit step (leading blanks + the emit) and the in-bounds blank count on an
+/// all-blank step — identical total consumption to [`MockBatchLabelStep`], so
+/// transcripts match regardless of `window` or `block_steps`.
+struct MockBatchBlockStep {
+    scripts: Vec<Vec<usize>>,
+    cursors: Vec<usize>,
+    valid: Vec<usize>,
+    blank: usize,
+    max_symbols: usize,
+    block_steps: usize,
+    window: usize,
+    // Carried per-lane state (device-resident on a real backend).
+    time: Vec<usize>,
+    prev: Vec<usize>,
+    symbols: Vec<usize>,
+    // Tape buffers, reused each block; lane-major `[lanes * block_steps]`.
+    tokens: Vec<i32>,
+    emit: Vec<i32>,
+    frames: Vec<i32>,
+    pub resets: usize,
+}
+
+impl MockBatchBlockStep {
+    fn new(
+        scripts: Vec<Vec<usize>>,
+        valid: Vec<usize>,
+        blank: usize,
+        max_symbols: usize,
+        block_steps: usize,
+        window: usize,
+    ) -> Self {
+        let lanes = scripts.len();
+        assert_eq!(valid.len(), lanes, "MockBatchBlockStep: one valid length per lane");
+        let cap = lanes * block_steps;
+        Self {
+            scripts,
+            cursors: vec![0; lanes],
+            valid,
+            blank,
+            max_symbols: max_symbols.max(1),
+            block_steps,
+            window: window.max(1),
+            time: vec![0; lanes],
+            prev: vec![blank; lanes],
+            symbols: vec![0; lanes],
+            tokens: vec![0; cap],
+            emit: vec![0; cap],
+            frames: vec![0; cap],
+            resets: 0,
+        }
+    }
+
+    /// Peek the scripted argmax `ahead` frames into lane `i`'s window without
+    /// advancing the cursor (clamps at the script end like the other mocks).
+    fn peek(&self, lane: usize, ahead: usize) -> usize {
+        let sc = &self.scripts[lane];
+        sc[(self.cursors[lane] + ahead).min(sc.len() - 1)]
+    }
+}
+
+impl BatchBlockStep for MockBatchBlockStep {
+    type Error = Infallible;
+
+    fn batch(&self) -> usize {
+        self.scripts.len()
+    }
+
+    fn block_steps(&self) -> usize {
+        self.block_steps
+    }
+
+    fn run_block(&mut self) -> Result<BlockTapes<'_>, Self::Error> {
+        let lanes = self.scripts.len();
+        let k = self.block_steps;
+        let w = self.window;
+        for s in 0..k {
+            for i in 0..lanes {
+                let j = i * k + s;
+                let in_bounds = self.time[i] < self.valid[i];
+                // safe_t = time when in bounds, else last (valid - 1); recorded
+                // on the frame tape (filtered by emit == 0 when out of bounds).
+                let safe_t = if in_bounds { self.time[i] as i64 } else { self.valid[i] as i64 - 1 };
+                if !in_bounds {
+                    self.tokens[j] = 0;
+                    self.emit[j] = 0;
+                    self.frames[j] = safe_t as i32;
+                    continue;
+                }
+                // Scan the window against the fixed state: leading blanks, then
+                // the first non-blank. `consumed` counts script tokens on the
+                // greedy path (the off-path window tail is never consumed).
+                let mut consumed = 0usize;
+                let mut emit_off: Option<usize> = None;
+                while consumed < w && self.time[i] + consumed < self.valid[i] {
+                    let tok = self.peek(i, consumed);
+                    consumed += 1;
+                    if tok != self.blank {
+                        emit_off = Some(consumed - 1);
+                        break;
+                    }
+                }
+                self.cursors[i] += consumed;
+                if let Some(off) = emit_off {
+                    let tok = self.scripts[i][(self.cursors[i] - 1).min(self.scripts[i].len() - 1)];
+                    let frame = self.time[i] + off;
+                    self.tokens[j] = tok as i32;
+                    self.emit[j] = 1;
+                    self.frames[j] = frame as i32;
+                    self.prev[i] = tok;
+                    // A jump to a fresh frame (off >= 1) resets the same-frame
+                    // counter before counting this emission.
+                    let sym_base = if off >= 1 { 0 } else { self.symbols[i] };
+                    let symbols1 = sym_base + 1;
+                    self.time[i] += off;
+                    if symbols1 >= self.max_symbols {
+                        self.time[i] += 1; // cap forces a single-frame advance
+                        self.symbols[i] = 0;
+                    } else {
+                        self.symbols[i] = symbols1;
+                    }
+                } else {
+                    // All in-bounds window frames blank: advance by the run length
+                    // (= min(window, valid - time)); one inert tape entry.
+                    self.tokens[j] = 0;
+                    self.emit[j] = 0;
+                    self.frames[j] = safe_t as i32;
+                    self.time[i] += consumed;
+                    self.symbols[i] = 0;
+                }
+            }
+        }
+        let active_any = (0..lanes).any(|i| self.time[i] < self.valid[i]);
+        Ok(BlockTapes { tokens: &self.tokens, emit: &self.emit, frames: &self.frames, active_any })
+    }
+
+    fn reset(&mut self) -> Result<(), Self::Error> {
+        self.resets += 1;
+        self.cursors.fill(0);
+        self.time.fill(0);
+        self.symbols.fill(0);
+        self.prev.fill(self.blank);
+        Ok(())
     }
 }
 
@@ -532,6 +696,54 @@ fn test_rnnt_labels_predictor_runs_only_on_emission_rounds() {
     assert_eq!(labels.predicts, 3);
 }
 
+// ─── decode_batch_blocks ──────────────────────────────────────────────────
+
+/// The WIND device-block loop must reproduce label-looping (and hence lockstep)
+/// exactly: identical texts and `(token_id, frame)` emissions per lane,
+/// independent of the block stride OR the decode window. Pins the device
+/// `forward_block` behavior, which had no isolated test.
+fn assert_blocks_match_labels(
+    scripts: Vec<Vec<usize>>,
+    valid_frames: Vec<usize>,
+    max_symbols: usize,
+    block_steps: usize,
+    window: usize,
+) {
+    let decoder = decoder_with(abc_vocab(), max_symbols);
+
+    let mut labels = MockBatchLabelStep::new(scripts.clone());
+    let expected = decoder.decode_batch_labels(&valid_frames, &mut labels).unwrap();
+
+    let mut blocks =
+        MockBatchBlockStep::new(scripts, valid_frames.clone(), decoder.blank_id(), max_symbols, block_steps, window);
+    let got = decoder.decode_batch_blocks(&valid_frames, &mut blocks).unwrap();
+    assert_eq!(blocks.resets, 1, "exactly one reset per decode");
+
+    assert_eq!(got, expected, "block stride {block_steps}, window {window}");
+}
+
+#[test_case::test_case(vec![vec![0, 3, 1, 3], vec![3; 4], vec![0, 1, 2, 0, 1, 2, 3, 3, 3]], vec![2, 1, 3], 2; "ragged with cap")]
+#[test_case::test_case(vec![vec![3; 8]], vec![8], 10; "blank only")]
+#[test_case::test_case(vec![vec![0, 1, 2, 3], vec![2, 3, 1, 3]], vec![2, 2], 10; "multi emit")]
+#[test_case::test_case(vec![vec![0, 3], vec![0, 3]], vec![1, 0], 10; "zero valid lane")]
+// WIND-specific subtleties the window scan must get right at W in {2,4,8}:
+#[test_case::test_case(vec![vec![3; 10]], vec![10], 10; "blank run longer than window")]
+#[test_case::test_case(vec![vec![3, 3, 3, 0, 3]], vec![5], 10; "first nonblank at last window offset")]
+#[test_case::test_case(vec![vec![3, 3, 0]], vec![3], 10; "emit at valid-1 window spills past valid")]
+#[test_case::test_case(vec![vec![3, 3, 0]], vec![4], 1; "jumped then cap")]
+#[test_case::test_case(vec![vec![0, 0, 0, 3]], vec![1], 2; "same-frame multi emit cap inside window")]
+fn test_rnnt_blocks_match_labels(scripts: Vec<Vec<usize>>, valid: Vec<usize>, max_symbols: usize) {
+    // The stride is a host-readback knob and the window is the WIND blank-skip
+    // width; equivalence must hold for every combination, including strides that
+    // split a frame's multi-emit run across block boundaries and windows that
+    // span more than a full blank run.
+    for block_steps in [1, 3, 16] {
+        for window in [1, 2, 4, 8] {
+            assert_blocks_match_labels(scripts.clone(), valid.clone(), max_symbols, block_steps, window);
+        }
+    }
+}
+
 // ─── frames_to_words ──────────────────────────────────────────────────────
 
 fn em(token_id: usize, frame: usize) -> TokenEmission {
@@ -651,6 +863,42 @@ proptest! {
             scripts.push(script);
         }
         assert_batch_matches_b1(scripts, valid, max_symbols);
+    }
+
+    /// WIND device-block decode ≡ label-looping decode for random scripts,
+    /// ragged frame counts, block strides, and decode windows. Pins
+    /// `forward_block` against the reference greedy loop without a GPU.
+    #[test]
+    fn prop_rnnt_blocks_match_labels(
+        n_lanes in 1usize..6,
+        max_symbols in 1usize..4,
+        block_steps in 1usize..6,
+        window in 1usize..9,
+        seed in any::<u64>(),
+    ) {
+        let blank = abc_vocab().len();
+        let mut state = seed;
+        let mut scripts = Vec::with_capacity(n_lanes);
+        let mut valid = Vec::with_capacity(n_lanes);
+        for _ in 0..n_lanes {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            let frames = ((state >> 32) % 8) as usize; // 0..8 frames per lane
+            valid.push(frames);
+            // Enough tokens to cover the worst case (every frame caps): the
+            // mock clamps the cursor at the end regardless.
+            let mut script = Vec::with_capacity(frames * max_symbols + 1);
+            for _ in 0..(frames * max_symbols + 1) {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                let pick = if (state >> 32) % 5 < 3 { blank } else { ((state >> 32) % 3) as usize };
+                script.push(pick);
+            }
+            scripts.push(script);
+        }
+        // All-zero-valid is handled by an early return in the driver; skip it so
+        // the reset-count assertion stays meaningful.
+        if valid.iter().any(|&v| v > 0) {
+            assert_blocks_match_labels(scripts, valid, max_symbols, block_steps, window);
+        }
     }
 
     /// Timestamps are non-decreasing and each frame index is in `[0, valid_frames)`.

--- a/model/src/gigaam/rnnt/block.rs
+++ b/model/src/gigaam/rnnt/block.rs
@@ -1,15 +1,32 @@
-//! K-step device-resident RNN-T decode block (NeMo FULL_GRAPH analog).
+//! K-step device-resident RNN-T decode block (NeMo FULL_GRAPH analog) with
+//! WIND windowed non-blank detection.
 //!
-//! [`forward_block`] traces [`BLOCK_STEPS`] label-looping steps with all
-//! state on-device and masked `where` everywhere (the predictor runs
-//! unconditionally; non-emitting lanes keep their committed state). The host
-//! reads one token tape per block. No runtime vars — everything concrete, so
-//! the plan graph-captures into one submit.
+//! [`forward_block`] traces [`BLOCK_STEPS`] decode steps with all state
+//! on-device and masked `where` everywhere (the predictor runs unconditionally;
+//! non-emitting lanes keep their committed state). The host reads one token tape
+//! per block. No runtime vars — everything concrete, so the plan graph-captures
+//! into one submit.
 //!
-//! Per step (identical greedy semantics to `decode_batch_labels`):
-//! tok = joint(enc[time], g) → emit = in_bounds & !blank →
-//! prev/state where-commit → symbols run length, cap forces advance →
-//! time += blank|cap; tapes record (tok, emit, time-before-advance).
+//! Each step evaluates the joint over a window of [`WIND_W`] frames against the
+//! FIXED predictor state and jumps to the first non-blank (WIND, arXiv
+//! 2505.13765). This is an exact reformulation of greedy decoding — for a fixed
+//! predictor state every frame before the first non-blank is provably blank, so
+//! skipping them matches frame-by-frame decoding — and it subsumes label-looping
+//! for this architecture: by collapsing a blank run into one step it cuts the
+//! predictor/joint evaluations and host syncs that a per-frame loop spends on
+//! blanks. `WIND_W == 1` is the per-frame baseline; the output is byte-identical
+//! across windows (verified against `decode_batch_labels` in the arch tests).
+//!
+//! Per step (identical greedy semantics to `decode_batch_labels` for any window):
+//! toks = joint(enc[time .. time+W], g) → first usable (in-bounds, non-blank)
+//! offset → emit one token there, prev/state where-commit, symbols run length +
+//! cap → time jumps past the leading blanks (or the whole blank window);
+//! tapes record (token, emit, emission-frame).
+//!
+//! On-device control flow the runtime lacks (a data-dependent while-loop, e.g.
+//! CUDA-graph conditional nodes) would remove the per-block host readback
+//! entirely; that is out of scope here — the host drives the block loop on the
+//! `active_any` flag.
 
 use snafu::ResultExt;
 use svod_dtype::DType;
@@ -22,6 +39,12 @@ use crate::gigaam::model::GigaAm;
 /// Decode steps per block execute. Amortizes the per-block readback; bounds
 /// the unrolled plan (~40 kernels/step).
 pub(crate) const BLOCK_STEPS: usize = 16;
+
+/// WIND window: frames the joint evaluates per step against the fixed predictor
+/// state, jumping `time` to the first non-blank (or by `WIND_W` if all blank).
+/// `1` is the per-frame baseline (byte-identical to the pre-WIND block); larger
+/// windows skip blank runs in one step. See [`forward_block`].
+pub(crate) const WIND_W: usize = 1;
 
 /// Tapes + carried state from one block trace; flat tuple keyed by
 /// `RnntBlockJit`'s output order.
@@ -40,6 +63,7 @@ pub(crate) fn forward_block(
     valid: &Tensor,
     h: &Tensor,
     c: &Tensor,
+    window: usize,
 ) -> Result<BlockOutputs> {
     let t = |r: std::result::Result<Tensor, svod_tensor::error::Error>| r.context(TensorSnafu);
     let (head, runtime) = model.head.expect_rnnt("RnntBlockJit")?;
@@ -50,6 +74,18 @@ pub(crate) fn forward_block(
     let (b, j) = (shape[0].as_const().expect("B concrete") as isize, shape[2].as_const().expect("J concrete") as isize);
     let valid64 = t(valid.cast(DType::Int64))?;
     let last = t(valid64.try_sub(&Tensor::from_slice([1i64])))?;
+    // Window offsets `[0, W)` as a row vector, broadcast onto each lane's frame
+    // cursor. At `window == 1` the window collapses to the single current frame
+    // and every step below reduces to the per-frame greedy update.
+    let window = window.max(1);
+    let w = window as isize;
+    let arange_w = {
+        let a = Tensor::arange(0, Some(window as i64), Some(1)).context(TensorSnafu)?;
+        t(t(a.cast(DType::Int64))?.try_reshape([1, w]))?
+    };
+    let w_const = Tensor::from_slice([window as i64]);
+    let zeros_i32 = Tensor::from_slice([0i32]);
+    let zeros_i64 = Tensor::from_slice([0i64]);
 
     let (mut time, mut prev, mut symbols, mut h, mut c) =
         (time.clone(), prev.clone(), symbols.clone(), h.clone(), c.clone());
@@ -58,36 +94,66 @@ pub(crate) fn forward_block(
     for _ in 0..BLOCK_STEPS {
         let in_bounds = t(time.try_lt(&valid64))?; // [B,1] bool
         // Clamp the gather index for finished lanes (mask restores correctness).
-        let safe_t = t(time.where_(&in_bounds, &last))?;
-        let idx = t(t(safe_t.try_reshape([b, 1, 1]))?.try_expand([b, 1, j]))?;
-        let enc_t = t(enc_proj.gather(1, &idx))?; // [B,1,J]
+        let safe_t = t(time.where_(&in_bounds, &last))?; // [B,1] i64
+        // Joint over a window of W frames against the FIXED predictor state:
+        // build `[safe_t, safe_t+W)`, clamp each row into a legal gather index
+        // (off-window / finished rows are masked out via `off_valid` below).
+        let win_t = t(safe_t.try_add(&arange_w))?; // [B,W]
+        let win_clamp = t(win_t.minimum(&last))?; // [B,W]
+        let idx = t(t(win_clamp.try_reshape([b, w, 1]))?.try_expand([b, w, j]))?;
+        let enc_window = t(enc_proj.gather(1, &idx))?; // [B,W,J]
 
         let (g, new_h, new_c) = head.predictor.forward_parts(&prev, &h, &c)?;
-        let tok = head.joint.argmax_preproj(&enc_t, &g)?; // [B,1] i32
-        let tok64 = t(tok.cast(DType::Int64))?;
+        // `argmax_preproj` broadcasts the `[B,1,J]` predictor projection over the
+        // window axis, so the same call serves W=1 and W>1.
+        let toks = head.joint.argmax_preproj(&enc_window, &g)?; // [B,W] i32
+        let tok64 = t(toks.cast(DType::Int64))?;
 
-        let is_blank = t(tok64.try_eq(&Tensor::from_slice([blank])))?;
+        let is_blank = t(tok64.try_eq(&Tensor::from_slice([blank])))?; // [B,W]
         let not_blank = t(is_blank.logical_not())?;
-        let emit = t(t(in_bounds.cast(DType::Bool))?.try_bitand(&not_blank))?; // [B,1]
+        // A window offset is usable only if it maps to a real (in-bounds) frame.
+        let off_valid = t(t(time.try_add(&arange_w))?.try_lt(&valid64))?; // [B,W]
+        let usable_i32 = t(t(off_valid.try_bitand(&not_blank))?.cast(DType::Int32))?; // [B,W] {0,1}
+        let any_nb = t(usable_i32.max_with().axes(1isize).keepdim(true).call())?; // [B,1]
+        let emit = t(any_nb.try_ge(&Tensor::from_slice([1i32])))?; // [B,1] bool
+        // argmax ties resolve to the first index → first usable (non-blank) offset
+        // (0 when none, which `emit == false` masks out).
+        let first_nb = t(usable_i32.argmax_with().axis(Some(1isize)).keepdim(true).call())?; // [B,1] i32
+        let first_nb64 = t(first_nb.cast(DType::Int64))?;
+        let tok_sel = t(tok64.gather(1, &first_nb64))?; // [B,1] i64 — token at the first non-blank
 
-        prev = t(tok64.where_(&emit, &prev))?;
+        // Commit the selected token + predictor state on emitting lanes.
+        prev = t(tok_sel.where_(&emit, &prev))?;
         // Commit state for emitting lanes: [B,1,L*P] → [L,B,P], masked.
         let emit_lbp = t(t(emit.try_reshape([1, b, 1]))?.try_expand([l, b, p]))?;
         let to_lbp = |s: Tensor| t(t(t(s.try_reshape([b, l, p]))?.try_permute(&[1, 0, 2]))?.try_reshape([l, b, p]));
         h = t(to_lbp(new_h)?.where_(&emit_lbp, &h))?;
         c = t(to_lbp(new_c)?.where_(&emit_lbp, &c))?;
 
-        let symbols1 = t(t(symbols.try_add(&Tensor::from_slice([1i32])))?.where_(&emit, &symbols))?;
+        // Same-frame run length: a window jump lands on a fresh frame, so reset
+        // the counter before this emission; the cap then forces a single-frame
+        // advance exactly as the per-frame loop does.
+        let jumped = t(emit.try_bitand(&t(first_nb64.try_ge(&Tensor::from_slice([1i64])))?))?;
+        let sym_base = t(zeros_i32.where_(&jumped, &symbols))?;
+        let symbols1 = t(t(sym_base.try_add(&Tensor::from_slice([1i32])))?.where_(&emit, &sym_base))?;
         let cap = t(symbols1.try_ge(&Tensor::from_slice([max_symbols as i32])))?;
-        let blank_adv = t(t(in_bounds.cast(DType::Bool))?.try_bitand(&is_blank))?;
-        let adv = t(blank_adv.try_bitor(&t(emit.try_bitand(&cap))?))?;
-        time = t(time.try_add(&t(adv.cast(DType::Int64))?))?;
-        let zeros = Tensor::zeros(&[b as usize, 1], DType::Int32).context(TensorSnafu)?;
-        symbols = t(zeros.where_(&adv, &symbols1))?;
+        // Advance time: jump past the leading blanks (emit at `first_nb`) or the
+        // whole in-bounds window (all blank), clamped so time never overshoots
+        // valid; the cap adds the extra single-frame step after a capped emit.
+        let rem = t(valid64.try_sub(&time))?;
+        let blank_run = t(t(rem.maximum(&zeros_i64))?.minimum(&w_const))?;
+        let blank_skip = t(first_nb64.where_(&emit, &blank_run))?;
+        let cap_adv = t(t(emit.try_bitand(&cap))?.cast(DType::Int64))?;
+        time = t(t(time.try_add(&blank_skip))?.try_add(&cap_adv))?;
+        let adv_frame = t(t(t(in_bounds.cast(DType::Bool))?.try_bitand(&t(emit.logical_not())?))?.try_bitor(&cap))?;
+        symbols = t(zeros_i32.where_(&adv_frame, &symbols1))?;
 
-        tapes.push(tok);
+        // Emission frame = safe_t + first_nb on emit (the jumped frame); the
+        // value is filtered out by `emit == 0` otherwise.
+        let frame_tape = t(safe_t.try_add(&t(first_nb64.where_(&emit, &zeros_i64))?))?;
+        tapes.push(t(tok_sel.cast(DType::Int32))?);
         emits.push(t(emit.cast(DType::Int32))?);
-        frames.push(t(safe_t.cast(DType::Int32))?);
+        frames.push(t(frame_tape.cast(DType::Int32))?);
     }
 
     let cat = |v: &[Tensor]| t(Tensor::cat(&v.iter().collect::<Vec<_>>(), 1)); // [B,K]

--- a/model/src/gigaam/rnnt/block.rs
+++ b/model/src/gigaam/rnnt/block.rs
@@ -47,12 +47,15 @@ pub(crate) const BLOCK_STEPS: usize = 16;
 pub(crate) const WIND_W: usize = 1;
 
 /// Tapes + carried state from one block trace; flat tuple keyed by
-/// `RnntBlockJit`'s output order.
+/// `RnntBlockJit`'s output order. Outputs 5-8 (`time/prev/symbols/h/c`) are
+/// in-place `assign`s back into the matching input buffers, so `execute()`
+/// recycles state on-device with no copy; only the 4 tape/flag outputs are read.
 pub(crate) type BlockOutputs = (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor);
 
 /// `enc_proj [B, T, J]` (pre-projected encoder, [`super::joint::RnntJoint::project_encoder`]), `time/prev [B,1] i64`, `symbols/valid [B,1] i32`,
 /// `h/c [L, B, P]` → `(tape, emit, frame [B,K] i32, active_any [1,1] i32,
-/// time, prev, symbols, h, c)`.
+/// time, prev, symbols, h, c)` where the last five are in-place writes into the
+/// input buffers (the carried state recycles without a device→device copy).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn forward_block(
     model: &GigaAm,
@@ -87,8 +90,12 @@ pub(crate) fn forward_block(
     let zeros_i32 = Tensor::from_slice([0i32]);
     let zeros_i64 = Tensor::from_slice([0i64]);
 
+    // Keep handles to the input-buffer tensors: the final carried state is
+    // written back into them in place (`assign`) at block end, so the next
+    // block reads updated state with no device→device recycle copy.
+    let (in_time, in_prev, in_symbols, in_h, in_c) = (time, prev, symbols, h, c);
     let (mut time, mut prev, mut symbols, mut h, mut c) =
-        (time.clone(), prev.clone(), symbols.clone(), h.clone(), c.clone());
+        (in_time.clone(), in_prev.clone(), in_symbols.clone(), in_h.clone(), in_c.clone());
     let (mut tapes, mut emits, mut frames) = (Vec::new(), Vec::new(), Vec::new());
 
     for _ in 0..BLOCK_STEPS {
@@ -161,5 +168,26 @@ pub(crate) fn forward_block(
     let active_any =
         t(t(t(active.cast(DType::Int32))?.sum_with().axes(0isize).keepdim(true).call())?.try_reshape([1, 1]))?;
 
-    Ok((cat(&tapes)?, cat(&emits)?, cat(&frames)?, active_any, time, prev, symbols, h, c))
+    // Carried-state outputs are in-place writes into the input buffers:
+    // `AFTER(in_buf, STORE(in_buf, final))`. The captured plan stores the final
+    // state where step 0 read it (read-before-write is safe — the inputs are
+    // read only at step 0), so `execute()` recycles state in place and the host
+    // never copies output→input between blocks. A fresh tensor on the input's
+    // buffer UOp carries the store, leaving the JIT's input handle untouched.
+    let assign_back = |input: &Tensor, value: Tensor| -> Result<Tensor> {
+        let out = Tensor::from_lazy(input.uop());
+        out.try_assign(&value).context(TensorSnafu)?;
+        Ok(out)
+    };
+    Ok((
+        cat(&tapes)?,
+        cat(&emits)?,
+        cat(&frames)?,
+        active_any,
+        assign_back(in_time, time)?,
+        assign_back(in_prev, prev)?,
+        assign_back(in_symbols, symbols)?,
+        assign_back(in_h, h)?,
+        assign_back(in_c, c)?,
+    ))
 }

--- a/model/src/gigaam/rnnt/block.rs
+++ b/model/src/gigaam/rnnt/block.rs
@@ -7,15 +7,17 @@
 //! per block. No runtime vars — everything concrete, so the plan graph-captures
 //! into one submit.
 //!
-//! Each step evaluates the joint over a window of [`WIND_W`] frames against the
-//! FIXED predictor state and jumps to the first non-blank (WIND, arXiv
-//! 2505.13765). This is an exact reformulation of greedy decoding — for a fixed
-//! predictor state every frame before the first non-blank is provably blank, so
-//! skipping them matches frame-by-frame decoding — and it subsumes label-looping
-//! for this architecture: by collapsing a blank run into one step it cuts the
+//! Each step evaluates the joint over a window of `W` frames (the
+//! [`forward_block`] const generic) against the FIXED predictor state and jumps
+//! to the first non-blank (WIND, arXiv 2505.13765). This is an exact
+//! reformulation of greedy decoding — for a fixed predictor state every frame
+//! before the first non-blank is provably blank, so skipping them matches
+//! frame-by-frame decoding — and it subsumes label-looping for this
+//! architecture: by collapsing a blank run into one step it cuts the
 //! predictor/joint evaluations and host syncs that a per-frame loop spends on
-//! blanks. `WIND_W == 1` is the per-frame baseline; the output is byte-identical
-//! across windows (verified against `decode_batch_labels` in the arch tests).
+//! blanks. `W == 1` is the per-frame baseline; the output is byte-identical
+//! across windows (verified against `decode_batch_labels` in the arch tests),
+//! so `W` is a pure performance knob whose optimum shifts with the GPU.
 //!
 //! Per step (identical greedy semantics to `decode_batch_labels` for any window):
 //! toks = joint(enc[time .. time+W], g) → first usable (in-bounds, non-blank)
@@ -40,14 +42,8 @@ use crate::gigaam::model::GigaAm;
 /// the unrolled plan (~40 kernels/step).
 pub(crate) const BLOCK_STEPS: usize = 16;
 
-/// WIND window: frames the joint evaluates per step against the fixed predictor
-/// state, jumping `time` to the first non-blank (or by `WIND_W` if all blank).
-/// `1` is the per-frame baseline (byte-identical to the pre-WIND block); larger
-/// windows skip blank runs in one step. See [`forward_block`].
-pub(crate) const WIND_W: usize = 1;
-
 /// Tapes + carried state from one block trace; flat tuple keyed by
-/// `RnntBlockJit`'s output order. Outputs 5-8 (`time/prev/symbols/h/c`) are
+/// `RnntBlockJit`'s output order. Outputs 4-8 (`time/prev/symbols/h/c`) are
 /// in-place `assign`s back into the matching input buffers, so `execute()`
 /// recycles state on-device with no copy; only the 4 tape/flag outputs are read.
 pub(crate) type BlockOutputs = (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor);
@@ -57,7 +53,7 @@ pub(crate) type BlockOutputs = (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, 
 /// time, prev, symbols, h, c)` where the last five are in-place writes into the
 /// input buffers (the carried state recycles without a device→device copy).
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn forward_block(
+pub(crate) fn forward_block<const W: usize>(
     model: &GigaAm,
     enc_proj: &Tensor,
     time: &Tensor,
@@ -66,8 +62,8 @@ pub(crate) fn forward_block(
     valid: &Tensor,
     h: &Tensor,
     c: &Tensor,
-    window: usize,
 ) -> Result<BlockOutputs> {
+    const { assert!(W >= 1, "WIND window W must be >= 1") };
     let t = |r: std::result::Result<Tensor, svod_tensor::error::Error>| r.context(TensorSnafu);
     let (head, runtime) = model.head.expect_rnnt("RnntBlockJit")?;
     let max_symbols = runtime.max_symbols_per_step.max(1);
@@ -78,15 +74,14 @@ pub(crate) fn forward_block(
     let valid64 = t(valid.cast(DType::Int64))?;
     let last = t(valid64.try_sub(&Tensor::from_slice([1i64])))?;
     // Window offsets `[0, W)` as a row vector, broadcast onto each lane's frame
-    // cursor. At `window == 1` the window collapses to the single current frame
-    // and every step below reduces to the per-frame greedy update.
-    let window = window.max(1);
-    let w = window as isize;
+    // cursor. At `W == 1` the window collapses to the single current frame and
+    // every step below reduces to the per-frame greedy update.
+    let w = W as isize;
     let arange_w = {
-        let a = Tensor::arange(0, Some(window as i64), Some(1)).context(TensorSnafu)?;
+        let a = Tensor::arange(0, Some(W as i64), Some(1)).context(TensorSnafu)?;
         t(t(a.cast(DType::Int64))?.try_reshape([1, w]))?
     };
-    let w_const = Tensor::from_slice([window as i64]);
+    let w_const = Tensor::from_slice([W as i64]);
     let zeros_i32 = Tensor::from_slice([0i32]);
     let zeros_i64 = Tensor::from_slice([0i64]);
 

--- a/model/src/gigaam/rnnt/block_backend.rs
+++ b/model/src/gigaam/rnnt/block_backend.rs
@@ -12,16 +12,15 @@ use super::block::BLOCK_STEPS;
 use super::jit::{RnntBlockJit, RnntEncProjJit};
 use crate::gigaam::model::GigaAm;
 
-/// Output order of `RnntBlockJit`.
+/// Read-back output positions of `RnntBlockJit`. The remaining outputs
+/// (`time/prev/symbols/h/c`, positions 4-8) are in-place writes back into the
+/// JIT's own input buffers (`forward_block` ends each carried state with
+/// `assign`), so the block recycles state on-device with no copy — those
+/// positions are never read out here.
 const TAPE_OUT: usize = 0;
 const EMIT_OUT: usize = 1;
 const FRAME_OUT: usize = 2;
 const ANY_OUT: usize = 3;
-const TIME_OUT: usize = 4;
-const PREV_OUT: usize = 5;
-const SYMBOLS_OUT: usize = 6;
-const H_OUT: usize = 7;
-const C_OUT: usize = 8;
 
 pub struct RnntBlockBackend {
     jit: RnntBlockJit,
@@ -45,11 +44,17 @@ pub struct RnntBlockBackend {
 #[derive(Default, Clone, Debug)]
 pub struct BlockStats {
     pub n_blocks: u64,
-    /// Real (non-blank) emissions across all blocks. Total executed steps are
-    /// `n_blocks * BLOCK_STEPS`; the gap to `steps_emitted` is the blank-advance
-    /// + finished-lane overhead a wider window cuts down.
+    /// Real (non-blank) emissions counted over the full `lanes * BLOCK_STEPS`
+    /// tape, across all blocks — i.e. total emitted tokens (window-invariant).
+    /// Compare against `n_blocks * lanes * BLOCK_STEPS` (tape slots) for the
+    /// useful fraction; the per-lane step count `n_blocks * BLOCK_STEPS` is the
+    /// separate lever a wider window cuts.
     pub steps_emitted: u64,
     pub t_exec: std::time::Duration,
+    /// Always ~0 now: carried state recycles in place inside `execute()` (the
+    /// plan stores `time/prev/symbols/h/c` back into its own input buffers), so
+    /// there is no host-issued output→input copy. Kept as a log signal that the
+    /// in-place recycle is active.
     pub t_recycle: std::time::Duration,
     pub t_read: std::time::Duration,
 }
@@ -139,16 +144,11 @@ impl BatchBlockStep for RnntBlockBackend {
 
     fn run_block(&mut self) -> Result<BlockTapes<'_>, Self::Error> {
         let t0 = std::time::Instant::now();
+        // `execute()` recycles carried state in place: the plan's `time/prev/
+        // symbols/h/c` outputs `assign` back into its own input buffers, so the
+        // next block reads updated state with no host-issued copy.
         self.jit.execute()?;
         let t1 = std::time::Instant::now();
-
-        // Recycle carried state on-device for the next block.
-        self.jit.copy_output_to_time(TIME_OUT, 0, 0, self.lanes * 8)?;
-        self.jit.copy_output_to_prev(PREV_OUT, 0, 0, self.lanes * 8)?;
-        self.jit.copy_output_to_symbols(SYMBOLS_OUT, 0, 0, self.lanes * 4)?;
-        self.jit.copy_output_to_h_in(H_OUT, 0, 0, self.state_bytes)?;
-        self.jit.copy_output_to_c_in(C_OUT, 0, 0, self.state_bytes)?;
-        let t2 = std::time::Instant::now();
 
         let outs = self.jit.output_buffers()?;
         let mut any = [0i32; 1];
@@ -156,13 +156,12 @@ impl BatchBlockStep for RnntBlockBackend {
         outs[EMIT_OUT].copyout_prefix(bytemuck::cast_slice_mut(&mut self.emit)).context(DeviceSnafu)?;
         outs[FRAME_OUT].copyout_prefix(bytemuck::cast_slice_mut(&mut self.frames_tape)).context(DeviceSnafu)?;
         outs[ANY_OUT].copyout_prefix(bytemuck::cast_slice_mut(&mut any)).context(DeviceSnafu)?;
-        let t3 = std::time::Instant::now();
+        let t2 = std::time::Instant::now();
 
         self.stats.n_blocks += 1;
         self.stats.steps_emitted += self.emit.iter().filter(|&&e| e != 0).count() as u64;
         self.stats.t_exec += t1 - t0;
-        self.stats.t_recycle += t2 - t1;
-        self.stats.t_read += t3 - t2;
+        self.stats.t_read += t2 - t1;
         Ok(BlockTapes { tokens: &self.tokens, emit: &self.emit, frames: &self.frames_tape, active_any: any[0] != 0 })
     }
 

--- a/model/src/gigaam/rnnt/block_backend.rs
+++ b/model/src/gigaam/rnnt/block_backend.rs
@@ -1,7 +1,8 @@
 //! Device-block RNN-T backend ([`svod_arch::rnnt::BatchBlockStep`]):
-//! [`super::block::forward_block`] unrolled to a single graph-captured plan;
-//! per block the host recycles the five carried states with on-device copies
-//! and reads back three small tapes + one flag.
+//! [`super::block::forward_block`] unrolled to a single graph-captured plan. The
+//! five carried states recycle in place inside `execute()` (the plan stores them
+//! back into its own input buffers); per block the host only reads back three
+//! small tapes + one flag.
 
 use snafu::ResultExt;
 use svod_arch::rnnt::{BatchBlockStep, BlockTapes};
@@ -50,12 +51,10 @@ pub struct BlockStats {
     /// useful fraction; the per-lane step count `n_blocks * BLOCK_STEPS` is the
     /// separate lever a wider window cuts.
     pub steps_emitted: u64,
+    /// Time inside `execute()` (graph submit; the block runs async).
     pub t_exec: std::time::Duration,
-    /// Always ~0 now: carried state recycles in place inside `execute()` (the
-    /// plan stores `time/prev/symbols/h/c` back into its own input buffers), so
-    /// there is no host-issued output→input copy. Kept as a log signal that the
-    /// in-place recycle is active.
-    pub t_recycle: std::time::Duration,
+    /// Time reading back the tapes — includes the wait for the block's compute,
+    /// since `execute()` does not block.
     pub t_read: std::time::Duration,
 }
 

--- a/model/src/gigaam/rnnt/block_backend.rs
+++ b/model/src/gigaam/rnnt/block_backend.rs
@@ -45,6 +45,10 @@ pub struct RnntBlockBackend {
 #[derive(Default, Clone, Debug)]
 pub struct BlockStats {
     pub n_blocks: u64,
+    /// Real (non-blank) emissions across all blocks. Total executed steps are
+    /// `n_blocks * BLOCK_STEPS`; the gap to `steps_emitted` is the blank-advance
+    /// + finished-lane overhead a wider window cuts down.
+    pub steps_emitted: u64,
     pub t_exec: std::time::Duration,
     pub t_recycle: std::time::Duration,
     pub t_read: std::time::Duration,
@@ -155,6 +159,7 @@ impl BatchBlockStep for RnntBlockBackend {
         let t3 = std::time::Instant::now();
 
         self.stats.n_blocks += 1;
+        self.stats.steps_emitted += self.emit.iter().filter(|&&e| e != 0).count() as u64;
         self.stats.t_exec += t1 - t0;
         self.stats.t_recycle += t2 - t1;
         self.stats.t_read += t3 - t2;

--- a/model/src/gigaam/rnnt/jit.rs
+++ b/model/src/gigaam/rnnt/jit.rs
@@ -24,8 +24,9 @@ mod block_jit {
             outputs { tape, emit, frame, active_any, time_out, prev_out, symbols_out, h_out, c_out },
 
             build(enc, time, prev, symbols, valid, h_in, c_in) {
+                use crate::gigaam::rnnt::block::{WIND_W, forward_block};
                 let out: crate::gigaam::error::Result<_> =
-                    crate::gigaam::rnnt::block::forward_block(model, enc, time, prev, symbols, valid, h_in, c_in);
+                    forward_block(model, enc, time, prev, symbols, valid, h_in, c_in, WIND_W);
                 out
             }
         }

--- a/model/src/gigaam/rnnt/jit.rs
+++ b/model/src/gigaam/rnnt/jit.rs
@@ -24,9 +24,10 @@ mod block_jit {
             outputs { tape, emit, frame, active_any, time_out, prev_out, symbols_out, h_out, c_out },
 
             build(enc, time, prev, symbols, valid, h_in, c_in) {
-                use crate::gigaam::rnnt::block::{WIND_W, forward_block};
+                // WIND decode window. Byte-identical output for any W>=1 (a pure
+                // perf knob, optimum is GPU-dependent); 4 is the validated default.
                 let out: crate::gigaam::error::Result<_> =
-                    forward_block(model, enc, time, prev, symbols, valid, h_in, c_in, WIND_W);
+                    crate::gigaam::rnnt::block::forward_block::<4>(model, enc, time, prev, symbols, valid, h_in, c_in);
                 out
             }
         }

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -638,16 +638,21 @@ impl<S: Splitter> Transcriber<S> {
 
         if let HeadDecoder::Rnnt { backend, .. } = &self.head_decoder {
             let s = &backend.stats;
-            // `total_steps` is the device-step budget; `steps_emitted` is the
-            // useful fraction. The gap (blank-advance + finished-lane steps) and
-            // `n_blocks` (host syncs) are the levers a wider decode window cuts.
+            // Two scales, kept distinct: `steps_per_lane` (= n_blocks ×
+            // block_steps) is the lockstep step count one lane drives — the WIND
+            // lever, which drops as the window widens. `tokens_emitted` and
+            // `tape_slots` are over the full lanes × steps tape, so
+            // tokens_emitted / tape_slots is the useful fraction; `n_blocks` is
+            // the host-sync count.
             let block_steps = svod_arch::rnnt::BatchBlockStep::block_steps(backend) as u64;
+            let lanes = svod_arch::rnnt::BatchBlockStep::batch(backend) as u64;
             let frames_total: usize = all_valid.iter().sum();
             tracing::info!(
                 target: "svod_model::gigaam::transcribe",
                 n_blocks = s.n_blocks,
-                total_steps = s.n_blocks * block_steps,
-                steps_emitted = s.steps_emitted,
+                steps_per_lane = s.n_blocks * block_steps,
+                tokens_emitted = s.steps_emitted,
+                tape_slots = s.n_blocks * lanes * block_steps,
                 frames_total,
                 exec_ms = s.t_exec.as_secs_f64() * 1e3,
                 recycle_ms = s.t_recycle.as_secs_f64() * 1e3,

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -655,7 +655,6 @@ impl<S: Splitter> Transcriber<S> {
                 tape_slots = s.n_blocks * lanes * block_steps,
                 frames_total,
                 exec_ms = s.t_exec.as_secs_f64() * 1e3,
-                recycle_ms = s.t_recycle.as_secs_f64() * 1e3,
                 read_ms = s.t_read.as_secs_f64() * 1e3,
                 "rnnt block stats",
             );

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -638,9 +638,17 @@ impl<S: Splitter> Transcriber<S> {
 
         if let HeadDecoder::Rnnt { backend, .. } = &self.head_decoder {
             let s = &backend.stats;
+            // `total_steps` is the device-step budget; `steps_emitted` is the
+            // useful fraction. The gap (blank-advance + finished-lane steps) and
+            // `n_blocks` (host syncs) are the levers a wider decode window cuts.
+            let block_steps = svod_arch::rnnt::BatchBlockStep::block_steps(backend) as u64;
+            let frames_total: usize = all_valid.iter().sum();
             tracing::info!(
                 target: "svod_model::gigaam::transcribe",
                 n_blocks = s.n_blocks,
+                total_steps = s.n_blocks * block_steps,
+                steps_emitted = s.steps_emitted,
+                frames_total,
                 exec_ms = s.t_exec.as_secs_f64() * 1e3,
                 recycle_ms = s.t_recycle.as_secs_f64() * 1e3,
                 read_ms = s.t_read.as_secs_f64() * 1e3,

--- a/tensor/src/test/unit/reduce.rs
+++ b/tensor/src/test/unit/reduce.rs
@@ -481,6 +481,18 @@ crate::codegen_tests! {
         assert_eq!(t.argmax(Some(0)).unwrap().realize_with_and(&config).as_vec::<i32>().unwrap(), [0]);
     }
 
+    // The WIND first-non-blank reduction relies on `argmax` over a {0,1} row
+    // returning the FIRST index that holds 1 (and index 0 when the row is all
+    // zero, which the caller masks out). Verify on the exact int32 / axis=1 /
+    // keepdim form the RN-T block uses.
+    fn test_argmax_first_true_in_binary_row(config) {
+        test_setup();
+        let t = Tensor::from_ndarray(&array![[0i32, 0, 1, 1], [0, 0, 0, 0], [1, 0, 0, 0]]);
+        let got = t.argmax_with().axis(Some(1)).keepdim(true).call().unwrap().realize_with_and(&config).as_vec::<i32>().unwrap();
+        // Row 0: first 1 at idx 2; row 1: all zero -> 0; row 2: first 1 at idx 0.
+        assert_eq!(got, [2, 0, 0]);
+    }
+
     fn test_argmax_2d_axis0_value(config) {
         test_setup();
         let t = Tensor::from_ndarray(&array![[1.0f32, 3.0, 2.0], [4.0, 2.0, 5.0]]);


### PR DESCRIPTION
Reworks the GigaAM RN-T device block decoder to:
1. evaluate the joint over a window of W frames against the fixed predictor state and jump to the first non-blank (WIND), instead of one frame per step;
2. recycle carried state in place, removing the per-block device→device copies.

WIND is an exact reformulation of greedy decoding — transcripts are byte-identical for any window W ≥ 1. GPU-validated on GigaAM v3 RN-T: RTF 0.0046 → 0.0038 (~17% end-to-end) at W=4, transcripts unchanged.

## Motivation

The block decoder runs the LSTM predictor + joint once per encoder frame and advances one frame per step. On speech, most frames are blank advances, so the per-frame loop spends the bulk of its predictor/joint evaluations — and host syncs — chewing through blank runs that emit nothing.

Under a fixed predictor state, every frame before the next non-blank is provably blank, so they can be skipped in one shot. WIND does exactly this: one windowed joint evaluation finds the next emission frame and jumps there. For this static-shape, masked-execution runtime it also subsumes label-looping (the predictor work it saves on blanks is the same target), while adding nothing the runtime can't already express.

Separately, the block recycled its five carried states (time/prev/symbols/h/c) between iterations with explicit device→device copies — overhead that disappears if the plan simply writes the new state back into the buffers it read from.

## Changes

1. WIND windowed non-blank detection (forward_block)
Each step builds a window [t, t+W), evaluates the joint once over it (gather → [B,W,J], argmax → [B,W]), finds the first in-bounds non-blank offset (argmax over a {0,1} mask — ties resolve to the first index), emits one token there, and jumps time past the leading blanks (or by W if all blank). Same-frame multi-emit and the max_symbols cap are handled exactly as the per-frame loop. Uses only static-shape ops already in the block, so the plan still graph-captures into one submit. W=1 reduces to the prior per-frame decoder.

2. In-place state recycle
forward_block ends each carried state with an assign back into its own input buffer (AFTER(in_buf, STORE(in_buf, final))), so execute() updates state in place and the 5 copy_output_to_* transfers per block are removed. Read-before-write safe (carried inputs are read only at step 0); buf_uop() resolves the store to the input buffer, and graph capture handles read==write on one buffer, so no macro or runtime change was needed.

3. Const-generic window (default 4)
forward_block<const W: usize>; the window value lives at the single JIT call site (forward_block::<4>), keeping it compile-time and capture-safe. Output is window-invariant, so W is a pure performance knob whose optimum is GPU-dependent — 4 is a validated default, tunable with a one-line change.