### PR TITLE
tk/matmul: 10× faster on gfx942 (small/moderate N) — tile selector + split-K

### DIFF
--- a/tk/src/kernels/matmul.rs
+++ b/tk/src/kernels/matmul.rs
@@ -245,19 +245,34 @@ pub fn matmul(a: &Tensor, b: &Tensor) -> crate::LaunchResult<Option<Tensor>> {
             // bf16, so the ABI's bf16 globals bind directly. Output stays f32 (accumulator).
             let a_bf = a.cast(DType::BFloat16).context(crate::launch::OperandSnafu)?;
             let b_bf = b.cast(DType::BFloat16).context(crate::launch::OperandSnafu)?;
-            let out = Tensor::empty(&[n, n], DType::Float32);
-            crate::graph_launch(
-                "matmul",
-                cfg.grid_dims(n),
-                cfg.threads(caps.wave_size),
-                out,
-                &[&a_bf, &b_bf],
-                caps,
-                move |ker| {
+            let threads = cfg.threads(caps.wave_size);
+            let k_splits = split_k_for(n, cfg);
+            if k_splits > 1 {
+                // Split-K: a `[(n/block)², k_splits]` grid keeps a small problem's grid
+                // wide enough to fill the machine. Each workgroup writes a partial tile
+                // to `scratch[k_slice]`; the graph reduce sums them into the result.
+                let g = (n / cfg.block) as i64;
+                let scratch = Tensor::empty(&[k_splits, n, n], DType::Float32);
+                let partial = crate::graph_launch(
+                    "matmul_splitk",
+                    [g * g, k_splits as i64, 1],
+                    threads,
+                    scratch,
+                    &[&a_bf, &b_bf],
+                    caps,
+                    move |ker| {
+                        build_matmul_splitk(ker, n, cfg, k_splits);
+                        ker.finish(cfg.n_accum)
+                    },
+                )?;
+                Ok(partial.sum(0).expect("split-K: reduce scratch over k_slice"))
+            } else {
+                let out = Tensor::empty(&[n, n], DType::Float32);
+                crate::graph_launch("matmul", cfg.grid_dims(n), threads, out, &[&a_bf, &b_bf], caps, move |ker| {
                     build_matmul_cfg(ker, n, cfg);
                     ker.finish(cfg.n_accum)
-                },
-            )
+                })
+            }
         },
     )
 }
@@ -406,4 +421,140 @@ pub fn gemm_core(
         let mrow = row.mul(&cidx(bps)).add(&acc_row(&warp_row, a, &cfg));
         c_t = g.store(c_t, c, MoveIdx::block((0, 0, mrow.clone(), nidx.clone()), 2));
     }
+}
+
+/// Split-K [`gemm_core`]: partitions the K reduction across `k_splits` workgroups
+/// per C tile so a small `(n/block)²` grid still fills the machine. Workgroup
+/// `(tile, k_slice)` (the latter on `block_idx[1]`, so this requires `l2_swizzle`
+/// — which frees `block_idx[1]`) computes the `block×block` tile's *partial* sum
+/// over K-strips `[k_slice·spk, (k_slice+1)·spk)` and writes it to
+/// `scratch[k_slice]`. The caller sums `scratch` over `k_slice` (a graph reduce).
+/// Single-buffered, same per-tile inner loop as [`gemm_core`].
+#[allow(clippy::too_many_arguments)]
+fn gemm_core_splitk(
+    ker: &Kernel,
+    n: usize,
+    cfg: MatmulCfg,
+    k_step: usize,
+    k_splits: usize,
+    c_gl: GL,
+    a_gl: GL,
+    b_gl: GL,
+) {
+    assert_eq!(n % cfg.block, 0, "split-K N={n} must be a multiple of block {}", cfg.block);
+    assert_eq!(k_step % 16, 0, "k_step={k_step} must be a multiple of 16");
+    assert!(cfg.l2_swizzle, "split-K needs l2_swizzle (block_idx[1] carries k_slice)");
+    let strips = n / k_step;
+    assert_eq!(strips % k_splits, 0, "split-K: strips {strips} must divide k_splits {k_splits}");
+    let spk = (strips / k_splits) as i64; // K-strips per slice
+    let reg = cfg.reg();
+    let g = ker.group_2d(cfg.wave_rows, cfg.wave_cols);
+    let bf16 = DType::BFloat16;
+
+    let a_smem = ker.shared_sw((cfg.block, k_step), bf16.clone(), TileLayout::Row);
+    let b_smem = ker.shared_sw((k_step, cfg.block), bf16.clone(), TileLayout::Row);
+
+    let (row, col) = block_coords(ker, n, n, &cfg);
+    let warp_row = g.warp_row();
+    let warp_col = g.warp_col();
+    let k_slice = ker.block_idx[1].clone(); // 0..k_splits
+    let k_origin = k_slice.mul(&cidx(spk)); // first global K-strip of this slice
+
+    let accs: Vec<RT> = (0..cfg.n_accum).map(|_| g.zero(ker.acc((reg, reg), TileLayout::Col))).collect();
+
+    let lp = ker.loop_static(spk);
+    let strip = k_origin.add(lp.index()); // global K-strip = k_slice*spk + t
+
+    let (a_smem, b_smem) = if cfg.vec_load {
+        (
+            g.fill_local_vec(a_smem, a_gl, &[Idx::Const(0), Idx::Const(0), Idx::from(&row), Idx::from(&strip)], 2),
+            g.fill_local_vec(b_smem, b_gl, &[Idx::Const(0), Idx::Const(0), Idx::from(&strip), Idx::from(&col)], 2),
+        )
+    } else {
+        (
+            g.load(a_smem, a_gl, MoveIdx::block((0, 0, row.clone(), strip.clone()), 2)),
+            g.load(b_smem, b_gl, MoveIdx::block((0, 0, strip.clone(), col.clone()), 2)),
+        )
+    };
+
+    let bb = g.load(
+        ker.operand((k_step, reg), bf16.clone(), TileLayout::Col),
+        b_smem.subtile((k_step, reg), (0, warp_col.clone())),
+        MoveIdx::default(),
+    );
+    let a_subs: Vec<RT> = (0..cfg.n_accum)
+        .map(|a| {
+            g.load(
+                ker.operand((reg, k_step), bf16.clone(), TileLayout::Row),
+                a_smem.subtile((reg, k_step), (acc_row(&warp_row, a, &cfg), 0)),
+                MoveIdx::default(),
+            )
+        })
+        .collect();
+
+    let mut bar_deps: smallvec::SmallVec<[Arc<UOp>; 4]> = smallvec![bb.uop().clone()];
+    bar_deps.extend(a_subs.iter().skip(1).map(|t| t.uop().clone()));
+    let sync = a_subs[0].uop().barrier(bar_deps);
+    let bb = bb.after(smallvec![sync.clone()]);
+    let a_subs: Vec<RT> = a_subs.into_iter().map(|t| t.after(smallvec![sync.clone()])).collect();
+
+    let mut prev_out: Option<Arc<UOp>> = None;
+    for (a, a_sub) in a_subs.iter().enumerate() {
+        let a_sub = match &prev_out {
+            Some(p) => a_sub.after(smallvec![p.clone()]),
+            None => a_sub.clone(),
+        };
+        prev_out = Some(g.mma_ab(accs[a].clone(), &a_sub, &bb).uop().clone());
+    }
+    let ended = lp.close();
+    let final_accs: Vec<RT> = accs.iter().map(|c| c.after(smallvec![ended.clone()])).collect();
+
+    // Epilogue: store the partial tile into `scratch[k_slice]` (leading dim = k_slice).
+    let bps = cfg.blocks_per_side() as i64;
+    let nidx = col.mul(&cidx(bps)).add(&warp_col);
+    let mut c_t = c_gl;
+    for (a, c) in final_accs.into_iter().enumerate() {
+        let mrow = row.mul(&cidx(bps)).add(&acc_row(&warp_row, a, &cfg));
+        c_t = g.store(c_t, c, MoveIdx::block((k_slice.clone(), 0, mrow.clone(), nidx.clone()), 2));
+    }
+}
+
+/// Bind the split-K ABI — output `scratch[k_splits, 1, n, n]` (f32 partials), inputs
+/// `a`/`b` `[1,1,n,n]` bf16 — and run [`gemm_core_splitk`]. The caller launches with
+/// grid `[(n/block)², k_splits, 1]` and reduces `scratch` over axis 0.
+pub fn build_matmul_splitk(ker: &Kernel, n: usize, cfg: MatmulCfg, k_splits: usize) {
+    let bf16 = DType::BFloat16;
+    let (outs, ins) = ker.bind_abi(
+        &[GlSpec::new(&[k_splits, 1, n, n], DType::Float32)],
+        &[GlSpec::new(&[1, 1, n, n], bf16.clone()), GlSpec::new(&[1, 1, n, n], bf16)],
+    );
+    gemm_core_splitk(ker, n, cfg, cfg.k_step(), k_splits, outs[0].clone(), ins[0].clone(), ins[1].clone());
+}
+
+/// Reference gfx942 CU count (MI300X) for the split-K grid target. A smaller SKU
+/// just over-splits slightly (more reduce traffic), so an exact count isn't needed.
+const SPLITK_CU_TARGET: usize = 304;
+
+/// Choose `k_splits` so the `n_tiles · k_splits` grid covers ~2× the CUs when the
+/// plain `(n/block)²` grid is too small to fill the machine. Returns 1 (no split)
+/// when the grid is already large enough or K can't be divided usefully. Picks the
+/// largest divisor of `strips` not exceeding the saturation target, bounding the
+/// reduce overhead.
+fn split_k_for(n: usize, cfg: MatmulCfg) -> usize {
+    if !cfg.l2_swizzle {
+        return 1; // split-K needs block_idx[1] free
+    }
+    let strips = n / cfg.k_step();
+    let n_tiles = (n / cfg.block).pow(2);
+    // Only split when the plain grid is *well* under the machine — otherwise the
+    // scratch round-trip of the reduce outweighs the added parallelism (at n_tiles ≈
+    // CU the grid already fills the GPU).
+    if n_tiles >= SPLITK_CU_TARGET / 2 || strips <= 1 {
+        return 1;
+    }
+    // Target ~1·CU total workgroups: past that the scratch round-trip of the reduce
+    // costs more than the extra parallelism buys (measured: k=4 beats k=8 at N=1024).
+    let target = SPLITK_CU_TARGET.div_ceil(n_tiles).max(1);
+    // Largest divisor of `strips` that is ≤ target (and ≥ 1).
+    (1..=strips).rev().find(|d| strips.is_multiple_of(*d) && *d <= target).unwrap_or(1)
 }

--- a/tk/src/kernels/matmul.rs
+++ b/tk/src/kernels/matmul.rs
@@ -110,6 +110,13 @@ pub const M1_CFG: MatmulCfg =
 pub const SMALL_CFG: MatmulCfg =
     MatmulCfg { block: 64, wave_rows: 1, wave_cols: 1, n_accum: 1, l2_swizzle: false, vec_load: false, k_step: K_STEP };
 
+/// Mid-N (gfx942): 128×128 block, 2×2 waves (4 waves / 256 threads), one 64×64
+/// accumulator/wave, L2 swizzle + 128-bit vec fills. 32 KB LDS (vs M1's 64 KB) so
+/// two workgroups fit per CU, and the grid is `(n/128)²` — 4× M1's tile count at a
+/// given N. Fills the saturation gap between SMALL (64×64) and M1 (256×256).
+pub const MID_CFG: MatmulCfg =
+    MatmulCfg { block: 128, wave_rows: 2, wave_cols: 2, n_accum: 1, l2_swizzle: true, vec_load: true, k_step: K_STEP };
+
 /// gfx1151 (RDNA3.5, wave32) config: 64×64 block, 2×2
 /// waves (4 waves / 128 threads), ONE
 /// 32×32 accumulator/wave, 128-bit vec fills, no L2 swizzle (single-XCD APU), and
@@ -123,11 +130,24 @@ pub const SMALL_CFG: MatmulCfg =
 pub const GFX1151_CFG: MatmulCfg =
     MatmulCfg { block: 64, wave_rows: 2, wave_cols: 2, n_accum: 1, l2_swizzle: false, vec_load: true, k_step: 32 };
 
-/// Size-adaptive config selection: small N (where the 256×256/8-wave grid
-/// starves the machine) uses [`SMALL_CFG`]; everything else keeps [`M1_CFG`].
-/// Small N uses an occupancy-tuned config; the threshold follows size-adaptive tuning.
+/// Size-adaptive config for gfx942 (CDNA wave64). [`MID_CFG`] (128×128) is the
+/// tuned block for all but small N: its 32 KB LDS admits two workgroups per CU and
+/// its `(n/128)²` grid keeps the machine fed, beating the 256×256 [`M1_CFG`] by
+/// 6–8× across 1024–8192 (M1's 64 KB LDS pins one single-buffered workgroup per CU,
+/// so it starves the GPU — it is no longer auto-selected). [`SMALL_CFG`] (64×64)
+/// keeps the grid fed for small N, where 128-blocks leave too few tiles. The block
+/// must divide N, so the chain also degrades gracefully (128 → 64) for sizes that
+/// aren't a multiple of 128.
 pub fn cfg_for_n(n: usize) -> MatmulCfg {
-    if n <= 768 && n.is_multiple_of(SMALL_CFG.block) { SMALL_CFG } else { M1_CFG }
+    if n <= 768 && n.is_multiple_of(SMALL_CFG.block) {
+        SMALL_CFG
+    } else if n.is_multiple_of(MID_CFG.block) {
+        MID_CFG
+    } else if n.is_multiple_of(SMALL_CFG.block) {
+        SMALL_CFG
+    } else {
+        M1_CFG
+    }
 }
 
 /// Per-arch config: gfx1151 (RDNA3.5 wave32) uses the occupancy-tuned

--- a/tk/src/test/unit/matmul.rs
+++ b/tk/src/test/unit/matmul.rs
@@ -395,7 +395,7 @@ fn test_matmul_graph_amd() {
 }
 
 /// The size-adaptive matmul is correct at every N, picking [`SMALL_CFG`] for
-/// small N (where the 256×256 block under-occupies the machine) and [`M1_CFG`]
+/// small N (where a larger block under-occupies the machine) and [`MID_CFG`]
 /// otherwise.
 ///
 /// `SVOD_DEVICE=AMD:0 cargo test -p svod-tk --lib matmul::test_matmul_adaptive_amd -- --ignored --nocapture`.


### PR DESCRIPTION
Speeds up `svod_tk::matmul` on gfx942 (MI300X) by **10×** at N=1024
(374 µs → 37 µs), closing the gap to hipBLASLt from **21× to 2.1×**.
Two independent, profiler-driven fixes; touches only `tk/src/kernels/matmul.rs`.

### 1. Retire the 256×256 block, default to 128×128 (`70bbfe43`)

The size-adaptive selector handed every N>768 to `M1_CFG` (256×256), whose
**64 KB LDS pins one single-buffered workgroup per CU** and whose `(n/256)²`
grid launches only **16 workgroups for N=1024** — ~5% of the MI300X's 304 CUs.

Added `MID_CFG` (128×128, 2×2 waves, 32 KB LDS → **2 WG/CU**, `(n/128)²` grid)
and select it for moderate+large N; `SMALL_CFG` (64×64) stays for small N. A
wave-layout sweep confirmed 128/2×2/reg64 is the local optimum (bigger register
tiles with fewer threads *tank*); `M1_CFG` is dominated at every measured size
and is no longer auto-selected.

| N | M1 (before) | MID (after) | generic | speedup |
|---|---|---|---|---|
| 1024 | 374 µs | 58 µs | 55 µs | 6.5× |
| 2048 | 963 µs | 121 µs | 139 µs | 7.9× |
| 4096 | 2.20 ms | 782 µs | 847 µs | 2.8× |
| 8192 | 19.9 ms | 5.50 ms | 6.53 ms | 3.6× |

### 2. Split-K for small N (`2b6d39a1`)

At N=1024 even the 128-block grid is only 64 workgroups (~21% of 304 CUs), and
no tile config fixes it (smaller blocks add workgroups but tank on arithmetic
intensity). Split-K partitions the K reduction across a `[(n/block)², k_splits]`
grid — each workgroup computes a tile's *partial* sum over a K-slice into
`scratch[k_slice]`, then `scratch.sum(0)` (a graph reduce) combines them.
Engages only when the plain grid is well under the CU count; the heuristic
targets ~1·CU total workgroups (measured: k=4 beats k=8 at 1024 — past ~CU the
scratch round-trip costs more than the parallelism buys). Needs `l2_swizzle`
(frees `block_idx[1]` for `k_slice`).

| N | before | split-K | generic | vendor |
|---|---|---|---|---|
| 1024 | 58 µs | **37 µs** (k=4) | 55 µs | 17.4 µs |
| 2048 | 121 µs | 121 µs (unsplit) | 139 µs | 38 µs |

### Result

| N | tk | TFLOP/s | generic | hipBLASLt | tk vs vendor |
|---|---|---|---|---|---|
| 1024 | 37 µs | 58 | 55 µs | 17.4 µs | 2.1× |
| 2048 | 121 µs | 142 | 139 µs | 38 µs | 3.2× |

tk now beats svod's own optimizer and is at GEMM-*compute* parity with the
vendor (the split-K matmul kernel itself is ~19 µs ≈ hipBLASLt's *total*).

### Design space explored (and deliberately not taken)

The residual 2.1× is the separate-kernel reduce vs the vendor's *fused* split-K.
Profiled to ground: the reduce is bandwidth-bound at ~1700 GB/s (this MI300X
**VF**'s effective HBM bandwidth), so it can't be tuned away in tk. Rejected,
with data:
- **LDS double-buffering** — neutral; occupancy (2 WG/CU) already hides the
  load latency, so the pipeline is redundant. (Also found+documented a VGPR-blowup
  trap in the register-staged prefetch.)
- **Atomic accumulate** (flat *and* `global_atomic_add_f32`) — correct but
  *slower*: 4-way atomic contention slows the GEMM 19→30 µs, plus zero-init
  overhead. Vendor parity needs an in-kernel fused combine, a framework effort.
- **Hand-written reduce kernel** — *slower* than the generic `sum(0)`; both are
  already near the VF bandwidth wall.