### PR TITLE
model: BGE-M3 / BGE-reranker + XLM-RoBERTa backbone

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -14,6 +14,7 @@ plans.
 | `state` | `HasStateDict` + `state_field!` macros for loading PyTorch / safetensors checkpoints into Rust weight structs. |
 | `blocks` | Shared `Conv2dWeights`, `BatchNormWeights`, `BasicBlock`, `Bottleneck`, `ResidualStage` reused by every ResNet-shaped backbone. timm/torchvision key convention. |
 | `wavlm` | WavLM speech-representation backbone (Conv1d feature extractor + gated rel-pos Transformer, per-layer pruning) consumed by `diarizen`. |
+| `xlm_roberta` | XLM-RoBERTa text encoder backbone (absolute position embeddings, post-norm Transformer) consumed by `bgem3`. |
 | `sentencepiece` | Minimal SentencePiece `.model` protobuf loader (vocab piece extraction). |
 
 ## Models
@@ -25,6 +26,8 @@ plans.
 | Silero VAD 16k | Voice activity | `silero_vad` | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) | [`vpermilp/silero-vad`](https://huggingface.co/vpermilp/silero-vad) |
 | DiariZen segmentation (WavLM + Conformer) | Speaker diarization | `diarizen` | [BUT-FIT/DiariZen](https://github.com/BUTSpeechFIT/DiariZen) | [`BUT-FIT/diarizen-wavlm-large-s80-md-v2`](https://huggingface.co/BUT-FIT/diarizen-wavlm-large-s80-md-v2) |
 | ModernBERT (base / large) | Text embeddings, fill-mask (MLM) | `modernbert` | [Answer.AI ModernBERT](https://github.com/AnswerDotAI/ModernBERT) | [`answerdotai/ModernBERT-base`](https://huggingface.co/answerdotai/ModernBERT-base) |
+| BGE-M3 (dense / sparse / ColBERT) | Text embeddings, retrieval | `bgem3` | [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3) (XLM-RoBERTa-large) | [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3) |
+| BGE-reranker-v2-m3 | Cross-encoder reranking | `bgem3` | [BAAI/bge-reranker-v2-m3](https://huggingface.co/BAAI/bge-reranker-v2-m3) | [`BAAI/bge-reranker-v2-m3`](https://huggingface.co/BAAI/bge-reranker-v2-m3) |
 | ResNet (18 / 34 / 50 / 101 / 152) | Vision | `resnet` | [He et al. 2015](https://arxiv.org/abs/1512.03385) | [`timm/resnet*.a1_in1k`](https://huggingface.co/timm) |
 | WeSpeaker ResNet34 | Speaker embedding | `wespeaker` | [wenet-e2e/wespeaker](https://github.com/wenet-e2e/wespeaker) | [`pyannote/wespeaker-voxceleb-resnet34-LM`](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM) |
 
@@ -33,6 +36,12 @@ FireRedVAD ships two variants: the non-streaming model (`FireRedVadSplitter`
 the causal `Stream-VAD` checkpoint (`FireRedVadStreamer` — incremental
 push/flush API with per-layer conv caches recycled on-device between
 chunks).
+
+BGE-M3 loads from `pytorch_model.bin` (pickle, no safetensors variant) with
+the three retrieval heads in separate `.pt` files (`sparse_linear.pt`,
+`colbert_linear.pt`). The reranker loads from `model.safetensors` with a
+`roberta.` prefix on backbone keys. Both share the XLM-RoBERTa-large
+backbone (`xlm_roberta` module).
 
 ## Examples
 

--- a/model/src/bgem3/colbert_head.rs
+++ b/model/src/bgem3/colbert_head.rs
@@ -1,0 +1,88 @@
+//! BGE-M3 ColBERT multi-vector embedding head.
+//!
+//! Per-token `Linear(D, colbert_dim, bias)` applied to hidden states excluding
+//! the CLS token, with padding masked to zero. Optional L2 normalization.
+//!
+//! Weights are loaded from `colbert_linear.pt` (PyTorch pickle with bare
+//! `weight` / `bias` keys).
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::{Tensor, s};
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+use crate::xlm_roberta::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct ColbertHead {
+    pub weight: Tensor,
+    pub bias: Tensor,
+    pub colbert_dim: usize,
+    pub normalize: bool,
+}
+
+impl ColbertHead {
+    pub fn empty(hidden_size: usize, colbert_dim: usize, dtype: DType) -> Self {
+        Self {
+            weight: fan_in_uniform(&[colbert_dim, hidden_size], hidden_size, dtype.clone()),
+            bias: zeros(&[colbert_dim], dtype),
+            colbert_dim,
+            normalize: true,
+        }
+    }
+
+    /// Load from a `colbert_linear.pt` checkpoint (bare `weight`/`bias` keys).
+    pub fn from_pytorch_bin(path: &std::path::Path, colbert_dim: usize, dtype: DType) -> Result<Self> {
+        let sd = crate::wespeaker::pickle::load_flat_pytorch_bin(path, "")
+            .map_err(|e| crate::xlm_roberta::Error::Pickle { source: Box::new(e) })?;
+        Self::from_state_dict(&sd, "", colbert_dim, dtype)
+    }
+
+    /// Build from a preloaded state dict, casting to `dtype`.
+    pub fn from_state_dict(sd: &StateDict, prefix: &str, colbert_dim: usize, dtype: DType) -> Result<Self> {
+        let sd = state::cast_all(sd, dtype.clone());
+        let mut head = Self::empty(0, colbert_dim, dtype);
+        head.load_state_dict(&sd, prefix).map_err(|e| crate::xlm_roberta::Error::State { source: Box::new(e) })?;
+        Ok(head)
+    }
+
+    /// Forward. `hidden`: `(B, L, D)`, `attention_mask`: optional `(B, L)` bool
+    /// where `true` = real token. Returns `(B, L-1, colbert_dim)` — the CLS
+    /// token (position 0) is dropped.
+    pub fn forward(&self, hidden: &Tensor, attention_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = hidden.shape().context(TensorSnafu)?;
+        let _l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "colbert_head" })?;
+
+        let hidden_no_cls = hidden.getitem(s![.., 1.., ..]).context(TensorSnafu)?;
+
+        let vecs = hidden_no_cls.linear().weight(&self.weight).bias(&self.bias).call().context(TensorSnafu)?;
+
+        let vecs = match attention_mask {
+            Some(m) => {
+                let m_no_cls = m.getitem(s![.., 1..]).context(TensorSnafu)?;
+                let m_3d =
+                    m_no_cls.cast(vecs.uop().dtype()).context(TensorSnafu)?.try_unsqueeze(-1).context(TensorSnafu)?;
+                vecs.try_mul(&m_3d).context(TensorSnafu)?
+            }
+            None => vecs,
+        };
+
+        if self.normalize { vecs.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(vecs) }
+    }
+}
+
+impl HasStateDict for ColbertHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd.insert(prefixed(prefix, "bias"), self.bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        self.bias = get_tensor(sd, &prefixed(prefix, "bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/bgem3/embedder.rs
+++ b/model/src/bgem3/embedder.rs
@@ -1,0 +1,145 @@
+//! BGE-M3 composite model: XLM-RoBERTa backbone + dense / sparse / ColBERT heads.
+//!
+//! `BAAI/bge-m3` produces three types of embeddings simultaneously:
+//! - **Dense**: CLS pooling + L2 normalize → `(B, D)`
+//! - **Sparse**: Linear → ReLU → scatter-to-vocab → `(B, vocab_size)`
+//! - **ColBERT**: per-token Linear (skip CLS) + L2 normalize → `(B, L-1, Dc)`
+//!
+//! Loads from HuggingFace Hub: `config.json` + `pytorch_model.bin` (backbone)
+//! + `sparse_linear.pt` + `colbert_linear.pt` (heads).
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::xlm_roberta::config::XlmRobertaConfig;
+use crate::xlm_roberta::error::{HubSnafu, Result, SymbolicShapeSnafu, TensorSnafu};
+use crate::xlm_roberta::model::XlmRobertaModel;
+use crate::xlm_roberta::pooling::cls;
+
+use super::colbert_head::ColbertHead;
+use super::sparse_head::SparseHead;
+
+/// Output of [`BgeM3::encode`]: any combination of the three embedding types.
+#[derive(Clone, Default)]
+pub struct BgeM3Output {
+    pub dense_vecs: Option<Tensor>,
+    pub sparse_vecs: Option<Tensor>,
+    pub colbert_vecs: Option<Tensor>,
+}
+
+/// Flags controlling which embedding types to compute.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EncodeOpts {
+    pub return_dense: bool,
+    pub return_sparse: bool,
+    pub return_colbert: bool,
+}
+
+impl EncodeOpts {
+    pub fn dense() -> Self {
+        Self { return_dense: true, return_sparse: false, return_colbert: false }
+    }
+    pub fn all() -> Self {
+        Self { return_dense: true, return_sparse: true, return_colbert: true }
+    }
+}
+
+#[derive(Clone)]
+pub struct BgeM3 {
+    pub model: XlmRobertaModel,
+    pub sparse_head: Option<SparseHead>,
+    pub colbert_head: Option<ColbertHead>,
+    pub normalize_dense: bool,
+}
+
+impl BgeM3 {
+    pub fn empty(config: XlmRobertaConfig) -> Self {
+        let dtype = config.dtype.clone();
+        let hidden = config.hidden_size;
+        let vocab = config.vocab_size;
+        let model = XlmRobertaModel::empty(config);
+        Self {
+            model,
+            sparse_head: Some(SparseHead::empty(hidden, vocab, dtype.clone())),
+            colbert_head: Some(ColbertHead::empty(hidden, hidden, dtype)),
+            normalize_dense: true,
+        }
+    }
+
+    /// Eager forward computing all requested embedding types.
+    pub fn encode(&self, input_ids: &Tensor, attention_mask: &Tensor, opts: EncodeOpts) -> Result<BgeM3Output> {
+        let hidden = self.model.forward(input_ids, Some(attention_mask))?;
+        let mut out = BgeM3Output::default();
+
+        if opts.return_dense {
+            let dense = cls(&hidden)?;
+            out.dense_vecs =
+                Some(if self.normalize_dense { dense.lp_normalize(-1, 2).context(TensorSnafu)? } else { dense });
+        }
+        if opts.return_sparse {
+            let head = self.sparse_head.as_ref().context(SymbolicShapeSnafu { what: "sparse_head" })?;
+            out.sparse_vecs = Some(head.forward(&hidden, input_ids)?);
+        }
+        if opts.return_colbert {
+            let head = self.colbert_head.as_ref().context(SymbolicShapeSnafu { what: "colbert_head" })?;
+            out.colbert_vecs = Some(head.forward(&hidden, Some(attention_mask))?);
+        }
+        Ok(out)
+    }
+
+    /// Dense-only forward (most common path). Returns `(B, D)`.
+    pub fn encode_dense(&self, input_ids: &Tensor, attention_mask: &Tensor) -> Result<Tensor> {
+        let hidden = self.model.forward(input_ids, Some(attention_mask))?;
+        let dense = cls(&hidden)?;
+        if self.normalize_dense { dense.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(dense) }
+    }
+
+    /// JIT-path dense forward with rebindable batch. Returns `(B, D)`.
+    pub fn encode_dense_batch(&self, input_ids: &Tensor, attention_mask: &Tensor, b: &BoundVariable) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, Some(attention_mask), b)?;
+        let dense = cls(&hidden)?;
+        if self.normalize_dense { dense.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(dense) }
+    }
+
+    /// JIT-path ColBERT forward with rebindable batch. Returns `(B, L-1, Dc)`.
+    pub fn encode_colbert_batch(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, Some(attention_mask), b)?;
+        let head = self.colbert_head.as_ref().context(SymbolicShapeSnafu { what: "colbert_head" })?;
+        head.forward(&hidden, Some(attention_mask))
+    }
+
+    /// Download all files from HuggingFace Hub and load the full BGE-M3 model.
+    pub fn from_hub(model_id: &str, mut config: XlmRobertaConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut XlmRobertaConfig) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = XlmRobertaConfig::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let weights_path = repo.get("pytorch_model.bin").context(HubSnafu)?;
+        let dtype = config.dtype.clone();
+        let model = XlmRobertaModel::from_pytorch_bin(&weights_path, config.clone())?;
+
+        let sparse_head = match repo.get("sparse_linear.pt") {
+            Ok(path) => Some(SparseHead::from_pytorch_bin(&path, config.vocab_size, dtype.clone())?),
+            Err(_) => None,
+        };
+        let colbert_head = match repo.get("colbert_linear.pt") {
+            Ok(path) => Some(ColbertHead::from_pytorch_bin(&path, config.hidden_size, dtype)?),
+            Err(_) => None,
+        };
+
+        Ok(Self { model, sparse_head, colbert_head, normalize_dense: true })
+    }
+}

--- a/model/src/bgem3/jit.rs
+++ b/model/src/bgem3/jit.rs
@@ -1,0 +1,53 @@
+//! JIT wrappers for BGE-M3 and BGE-reranker-v2-m3.
+
+extern crate self as svod_model;
+
+use svod_macros::jit_wrapper;
+
+use super::embedder::BgeM3;
+use super::reranker::BgeRerankerV2M3;
+
+jit_wrapper! {
+    BgeM3DenseJit(BgeM3) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.encode_dense_batch(input_ids, attention_mask, &b)
+        }
+    }
+}
+
+jit_wrapper! {
+    BgeM3ColbertJit(BgeM3) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.encode_colbert_batch(input_ids, attention_mask, &b)
+        }
+    }
+}
+
+jit_wrapper! {
+    BgeRerankerJit(BgeRerankerV2M3) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.forward_batch(input_ids, Some(attention_mask), &b)
+        }
+    }
+}

--- a/model/src/bgem3/mod.rs
+++ b/model/src/bgem3/mod.rs
@@ -1,0 +1,24 @@
+//! BGE-M3 — multilingual embedding model and reranker (`BAAI/bge-m3`).
+//!
+//! Built on the [`crate::xlm_roberta`] backbone. Three retrieval heads:
+//!
+//! - **Dense**: CLS pooling + L2 normalize → `(B, D)`
+//! - **Sparse**: Linear → ReLU → scatter-to-vocab → `(B, vocab_size)`
+//! - **ColBERT**: per-token Linear (skip CLS) + L2 normalize → `(B, L-1, Dc)`
+//!
+//! Also provides [`BgeRerankerV2M3`] (`BAAI/bge-reranker-v2-m3`), a cross-encoder
+//! reranker sharing the same XLM-RoBERTa backbone with a classification head.
+
+mod colbert_head;
+mod embedder;
+mod jit;
+mod reranker;
+mod scoring;
+mod sparse_head;
+
+pub use colbert_head::ColbertHead;
+pub use embedder::{BgeM3, BgeM3Output, EncodeOpts};
+pub use jit::{BgeM3ColbertJit, BgeM3DenseJit, BgeRerankerJit};
+pub use reranker::BgeRerankerV2M3;
+pub use scoring::{colbert_score, dense_score, hybrid_score, sparse_score};
+pub use sparse_head::SparseHead;

--- a/model/src/bgem3/reranker.rs
+++ b/model/src/bgem3/reranker.rs
@@ -1,0 +1,164 @@
+//! BGE-reranker-v2-m3: XLM-RoBERTa backbone + sequence classification head.
+//!
+//! Cross-encoder reranker fine-tuned from `BAAI/bge-m3`. The tokenizer
+//! concatenates `(query, passage)` into a single input sequence with
+//! `<s> query </s></s> passage </s>`; the model runs the backbone, takes the
+//! CLS token, applies the two-layer classification head (`dense → tanh →
+//! out_proj`), and optionally sigmoid-normalizes.
+//!
+//! Same backbone as [`crate::xlm_roberta::XlmRobertaModel`] — only the head
+//! differs. Loads from `model.safetensors` with `roberta.` prefix on backbone
+//! keys.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, cast_all, get_tensor, prefixed};
+use crate::xlm_roberta::config::XlmRobertaConfig;
+use crate::xlm_roberta::error::{HubSnafu, Result, StateSnafu, TensorSnafu};
+use crate::xlm_roberta::model::XlmRobertaModel;
+use crate::xlm_roberta::pooling::cls;
+
+/// `RobertaClassificationHead`: `dense(D, D) → tanh → out_proj(D, num_labels)`.
+#[derive(Clone)]
+pub struct ClassificationHead {
+    pub dense_weight: Tensor,
+    pub dense_bias: Tensor,
+    pub out_proj_weight: Tensor,
+    pub out_proj_bias: Tensor,
+}
+
+impl ClassificationHead {
+    pub fn empty(hidden_size: usize, num_labels: usize, dtype: DType) -> Self {
+        Self {
+            dense_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            dense_bias: zeros(&[hidden_size], dtype.clone()),
+            out_proj_weight: fan_in_uniform(&[num_labels, hidden_size], hidden_size, dtype.clone()),
+            out_proj_bias: zeros(&[num_labels], dtype),
+        }
+    }
+
+    /// Forward: `CLS → dense → tanh → out_proj → (B, num_labels)`.
+    pub fn forward(&self, hidden: &Tensor) -> Result<Tensor> {
+        let cls_emb = cls(hidden)?;
+        let h = cls_emb.linear().weight(&self.dense_weight).bias(&self.dense_bias).call().context(TensorSnafu)?;
+        let h = h.tanh().context(TensorSnafu)?;
+        h.linear().weight(&self.out_proj_weight).bias(&self.out_proj_bias).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for ClassificationHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "dense.weight"), self.dense_weight.clone());
+        sd.insert(prefixed(prefix, "dense.bias"), self.dense_bias.clone());
+        sd.insert(prefixed(prefix, "out_proj.weight"), self.out_proj_weight.clone());
+        sd.insert(prefixed(prefix, "out_proj.bias"), self.out_proj_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.dense_weight = get_tensor(sd, &prefixed(prefix, "dense.weight"))?;
+        self.dense_bias = get_tensor(sd, &prefixed(prefix, "dense.bias"))?;
+        self.out_proj_weight = get_tensor(sd, &prefixed(prefix, "out_proj.weight"))?;
+        self.out_proj_bias = get_tensor(sd, &prefixed(prefix, "out_proj.bias"))?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct BgeRerankerV2M3 {
+    pub model: XlmRobertaModel,
+    pub classifier: ClassificationHead,
+}
+
+impl BgeRerankerV2M3 {
+    pub fn empty(config: XlmRobertaConfig) -> Self {
+        let dtype = config.dtype.clone();
+        let hidden = config.hidden_size;
+        Self { model: XlmRobertaModel::empty(config), classifier: ClassificationHead::empty(hidden, 1, dtype) }
+    }
+
+    /// Forward: backbone → classification head → logits `(B, 1)`.
+    pub fn forward(&self, input_ids: &Tensor, attention_mask: Option<&Tensor>) -> Result<Tensor> {
+        let hidden = self.model.forward(input_ids, attention_mask)?;
+        self.classifier.forward(&hidden)
+    }
+
+    /// Score with optional sigmoid normalization. Returns `(B, 1)`.
+    pub fn compute_score(&self, input_ids: &Tensor, attention_mask: &Tensor, normalize: bool) -> Result<Tensor> {
+        let logits = self.forward(input_ids, Some(attention_mask))?;
+        if normalize { logits.sigmoid().context(TensorSnafu) } else { Ok(logits) }
+    }
+
+    /// JIT-path forward with rebindable batch. Returns `(B, 1)`.
+    pub fn forward_batch(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: Option<&Tensor>,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, attention_mask, b)?;
+        self.classifier.forward(&hidden)
+    }
+
+    /// Download from HuggingFace Hub and load.
+    pub fn from_hub(model_id: &str, mut config: XlmRobertaConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut XlmRobertaConfig) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = XlmRobertaConfig::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let weights_path = repo.get("model.safetensors").context(HubSnafu)?;
+        Self::from_safetensors(&weights_path, config.clone())
+    }
+
+    /// Load from a `model.safetensors` checkpoint. Strips the `roberta.`
+    /// prefix from backbone keys.
+    pub fn from_safetensors(path: &std::path::Path, config: XlmRobertaConfig) -> Result<Self> {
+        let sd = crate::state::load_safetensors(path).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Build from a preloaded state dict. Strips `roberta.` prefix.
+    pub fn from_state_dict(sd: &StateDict, config: XlmRobertaConfig) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let stripped = strip_roberta_prefix(sd);
+        let sd_cast = cast_all(&stripped, dtype);
+        let mut model = Self::empty(config);
+        model.load_state_dict(&sd_cast, "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for BgeRerankerV2M3 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.model.state_dict(prefix);
+        sd.extend(self.classifier.state_dict(&prefixed(prefix, "classifier")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.model.load_state_dict(sd, prefix)?;
+        self.classifier.load_state_dict(sd, &prefixed(prefix, "classifier"))?;
+        Ok(())
+    }
+}
+
+fn strip_roberta_prefix(sd: &StateDict) -> StateDict {
+    sd.iter()
+        .map(|(k, v)| {
+            let stripped = k.strip_prefix("roberta.").unwrap_or(k);
+            (stripped.to_string(), v.clone())
+        })
+        .collect()
+}

--- a/model/src/bgem3/scoring.rs
+++ b/model/src/bgem3/scoring.rs
@@ -1,0 +1,60 @@
+//! Scoring functions for BGE-M3 multi-modal retrieval.
+//!
+//! All functions operate on **pre-computed** embeddings, so they can be used
+//! with stored/indexed vectors without re-running the model.
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::Tensor;
+
+use crate::xlm_roberta::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// Dense retrieval score: `q @ p^T`. `q`: `(Bq, D)`, `p`: `(Bp, D)` → `(Bq, Bp)`.
+pub fn dense_score(q: &Tensor, p: &Tensor) -> Result<Tensor> {
+    q.matmul(&p.try_transpose(-1, -2).context(TensorSnafu)?).context(TensorSnafu)
+}
+
+/// Sparse (lexical) retrieval score: `q @ p^T`. Same operation as dense but on
+/// `(B, vocab_size)` sparse vectors.
+pub fn sparse_score(q: &Tensor, p: &Tensor) -> Result<Tensor> {
+    q.matmul(&p.try_transpose(-1, -2).context(TensorSnafu)?).context(TensorSnafu)
+}
+
+/// ColBERT MaxSim score for a single query-passage pair.
+///
+/// `q`: `(Lq, Dc)` query token vectors, `p`: `(Lp, Dc)` passage token vectors.
+/// Returns a scalar: `sum_i(max_j(q_i · p_j)) / Lq`.
+pub fn colbert_score(q: &Tensor, p: &Tensor) -> Result<Tensor> {
+    let token_scores = Tensor::einsum("in,jn->ij", &[q, p]).context(TensorSnafu)?;
+    let max_per_q = token_scores.max(-1).context(TensorSnafu)?;
+    let sum = max_per_q.sum(()).context(TensorSnafu)?;
+    let lq = q.shape().context(TensorSnafu)?;
+    let lq_val = Tensor::const_(
+        lq[0].as_const().context(SymbolicShapeSnafu { what: "colbert_score" })? as f64,
+        sum.uop().dtype(),
+    );
+    sum.try_div(&lq_val).context(TensorSnafu)
+}
+
+/// Hybrid score: weighted combination of dense, sparse, and colbert scores.
+///
+/// `weights = [dense_w, sparse_w, colbert_w]`. Combined as
+/// `(dense*w0 + sparse*w1 + colbert*w2) / (w0 + w1 + w2)`.
+pub fn hybrid_score(dense: &Tensor, sparse: &Tensor, colbert: &Tensor, weights: &[f32; 3]) -> Result<Tensor> {
+    let dtype = dense.uop().dtype();
+    let w_sum = weights.iter().map(|w| *w as f64).sum::<f64>();
+    let w_sum_t = Tensor::const_(w_sum, dtype.clone());
+
+    let w0 = Tensor::const_(weights[0] as f64, dtype.clone());
+    let w1 = Tensor::const_(weights[1] as f64, dtype.clone());
+    let w2 = Tensor::const_(weights[2] as f64, dtype.clone());
+
+    let combined = dense
+        .try_mul(&w0)
+        .context(TensorSnafu)?
+        .try_add(&sparse.try_mul(&w1).context(TensorSnafu)?)
+        .context(TensorSnafu)?
+        .try_add(&colbert.try_mul(&w2).context(TensorSnafu)?)
+        .context(TensorSnafu)?;
+
+    combined.try_div(&w_sum_t).context(TensorSnafu)
+}

--- a/model/src/bgem3/sparse_head.rs
+++ b/model/src/bgem3/sparse_head.rs
@@ -1,0 +1,111 @@
+//! BGE-M3 sparse (lexical) embedding head.
+//!
+//! `Linear(D, 1, bias) → ReLU → scatter_reduce(input_ids, vocab, amax)`.
+//! Produces a `(B, vocab_size)` sparse embedding vector where each position
+//! holds the maximum ReLU activation across all tokens with that ID.
+//!
+//! Unused token positions (CLS, EOS, PAD, UNK) are zeroed post-scatter to
+//! match the FlagEmbedding convention.
+//!
+//! Weights are loaded from `sparse_linear.pt` (PyTorch pickle with bare
+//! `weight` / `bias` keys).
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+use svod_tensor::indexing::ScatterReduction;
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+use crate::xlm_roberta::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// XLM-RoBERTa special token IDs — always zeroed in sparse output.
+/// `<s>`=0, `<pad>`=1, `</s>`=2, `<unk>`=3.
+const XLM_R_SPECIAL_IDS: &[usize] = &[0, 1, 2, 3];
+
+#[derive(Clone)]
+pub struct SparseHead {
+    pub weight: Tensor,
+    pub bias: Tensor,
+    pub vocab_size: usize,
+}
+
+impl SparseHead {
+    pub fn empty(hidden_size: usize, vocab_size: usize, dtype: DType) -> Self {
+        Self {
+            weight: fan_in_uniform(&[1, hidden_size], hidden_size, dtype.clone()),
+            bias: zeros(&[1], dtype),
+            vocab_size,
+        }
+    }
+
+    /// Load from a `sparse_linear.pt` checkpoint (bare `weight`/`bias` keys).
+    pub fn from_pytorch_bin(path: &std::path::Path, vocab_size: usize, dtype: DType) -> Result<Self> {
+        let sd = crate::wespeaker::pickle::load_flat_pytorch_bin(path, "")
+            .map_err(|e| crate::xlm_roberta::Error::Pickle { source: Box::new(e) })?;
+        Self::from_state_dict(&sd, "", vocab_size, dtype)
+    }
+
+    /// Build from a preloaded state dict, casting to `dtype`.
+    pub fn from_state_dict(sd: &StateDict, prefix: &str, vocab_size: usize, dtype: DType) -> Result<Self> {
+        let sd = state::cast_all(sd, dtype.clone());
+        let mut head = Self::empty(0, vocab_size, dtype);
+        head.load_state_dict(&sd, prefix).map_err(|e| crate::xlm_roberta::Error::State { source: Box::new(e) })?;
+        Ok(head)
+    }
+
+    /// Forward. `hidden`: `(B, L, D)`, `input_ids`: `(B, L)` int.
+    /// Returns `(B, vocab_size)` sparse embedding with special-token positions zeroed.
+    pub fn forward(&self, hidden: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
+        let shape = hidden.shape().context(TensorSnafu)?;
+        let b: usize = shape[0].as_const().context(SymbolicShapeSnafu { what: "sparse_head" })?;
+
+        let token_weights = hidden
+            .linear()
+            .weight(&self.weight)
+            .bias(&self.bias)
+            .call()
+            .context(TensorSnafu)?
+            .relu()
+            .context(TensorSnafu)?;
+
+        let token_weights = token_weights.try_squeeze(Some(-1)).context(TensorSnafu)?;
+
+        let zeros = Tensor::zeros(&[b, self.vocab_size], hidden.uop().dtype()).expect("non-empty shape");
+        let sparse =
+            zeros.scatter_reduce(-1, input_ids, &token_weights, ScatterReduction::Amax, true).context(TensorSnafu)?;
+
+        let mask = self.unused_token_mask(hidden.uop().dtype())?;
+        sparse.try_mul(&mask).context(TensorSnafu)
+    }
+
+    fn unused_token_mask(&self, dtype: DType) -> Result<Tensor> {
+        let mut vals = vec![1.0f32; self.vocab_size];
+        for &id in XLM_R_SPECIAL_IDS {
+            if id < self.vocab_size {
+                vals[id] = 0.0;
+            }
+        }
+        let mask = Tensor::from_slice(&vals)
+            .try_reshape([1isize, self.vocab_size as isize])
+            .context(TensorSnafu)?
+            .cast(dtype)
+            .context(TensorSnafu)?;
+        Ok(mask)
+    }
+}
+
+impl HasStateDict for SparseHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd.insert(prefixed(prefix, "bias"), self.bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        self.bias = get_tensor(sd, &prefixed(prefix, "bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/gigaam/remap.rs
+++ b/model/src/gigaam/remap.rs
@@ -62,7 +62,7 @@ fn remap_key(key: &str, config: &GigaAmConfig) -> Option<String> {
     }
 
     if parts.len() >= 4 && parts[..2] == ["head", "decoder_layers"] {
-        return Some(format!("head.{}", &parts[3..].join(".")));
+        return Some(format!("head.{}", parts[3..].join(".")));
     }
 
     // RNN-T predictor: head.decoder.embed.weight, head.decoder.lstm.{w,b}_{ih,hh}_l{N}.

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod bgem3;
 pub mod blocks;
 pub mod diarizen;
 pub mod firered_vad;
@@ -12,6 +13,7 @@ pub mod silero_vad;
 pub mod state;
 pub mod wavlm;
 pub mod wespeaker;
+pub mod xlm_roberta;
 
 #[cfg(test)]
 mod test;

--- a/model/src/test/unit/bgem3/bge_m3.rs
+++ b/model/src/test/unit/bgem3/bge_m3.rs
@@ -1,0 +1,71 @@
+use crate::bgem3::{BgeM3, BgeRerankerV2M3, EncodeOpts};
+use crate::state::HasStateDict;
+use crate::xlm_roberta::XlmRobertaConfig;
+use svod_dtype::DType;
+
+fn tiny_cfg() -> XlmRobertaConfig {
+    XlmRobertaConfig {
+        vocab_size: 100,
+        hidden_size: 32,
+        num_hidden_layers: 2,
+        num_attention_heads: 4,
+        intermediate_size: 64,
+        max_position_embeddings: 20,
+        type_vocab_size: 1,
+        layer_norm_eps: 1e-5,
+        pad_token_id: 1,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}
+
+#[test]
+fn bgem3_encode_dense_shape() {
+    let model = BgeM3::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2]).try_reshape([1isize, 4]).unwrap();
+    let mask = svod_tensor::Tensor::from_slice([1i64, 1, 1, 1]).try_reshape([1isize, 4]).unwrap();
+    let mut dense = model.encode_dense(&ids, &mask).unwrap();
+    dense.realize().unwrap();
+    let s = dense.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 32);
+}
+
+#[test]
+fn bgem3_encode_all_modalities() {
+    let model = BgeM3::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2]).try_reshape([1isize, 4]).unwrap();
+    let mask = svod_tensor::Tensor::from_slice([1i64, 1, 1, 1]).try_reshape([1isize, 4]).unwrap();
+    let out = model.encode(&ids, &mask, EncodeOpts::all()).unwrap();
+    assert!(out.dense_vecs.is_some());
+    assert!(out.sparse_vecs.is_some());
+    assert!(out.colbert_vecs.is_some());
+}
+
+#[test]
+fn reranker_forward_shape() {
+    let model = BgeRerankerV2M3::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2, 1]).try_reshape([1isize, 5]).unwrap();
+    let mask = svod_tensor::Tensor::from_slice([1i64, 1, 1, 1, 0]).try_reshape([1isize, 5]).unwrap();
+    let mut out = model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 1);
+}
+
+#[test]
+fn reranker_state_dict_round_trip() {
+    let model = BgeRerankerV2M3::empty(tiny_cfg());
+    let sd = model.state_dict("");
+    assert!(sd.contains_key("classifier.dense.weight"));
+    assert!(sd.contains_key("classifier.out_proj.weight"));
+    assert!(sd.contains_key("embeddings.word_embeddings.weight"));
+    let mut model2 = BgeRerankerV2M3::empty(tiny_cfg());
+    model2.load_state_dict(&sd, "").unwrap();
+    let mut k1: Vec<String> = sd.keys().cloned().collect();
+    let mut k2: Vec<String> = model2.state_dict("").keys().cloned().collect();
+    k1.sort();
+    k2.sort();
+    assert_eq!(k1, k2);
+}

--- a/model/src/test/unit/bgem3/heads.rs
+++ b/model/src/test/unit/bgem3/heads.rs
@@ -1,0 +1,42 @@
+use crate::bgem3::{ColbertHead, SparseHead};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+#[test]
+fn sparse_head_forward_shape() {
+    let head = SparseHead::empty(32, 100, DType::Float32);
+    let hidden = Tensor::zeros(&[2, 5, 32], DType::Float32).unwrap();
+    let ids = Tensor::from_slice([0i64, 10, 20, 2, 1, 0, 10, 20, 2, 1]).try_reshape([2, 5]).unwrap();
+    let mut out = head.forward(&hidden, &ids).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 2);
+    assert_eq!(s[1].as_const().unwrap(), 100);
+}
+
+#[test]
+fn sparse_head_zeros_special_tokens() {
+    let head = SparseHead::empty(32, 100, DType::Float32);
+    let hidden = Tensor::ones(&[1, 3, 32], DType::Float32).unwrap();
+    let ids = Tensor::from_slice([0i64, 50, 2]).try_reshape([1, 3]).unwrap();
+    let mut out = head.forward(&hidden, &ids).unwrap();
+    out.realize().unwrap();
+    let vals = out.as_vec::<f32>().unwrap();
+    assert_eq!(vals[0], 0.0); // CLS
+    assert_eq!(vals[1], 0.0); // PAD
+    assert_eq!(vals[2], 0.0); // EOS
+    assert_eq!(vals[3], 0.0); // UNK
+}
+
+#[test]
+fn colbert_head_forward_shape() {
+    let head = ColbertHead::empty(32, 32, DType::Float32);
+    let hidden = Tensor::zeros(&[2, 6, 32], DType::Float32).unwrap();
+    let mask = Tensor::from_slice([1i64, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0]).try_reshape([2, 6]).unwrap();
+    let mut out = head.forward(&hidden, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 2);
+    assert_eq!(s[1].as_const().unwrap(), 5);
+    assert_eq!(s[2].as_const().unwrap(), 32);
+}

--- a/model/src/test/unit/bgem3/mod.rs
+++ b/model/src/test/unit/bgem3/mod.rs
@@ -1,0 +1,4 @@
+mod bge_m3;
+mod heads;
+mod parity;
+mod scoring;

--- a/model/src/test/unit/bgem3/parity.rs
+++ b/model/src/test/unit/bgem3/parity.rs
@@ -1,0 +1,173 @@
+//! Parity tests comparing Rust model outputs against PyTorch/HuggingFace golden
+//! reference outputs.
+//!
+//! Run with:
+//!   SVOD_BGEM3=$PWD/data/bgem3 cargo test -p svod-model --lib bgem3::parity -- --ignored
+
+use crate::bgem3::{BgeM3, BgeRerankerV2M3, EncodeOpts};
+use crate::state::{self, StateDict};
+use crate::xlm_roberta::XlmRobertaConfig;
+use std::path::PathBuf;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+const HUB_REPO: &str = "BAAI/bge-m3";
+const RERANKER_HUB: &str = "BAAI/bge-reranker-v2-m3";
+
+fn real_file(name: &str) -> PathBuf {
+    resolve_file(name, HUB_REPO)
+}
+
+fn real_file_reranker(name: &str) -> PathBuf {
+    resolve_file(name, RERANKER_HUB)
+}
+
+fn resolve_file(name: &str, hub_repo: &str) -> PathBuf {
+    if let Ok(dir) = std::env::var("SVOD_BGEM3") {
+        let p = PathBuf::from(dir).join(name);
+        if p.exists() {
+            return p;
+        }
+    }
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../data/bgem3").join(name);
+    if p.exists() {
+        return p;
+    }
+    let api = hf_hub::api::sync::Api::new().expect("HF Hub API");
+    let repo = hf_hub::Repo::with_revision(hub_repo.into(), hf_hub::RepoType::Model, "main".into());
+    api.repo(repo).get(name).unwrap_or_else(|_| panic!("download {name} from {hub_repo}"))
+}
+
+fn load_fixture() -> (BgeM3, StateDict) {
+    let golden = state::load_safetensors(&real_file("golden.safetensors")).expect("golden");
+    let mut cfg = XlmRobertaConfig::from_json(&real_file("config.json")).expect("config");
+    cfg.dtype = DType::Float32;
+    let dtype = cfg.dtype.clone();
+    let backbone = crate::xlm_roberta::XlmRobertaModel::from_pytorch_bin(&real_file("pytorch_model.bin"), cfg).unwrap();
+    let sparse = real_file("sparse_linear.pt");
+    let sparse = if sparse.exists() {
+        Some(crate::bgem3::SparseHead::from_pytorch_bin(&sparse, backbone.config.vocab_size, dtype.clone()).unwrap())
+    } else {
+        None
+    };
+    let colbert = real_file("colbert_linear.pt");
+    let colbert = if colbert.exists() {
+        Some(crate::bgem3::ColbertHead::from_pytorch_bin(&colbert, backbone.config.hidden_size, dtype).unwrap())
+    } else {
+        None
+    };
+    (BgeM3 { model: backbone, sparse_head: sparse, colbert_head: colbert, normalize_dense: true }, golden)
+}
+
+fn load_golden_vec<T: Clone + Default + svod_dtype::ext::HasDType>(sd: &StateDict, key: &str) -> Vec<T> {
+    let mut t = sd.get(key).unwrap_or_else(|| panic!("missing golden key: {key}")).clone();
+    t.realize().unwrap();
+    t.as_vec::<T>().unwrap()
+}
+
+fn max_abs_delta(got: &[f32], want: &[f32]) -> f32 {
+    assert_eq!(got.len(), want.len());
+    got.iter().zip(want.iter()).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max)
+}
+
+fn prep_inputs(golden: &StateDict) -> (Tensor, Tensor) {
+    let ids = load_golden_vec::<i64>(golden, "input_ids");
+    let shape = load_golden_vec::<i64>(golden, "input_ids_shape");
+    let (b, t) = (shape[0] as usize, shape[1] as usize);
+    let mask = load_golden_vec::<i64>(golden, "attention_mask");
+    let input_ids = Tensor::from_slice(&ids).try_reshape([b as isize, t as isize]).unwrap();
+    let mask = Tensor::from_slice(&mask).try_reshape([b as isize, t as isize]).unwrap();
+    (input_ids, mask)
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn last_hidden_state_matches_pytorch() {
+    let (model, golden) = load_fixture();
+    let (ids, mask) = prep_inputs(&golden);
+    let mut out = model.model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let delta = max_abs_delta(&out.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "last_hidden_state"));
+    assert!(delta < 1e-3, "last_hidden_state max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn dense_vecs_match_pytorch() {
+    let (model, golden) = load_fixture();
+    let (ids, mask) = prep_inputs(&golden);
+    let mut dense = model.encode_dense(&ids, &mask).unwrap();
+    dense.realize().unwrap();
+    let delta = max_abs_delta(&dense.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "dense_vecs"));
+    assert!(delta < 1e-3, "dense_vecs max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn sparse_vecs_match_pytorch() {
+    let (model, golden) = load_fixture();
+    if model.sparse_head.is_none() {
+        eprintln!("skipping: no sparse_linear.pt");
+        return;
+    }
+    let (ids, mask) = prep_inputs(&golden);
+    let out = model
+        .encode(&ids, &mask, EncodeOpts { return_dense: false, return_sparse: true, return_colbert: false })
+        .unwrap();
+    let mut sparse = out.sparse_vecs.unwrap();
+    sparse.realize().unwrap();
+    let delta = max_abs_delta(&sparse.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "sparse_vecs"));
+    assert!(delta < 1e-3, "sparse_vecs max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn colbert_vecs_match_pytorch() {
+    let (model, golden) = load_fixture();
+    if model.colbert_head.is_none() {
+        eprintln!("skipping: no colbert_linear.pt");
+        return;
+    }
+    let (ids, mask) = prep_inputs(&golden);
+    let out = model
+        .encode(&ids, &mask, EncodeOpts { return_dense: false, return_sparse: false, return_colbert: true })
+        .unwrap();
+    let mut colbert = out.colbert_vecs.unwrap();
+    colbert.realize().unwrap();
+    let delta = max_abs_delta(&colbert.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "colbert_vecs"));
+    assert!(delta < 1e-2, "colbert_vecs max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn ignoring_padding_diverges_from_golden() {
+    let (model, golden) = load_fixture();
+    let (ids, _) = prep_inputs(&golden);
+    let t = load_golden_vec::<i64>(&golden, "input_ids_shape")[1] as usize;
+    let mask = Tensor::from_slice(vec![1i64; t]).try_reshape([1isize, t as isize]).unwrap();
+    let mut out = model.model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let delta = max_abs_delta(&out.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "last_hidden_state"));
+    assert!(delta > 1e-2, "all-ones mask did NOT diverge (delta={delta:.6})");
+}
+
+// --- Reranker ---
+
+fn load_reranker_fixture() -> (BgeRerankerV2M3, StateDict) {
+    let golden = state::load_safetensors(&real_file("golden_reranker.safetensors")).expect("golden");
+    let mut cfg = XlmRobertaConfig::from_json(&real_file_reranker("config.json")).expect("config");
+    cfg.dtype = DType::Float32;
+    let model = BgeRerankerV2M3::from_safetensors(&real_file_reranker("model.safetensors"), cfg).unwrap();
+    (model, golden)
+}
+
+#[test]
+#[ignore = "heavy: real BGE-reranker-v2-m3 weights + PyTorch golden"]
+fn reranker_logits_match_pytorch() {
+    let (model, golden) = load_reranker_fixture();
+    let (ids, mask) = prep_inputs(&golden);
+    let mut out = model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let delta = max_abs_delta(&out.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "logits"));
+    assert!(delta < 1e-3, "reranker logits max |delta| = {delta:.6}");
+}

--- a/model/src/test/unit/bgem3/scoring.rs
+++ b/model/src/test/unit/bgem3/scoring.rs
@@ -1,0 +1,29 @@
+use crate::bgem3::{colbert_score, dense_score, sparse_score};
+use svod_tensor::Tensor;
+
+#[test]
+fn dense_score_identity() {
+    let q = Tensor::from_slice([1.0f32, 0.0, 0.0]).try_reshape([1, 3]).unwrap();
+    let p = Tensor::from_slice([1.0f32, 0.0, 0.0]).try_reshape([1, 3]).unwrap();
+    let mut s = dense_score(&q, &p).unwrap();
+    s.realize().unwrap();
+    assert!((s.as_vec::<f32>().unwrap()[0] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn sparse_score_basic() {
+    let q = Tensor::from_slice([0.0f32, 2.0, 0.0, 3.0]).try_reshape([1, 4]).unwrap();
+    let p = Tensor::from_slice([0.0f32, 1.0, 0.0, 1.0]).try_reshape([1, 4]).unwrap();
+    let mut s = sparse_score(&q, &p).unwrap();
+    s.realize().unwrap();
+    assert!((s.as_vec::<f32>().unwrap()[0] - 5.0).abs() < 1e-6);
+}
+
+#[test]
+fn colbert_score_basic() {
+    let q = Tensor::from_slice([1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0]).try_reshape([2, 3]).unwrap();
+    let p = Tensor::from_slice([1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]).try_reshape([3, 3]).unwrap();
+    let mut s = colbert_score(&q, &p).unwrap();
+    s.realize().unwrap();
+    assert!((s.as_vec::<f32>().unwrap()[0] - 1.0).abs() < 1e-5);
+}

--- a/model/src/test/unit/mod.rs
+++ b/model/src/test/unit/mod.rs
@@ -1,5 +1,6 @@
 mod audio;
 mod batch;
+mod bgem3;
 mod bounds;
 mod config;
 mod diarizen;
@@ -17,3 +18,4 @@ mod state_dict;
 mod transcribe;
 mod wavlm;
 mod wespeaker;
+mod xlm_roberta;

--- a/model/src/test/unit/xlm_roberta/config.rs
+++ b/model/src/test/unit/xlm_roberta/config.rs
@@ -1,0 +1,44 @@
+use crate::xlm_roberta::{XlmRobertaConfig, xlm_roberta_large};
+use svod_dtype::DType;
+
+#[test]
+fn large_dims() {
+    let cfg = xlm_roberta_large();
+    assert_eq!(cfg.vocab_size, 250002);
+    assert_eq!(cfg.hidden_size, 1024);
+    assert_eq!(cfg.num_hidden_layers, 24);
+    assert_eq!(cfg.num_attention_heads, 16);
+    assert_eq!(cfg.head_dim(), 64);
+    assert_eq!(cfg.intermediate_size, 4096);
+    assert_eq!(cfg.max_position_embeddings, 8194);
+    assert_eq!(cfg.type_vocab_size, 1);
+    assert_eq!(cfg.pad_token_id, 1);
+    assert_eq!(cfg.layer_norm_eps, 1e-5);
+}
+
+#[test]
+fn parse_config_json() {
+    let json = r#"{
+        "vocab_size": 250002, "hidden_size": 1024, "num_hidden_layers": 24,
+        "num_attention_heads": 16, "intermediate_size": 4096,
+        "max_position_embeddings": 8194, "type_vocab_size": 1,
+        "layer_norm_eps": 1e-05, "pad_token_id": 1
+    }"#;
+    let cfg = XlmRobertaConfig::from_json_str(json).unwrap();
+    assert_eq!(cfg.vocab_size, 250002);
+    assert_eq!(cfg.pad_token_id, 1);
+}
+
+#[test]
+fn parse_norm_eps_alias() {
+    let cfg = XlmRobertaConfig::from_json_str(r#"{"norm_eps": 1e-5}"#).unwrap();
+    assert!((cfg.layer_norm_eps - 1e-5).abs() < 1e-12);
+}
+
+#[test]
+fn merge_preserves_dtype() {
+    let mut caller = XlmRobertaConfig { dtype: DType::Float32, max_batch_size: 4, ..xlm_roberta_large() };
+    caller.merge_structural_from(&xlm_roberta_large());
+    assert_eq!(caller.dtype, DType::Float32);
+    assert_eq!(caller.max_batch_size, 4);
+}

--- a/model/src/test/unit/xlm_roberta/mod.rs
+++ b/model/src/test/unit/xlm_roberta/mod.rs
@@ -1,0 +1,3 @@
+mod config;
+mod model;
+mod position_ids;

--- a/model/src/test/unit/xlm_roberta/model.rs
+++ b/model/src/test/unit/xlm_roberta/model.rs
@@ -1,0 +1,45 @@
+use crate::state::HasStateDict;
+use crate::xlm_roberta::{XlmRobertaConfig, XlmRobertaModel};
+use svod_dtype::DType;
+
+fn tiny_cfg() -> XlmRobertaConfig {
+    XlmRobertaConfig {
+        vocab_size: 100,
+        hidden_size: 32,
+        num_hidden_layers: 2,
+        num_attention_heads: 4,
+        intermediate_size: 64,
+        max_position_embeddings: 20,
+        type_vocab_size: 1,
+        layer_norm_eps: 1e-5,
+        pad_token_id: 1,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}
+
+#[test]
+fn forward_output_shape() {
+    let model = XlmRobertaModel::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2, 1]).try_reshape([1isize, 5]).unwrap();
+    let mut out = model.forward(&ids, None).unwrap();
+    out.realize().unwrap();
+    let v = out.as_vec::<f32>().unwrap();
+    assert_eq!(v.len(), 5 * 32);
+    assert!(v.iter().all(|x| x.is_finite()));
+}
+
+#[test]
+fn state_dict_round_trip() {
+    let model = XlmRobertaModel::empty(tiny_cfg());
+    let sd = model.state_dict("");
+    assert!(sd.contains_key("embeddings.word_embeddings.weight"));
+    assert!(sd.contains_key("encoder.layer.0.attention.self.query.weight"));
+    let mut model2 = XlmRobertaModel::empty(tiny_cfg());
+    model2.load_state_dict(&sd, "").unwrap();
+    let mut k1: Vec<String> = sd.keys().cloned().collect();
+    let mut k2: Vec<String> = model2.state_dict("").keys().cloned().collect();
+    k1.sort();
+    k2.sort();
+    assert_eq!(k1, k2);
+}

--- a/model/src/test/unit/xlm_roberta/position_ids.rs
+++ b/model/src/test/unit/xlm_roberta/position_ids.rs
@@ -1,0 +1,26 @@
+use crate::xlm_roberta::position_ids_from_input_ids;
+use svod_tensor::Tensor;
+
+#[test]
+fn position_ids_basic() {
+    let ids = Tensor::from_slice([0i64, 100, 200, 300, 2, 1, 1]).try_reshape([1, 7]).unwrap();
+    let mut pos = position_ids_from_input_ids(&ids, 1).unwrap();
+    pos.realize().unwrap();
+    assert_eq!(pos.as_vec::<i32>().unwrap(), vec![2, 3, 4, 5, 6, 1, 1]);
+}
+
+#[test]
+fn position_ids_all_real() {
+    let ids = Tensor::from_slice([0i64, 100, 200, 2]).try_reshape([1, 4]).unwrap();
+    let mut pos = position_ids_from_input_ids(&ids, 1).unwrap();
+    pos.realize().unwrap();
+    assert_eq!(pos.as_vec::<i32>().unwrap(), vec![2, 3, 4, 5]);
+}
+
+#[test]
+fn position_ids_leading_padding() {
+    let ids = Tensor::from_slice([1i64, 1, 0, 100, 2]).try_reshape([1, 5]).unwrap();
+    let mut pos = position_ids_from_input_ids(&ids, 1).unwrap();
+    pos.realize().unwrap();
+    assert_eq!(pos.as_vec::<i32>().unwrap(), vec![1, 1, 2, 3, 4]);
+}

--- a/model/src/wespeaker/pickle.rs
+++ b/model/src/wespeaker/pickle.rs
@@ -116,8 +116,8 @@ fn load_pytorch_bin_with_state_dict_key(
             unwrap_ordered_dict_items(state_dict_value)
                 .context(StructureSnafu { context: format!("{key} value is not an OrderedDict") })?
         }
-        None => unwrap_ordered_dict_items(toplevel)
-            .or_else(|| unwrap_outer_dict(toplevel))
+        None => unwrap_outer_dict(toplevel)
+            .or_else(|| unwrap_ordered_dict_items(toplevel))
             .context(StructureSnafu { context: "toplevel not recognised as a flat OrderedDict" })?,
     };
 

--- a/model/src/xlm_roberta/attention.rs
+++ b/model/src/xlm_roberta/attention.rs
@@ -1,0 +1,121 @@
+//! XLM-RoBERTa self-attention with separate biased Q/K/V/O projections.
+//!
+//! Standard BERT-style multi-head attention: separate `Linear(D, D, bias)` for
+//! Q, K, V; reshape to `(B, H, L, hd)`; scaled dot-product attention (global,
+//! no window); output `Linear(D, D, bias)`. No RoPE, no relative positions.
+//!
+//! State-dict keys match the published `BAAI/bge-m3` `pytorch_model.bin`:
+//! `attention.self.{query,key,value}.{weight,bias}`,
+//! `attention.output.dense.{weight,bias}`.
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct XlmRobertaAttention {
+    pub hidden_size: usize,
+    pub num_heads: usize,
+    pub head_dim: usize,
+    pub query_weight: Tensor,
+    pub query_bias: Tensor,
+    pub key_weight: Tensor,
+    pub key_bias: Tensor,
+    pub value_weight: Tensor,
+    pub value_bias: Tensor,
+    pub out_weight: Tensor,
+    pub out_bias: Tensor,
+}
+
+impl XlmRobertaAttention {
+    pub fn empty(hidden_size: usize, num_heads: usize, head_dim: usize, dtype: DType) -> Self {
+        Self {
+            hidden_size,
+            num_heads,
+            head_dim,
+            query_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            query_bias: zeros(&[hidden_size], dtype.clone()),
+            key_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            key_bias: zeros(&[hidden_size], dtype.clone()),
+            value_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            value_bias: zeros(&[hidden_size], dtype.clone()),
+            out_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            out_bias: zeros(&[hidden_size], dtype),
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)`. Returns `(B, L, D)`.
+    /// `padding_mask`: optional bool `(B, 1, 1, L)` where `true` masks out
+    /// (padding) positions in the KEY axis.
+    pub fn forward(&self, x: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = x.shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+        let l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "attention" })?;
+        let h = self.num_heads as isize;
+        let hd = self.head_dim as isize;
+        let bsint: SInt = b;
+
+        let q = x.linear().weight(&self.query_weight).bias(&self.query_bias).call().context(TensorSnafu)?;
+        let k = x.linear().weight(&self.key_weight).bias(&self.key_bias).call().context(TensorSnafu)?;
+        let v = x.linear().weight(&self.value_weight).bias(&self.value_bias).call().context(TensorSnafu)?;
+
+        let to_heads = |t: Tensor| -> Result<Tensor> {
+            t.view([bsint.clone(), l.into(), h.into(), hd.into()])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)
+        };
+        let q = to_heads(q)?;
+        let k = to_heads(k)?;
+        let v = to_heads(v)?;
+
+        let attn = q
+            .scaled_dot_product_attention()
+            .key(&k)
+            .value(&v)
+            .maybe_attn_mask(padding_mask)
+            .call()
+            .context(TensorSnafu)?;
+
+        let attn = attn
+            .try_permute(&[0, 2, 1, 3])
+            .context(TensorSnafu)?
+            .view([bsint, l.into(), (self.num_heads * self.head_dim).into()])
+            .context(TensorSnafu)?;
+
+        attn.linear().weight(&self.out_weight).bias(&self.out_bias).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for XlmRobertaAttention {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "self.query.weight"), self.query_weight.clone());
+        sd.insert(prefixed(prefix, "self.query.bias"), self.query_bias.clone());
+        sd.insert(prefixed(prefix, "self.key.weight"), self.key_weight.clone());
+        sd.insert(prefixed(prefix, "self.key.bias"), self.key_bias.clone());
+        sd.insert(prefixed(prefix, "self.value.weight"), self.value_weight.clone());
+        sd.insert(prefixed(prefix, "self.value.bias"), self.value_bias.clone());
+        sd.insert(prefixed(prefix, "output.dense.weight"), self.out_weight.clone());
+        sd.insert(prefixed(prefix, "output.dense.bias"), self.out_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.query_weight = get_tensor(sd, &prefixed(prefix, "self.query.weight"))?;
+        self.query_bias = get_tensor(sd, &prefixed(prefix, "self.query.bias"))?;
+        self.key_weight = get_tensor(sd, &prefixed(prefix, "self.key.weight"))?;
+        self.key_bias = get_tensor(sd, &prefixed(prefix, "self.key.bias"))?;
+        self.value_weight = get_tensor(sd, &prefixed(prefix, "self.value.weight"))?;
+        self.value_bias = get_tensor(sd, &prefixed(prefix, "self.value.bias"))?;
+        self.out_weight = get_tensor(sd, &prefixed(prefix, "output.dense.weight"))?;
+        self.out_bias = get_tensor(sd, &prefixed(prefix, "output.dense.bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/config.rs
+++ b/model/src/xlm_roberta/config.rs
@@ -1,0 +1,122 @@
+//! XLM-RoBERTa configuration, parsed from HuggingFace `config.json`.
+//!
+//! Mirrors the published schema of `BAAI/bge-m3` (XLM-RoBERTa-large). The
+//! [`RawXlmRobertaConfig`] serde mirror captures the on-disk shape; the clean
+//! [`XlmRobertaConfig`] keeps only the fields the Rust backbone consumes and
+//! adds a caller-chosen compute [`DType`] (defaults to bf16 on the AMD target,
+//! f32 for CPU parity tests).
+
+use std::path::Path;
+
+use serde::Deserialize;
+use svod_dtype::DType;
+
+use super::error::{Error, Result};
+
+/// Clean, resolved XLM-RoBERTa config.
+#[derive(Clone, Debug)]
+pub struct XlmRobertaConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub intermediate_size: usize,
+    pub max_position_embeddings: usize,
+    pub type_vocab_size: usize,
+    pub layer_norm_eps: f64,
+    /// XLM-RoBERTa padding index (= `pad_token_id`). Position IDs are offset
+    /// by this value: real tokens start at `padding_idx + 1`.
+    pub pad_token_id: usize,
+    /// Caller-chosen compute dtype (bf16 by default; f32 for CPU parity).
+    pub dtype: DType,
+    /// Upper bound on the symbolic batch variable in the JIT wrapper.
+    pub max_batch_size: usize,
+}
+
+impl XlmRobertaConfig {
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+
+    /// Splice in the structural fields parsed from the published `config.json`,
+    /// preserving the caller-chosen `dtype` / `max_batch_size`. Shared by the
+    /// backbone and head Hub loaders so both stay in sync.
+    pub fn merge_structural_from(&mut self, parsed: &Self) {
+        self.vocab_size = parsed.vocab_size;
+        self.hidden_size = parsed.hidden_size;
+        self.num_hidden_layers = parsed.num_hidden_layers;
+        self.num_attention_heads = parsed.num_attention_heads;
+        self.intermediate_size = parsed.intermediate_size;
+        self.max_position_embeddings = parsed.max_position_embeddings;
+        self.type_vocab_size = parsed.type_vocab_size;
+        self.layer_norm_eps = parsed.layer_norm_eps;
+        self.pad_token_id = parsed.pad_token_id;
+    }
+
+    /// Parse a HuggingFace `config.json`. Unrecognized fields are ignored; any
+    /// of the structural fields below that is absent falls back to the
+    /// XLM-RoBERTa-large defaults.
+    pub fn from_json(path: &Path) -> Result<Self> {
+        let data = std::fs::read_to_string(path)
+            .map_err(|e| Error::Config { message: format!("reading config.json: {e}") })?;
+        Self::from_json_str(&data)
+    }
+
+    pub fn from_json_str(data: &str) -> Result<Self> {
+        let raw: RawXlmRobertaConfig =
+            serde_json::from_str(data).map_err(|e| Error::Config { message: format!("JSON parse error: {e}") })?;
+        Ok(Self::from_raw(raw))
+    }
+
+    fn from_raw(raw: RawXlmRobertaConfig) -> Self {
+        let base = xlm_roberta_large();
+        XlmRobertaConfig {
+            vocab_size: raw.vocab_size.unwrap_or(base.vocab_size),
+            hidden_size: raw.hidden_size.unwrap_or(base.hidden_size),
+            num_hidden_layers: raw.num_hidden_layers.unwrap_or(base.num_hidden_layers),
+            num_attention_heads: raw.num_attention_heads.unwrap_or(base.num_attention_heads),
+            intermediate_size: raw.intermediate_size.unwrap_or(base.intermediate_size),
+            max_position_embeddings: raw.max_position_embeddings.unwrap_or(base.max_position_embeddings),
+            type_vocab_size: raw.type_vocab_size.unwrap_or(base.type_vocab_size),
+            layer_norm_eps: raw.layer_norm_eps.or(raw.norm_eps).unwrap_or(base.layer_norm_eps),
+            pad_token_id: raw.pad_token_id.unwrap_or(base.pad_token_id),
+            dtype: base.dtype,
+            max_batch_size: base.max_batch_size,
+        }
+    }
+}
+
+/// `BAAI/bge-m3` / XLM-RoBERTa-large: 24 layers, hidden 1024, intermediate
+/// 4096, 16 heads (head_dim 64), vocab 250002, position embeddings 8194.
+pub fn xlm_roberta_large() -> XlmRobertaConfig {
+    XlmRobertaConfig {
+        vocab_size: 250002,
+        hidden_size: 1024,
+        num_hidden_layers: 24,
+        num_attention_heads: 16,
+        intermediate_size: 4096,
+        max_position_embeddings: 8194,
+        type_vocab_size: 1,
+        layer_norm_eps: 1e-5,
+        pad_token_id: 1,
+        dtype: DType::BFloat16,
+        max_batch_size: 1,
+    }
+}
+
+/// Serde mirror of the published `config.json`. Every field is optional so a
+/// missing field falls back to the large defaults rather than failing.
+#[derive(Deserialize)]
+struct RawXlmRobertaConfig {
+    vocab_size: Option<usize>,
+    hidden_size: Option<usize>,
+    num_hidden_layers: Option<usize>,
+    num_attention_heads: Option<usize>,
+    intermediate_size: Option<usize>,
+    max_position_embeddings: Option<usize>,
+    type_vocab_size: Option<usize>,
+    /// XLM-RoBERTa publishes both `layer_norm_eps` and `norm_eps` (equal).
+    layer_norm_eps: Option<f64>,
+    norm_eps: Option<f64>,
+    pad_token_id: Option<usize>,
+}

--- a/model/src/xlm_roberta/embeddings.rs
+++ b/model/src/xlm_roberta/embeddings.rs
@@ -1,0 +1,85 @@
+//! XLM-RoBERTa embeddings: word + position + token_type → LayerNorm.
+//!
+//! Unlike ModernBERT (which uses RoPE and has no position embeddings),
+//! XLM-RoBERTa uses **absolute learned position embeddings** with the fairseq
+//! `make_positions` offset (see [`super::position_ids`]).
+//!
+//! Token-type embeddings: `type_vocab_size = 1`, so only row 0 exists and is
+//! always selected (token_type_ids are implicitly zeros). We broadcast row 0
+//! directly instead of constructing a zeros index tensor — simpler and avoids
+//! a symbolic-shape dependency on the index.
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+use super::normalization::LayerNormWeights;
+use super::position_ids::position_ids_from_input_ids;
+
+#[derive(Clone)]
+pub struct XlmRobertaEmbeddings {
+    pub word_embeddings: Tensor,
+    pub position_embeddings: Tensor,
+    pub token_type_embeddings: Tensor,
+    pub norm: LayerNormWeights,
+    pub pad_token_id: usize,
+}
+
+impl XlmRobertaEmbeddings {
+    pub fn empty(
+        vocab_size: usize,
+        hidden_size: usize,
+        max_position_embeddings: usize,
+        type_vocab_size: usize,
+        eps: f64,
+        pad_token_id: usize,
+        dtype: DType,
+    ) -> Self {
+        Self {
+            word_embeddings: fan_in_uniform(&[vocab_size, hidden_size], hidden_size, dtype.clone()),
+            position_embeddings: fan_in_uniform(&[max_position_embeddings, hidden_size], hidden_size, dtype.clone()),
+            token_type_embeddings: fan_in_uniform(&[type_vocab_size, hidden_size], hidden_size, dtype.clone()),
+            norm: LayerNormWeights::with_eps(hidden_size, eps, dtype),
+            pad_token_id,
+        }
+    }
+
+    /// Forward. `input_ids`: `(B, L)` int → `(B, L, D)`.
+    pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let shape = input_ids.shape().context(TensorSnafu)?;
+        let _l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "embeddings" })?;
+
+        let word = self.word_embeddings.embedding(input_ids).context(TensorSnafu)?;
+
+        let pos_ids = position_ids_from_input_ids(input_ids, self.pad_token_id)?;
+        let pos = self.position_embeddings.embedding(&pos_ids).context(TensorSnafu)?;
+
+        let tok_type = self.token_type_embeddings.try_unsqueeze(0).context(TensorSnafu)?;
+
+        let h = word.try_add(&pos).context(TensorSnafu)?.try_add(&tok_type).context(TensorSnafu)?;
+        self.norm.apply(&h)
+    }
+}
+
+impl HasStateDict for XlmRobertaEmbeddings {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "word_embeddings.weight"), self.word_embeddings.clone());
+        sd.insert(prefixed(prefix, "position_embeddings.weight"), self.position_embeddings.clone());
+        sd.insert(prefixed(prefix, "token_type_embeddings.weight"), self.token_type_embeddings.clone());
+        sd.extend(self.norm.state_dict(&format!("{prefix}.LayerNorm")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.word_embeddings = get_tensor(sd, &prefixed(prefix, "word_embeddings.weight"))?;
+        self.position_embeddings = get_tensor(sd, &prefixed(prefix, "position_embeddings.weight"))?;
+        self.token_type_embeddings = get_tensor(sd, &prefixed(prefix, "token_type_embeddings.weight"))?;
+        self.norm.load_state_dict(sd, &format!("{prefix}.LayerNorm"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/encoder.rs
+++ b/model/src/xlm_roberta/encoder.rs
@@ -1,0 +1,63 @@
+//! XLM-RoBERTa transformer encoder: a stack of post-norm [`EncoderLayer`]s.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::XlmRobertaConfig;
+use super::encoder_layer::EncoderLayer;
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct XlmRobertaEncoder {
+    pub config: XlmRobertaConfig,
+    pub layers: Vec<EncoderLayer>,
+}
+
+impl XlmRobertaEncoder {
+    pub fn empty(config: &XlmRobertaConfig) -> Self {
+        let layers = (0..config.num_hidden_layers).map(|_| EncoderLayer::empty(config)).collect();
+        Self { config: config.clone(), layers }
+    }
+
+    /// Run the encoder stack. `x`: `(B, L, D)` → `(B, L, D)`.
+    pub fn forward(&self, x: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = x.shape().context(TensorSnafu)?;
+        let seq_len: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "encoder" })?;
+
+        let mask_4d = match padding_mask {
+            Some(m) => {
+                let b_dim = shape[0].clone();
+                let m2 = m.try_reshape([b_dim, SInt::from(seq_len)]).context(TensorSnafu)?;
+                let inverted = m2.logical_not().context(TensorSnafu)?;
+                Some(inverted.try_unsqueeze(1).context(TensorSnafu)?.try_unsqueeze(1).context(TensorSnafu)?)
+            }
+            None => None,
+        };
+
+        let mut h = x.clone();
+        for layer in &self.layers {
+            h = layer.forward(&h, mask_4d.as_ref())?;
+        }
+        Ok(h)
+    }
+}
+
+impl HasStateDict for XlmRobertaEncoder {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, layer) in self.layers.iter().enumerate() {
+            sd.extend(layer.state_dict(&format!("{prefix}.layer.{i}")));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, layer) in self.layers.iter_mut().enumerate() {
+            layer.load_state_dict(sd, &format!("{prefix}.layer.{i}"))?;
+        }
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/encoder_layer.rs
+++ b/model/src/xlm_roberta/encoder_layer.rs
@@ -1,0 +1,70 @@
+//! XLM-RoBERTa post-norm encoder layer.
+//!
+//! Standard BERT/RoBERTa post-norm:
+//! ```text
+//! attn_out = LayerNorm_attn(x + Attention(x))
+//! layer_out = LayerNorm_ffn(attn_out + FFN(attn_out))
+//! ```
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::attention::XlmRobertaAttention;
+use super::config::XlmRobertaConfig;
+use super::error::{Result, TensorSnafu};
+use super::feed_forward::FeedForwardWeights;
+use super::normalization::LayerNormWeights;
+
+#[derive(Clone)]
+pub struct EncoderLayer {
+    pub attention: XlmRobertaAttention,
+    pub attention_norm: LayerNormWeights,
+    pub feed_forward: FeedForwardWeights,
+    pub ffn_norm: LayerNormWeights,
+}
+
+impl EncoderLayer {
+    pub fn empty(config: &XlmRobertaConfig) -> Self {
+        let hidden = config.hidden_size;
+        let eps = config.layer_norm_eps;
+        let dtype = config.dtype.clone();
+        Self {
+            attention: XlmRobertaAttention::empty(hidden, config.num_attention_heads, config.head_dim(), dtype.clone()),
+            attention_norm: LayerNormWeights::with_eps(hidden, eps, dtype.clone()),
+            feed_forward: FeedForwardWeights::empty(hidden, config.intermediate_size, dtype.clone()),
+            ffn_norm: LayerNormWeights::with_eps(hidden, eps, dtype),
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)` → `(B, L, D)`. Post-norm.
+    pub fn forward(&self, x: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let attn_delta = self.attention.forward(x, padding_mask)?;
+        let x = x.try_add(&attn_delta).context(TensorSnafu)?;
+        let x = self.attention_norm.apply(&x)?;
+
+        let ffn_delta = self.feed_forward.forward(&x)?;
+        let x = x.try_add(&ffn_delta).context(TensorSnafu)?;
+        self.ffn_norm.apply(&x)
+    }
+}
+
+impl HasStateDict for EncoderLayer {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.extend(self.attention.state_dict(&format!("{prefix}.attention")));
+        sd.extend(self.attention_norm.state_dict(&format!("{prefix}.attention.output.LayerNorm")));
+        sd.extend(self.feed_forward.state_dict(prefix));
+        sd.extend(self.ffn_norm.state_dict(&format!("{prefix}.output.LayerNorm")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.attention.load_state_dict(sd, &format!("{prefix}.attention"))?;
+        self.attention_norm.load_state_dict(sd, &format!("{prefix}.attention.output.LayerNorm"))?;
+        self.feed_forward.load_state_dict(sd, prefix)?;
+        self.ffn_norm.load_state_dict(sd, &format!("{prefix}.output.LayerNorm"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/error.rs
+++ b/model/src/xlm_roberta/error.rs
@@ -1,0 +1,29 @@
+use snafu::Snafu;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    #[snafu(display("tensor op failed"))]
+    Tensor {
+        #[snafu(source(from(svod_tensor::error::Error, Box::new)))]
+        source: Box<svod_tensor::error::Error>,
+    },
+    #[snafu(display("state-dict op failed"))]
+    State {
+        #[snafu(source(from(crate::state::Error, Box::new)))]
+        source: Box<crate::state::Error>,
+    },
+    #[snafu(display("pickle load failed"))]
+    Pickle {
+        #[snafu(source(from(crate::wespeaker::pickle::Error, Box::new)))]
+        source: Box<crate::wespeaker::pickle::Error>,
+    },
+    #[snafu(display("HF Hub op failed"))]
+    Hub { source: hf_hub::api::sync::ApiError },
+    #[snafu(display("reading config.json failed: {message}"))]
+    Config { message: String },
+    #[snafu(display("{what} requires a concrete sequence length, got a symbolic dim"))]
+    SymbolicShape { what: &'static str },
+}

--- a/model/src/xlm_roberta/feed_forward.rs
+++ b/model/src/xlm_roberta/feed_forward.rs
@@ -1,0 +1,60 @@
+//! XLM-RoBERTa feed-forward block: `Linear(D, I, bias) → GELU(exact) → Linear(I, D, bias)`.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, TensorSnafu};
+
+#[derive(Clone)]
+pub struct FeedForwardWeights {
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub intermediate_weight: Tensor,
+    pub intermediate_bias: Tensor,
+    pub output_weight: Tensor,
+    pub output_bias: Tensor,
+}
+
+impl FeedForwardWeights {
+    pub fn empty(hidden_size: usize, intermediate_size: usize, dtype: DType) -> Self {
+        Self {
+            hidden_size,
+            intermediate_size,
+            intermediate_weight: fan_in_uniform(&[intermediate_size, hidden_size], hidden_size, dtype.clone()),
+            intermediate_bias: zeros(&[intermediate_size], dtype.clone()),
+            output_weight: fan_in_uniform(&[hidden_size, intermediate_size], intermediate_size, dtype.clone()),
+            output_bias: zeros(&[hidden_size], dtype),
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)` → `(B, L, D)`.
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let y =
+            x.linear().weight(&self.intermediate_weight).bias(&self.intermediate_bias).call().context(TensorSnafu)?;
+        let y = y.gelu_exact().context(TensorSnafu)?;
+        y.linear().weight(&self.output_weight).bias(&self.output_bias).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for FeedForwardWeights {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "intermediate.dense.weight"), self.intermediate_weight.clone());
+        sd.insert(prefixed(prefix, "intermediate.dense.bias"), self.intermediate_bias.clone());
+        sd.insert(prefixed(prefix, "output.dense.weight"), self.output_weight.clone());
+        sd.insert(prefixed(prefix, "output.dense.bias"), self.output_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.intermediate_weight = get_tensor(sd, &prefixed(prefix, "intermediate.dense.weight"))?;
+        self.intermediate_bias = get_tensor(sd, &prefixed(prefix, "intermediate.dense.bias"))?;
+        self.output_weight = get_tensor(sd, &prefixed(prefix, "output.dense.weight"))?;
+        self.output_bias = get_tensor(sd, &prefixed(prefix, "output.dense.bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/jit.rs
+++ b/model/src/xlm_roberta/jit.rs
@@ -1,0 +1,22 @@
+//! JIT wrapper for [`super::model::XlmRobertaModel`].
+
+extern crate self as svod_model;
+
+use svod_macros::jit_wrapper;
+
+use super::model::XlmRobertaModel;
+
+jit_wrapper! {
+    XlmRobertaJit(XlmRobertaModel) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.forward_batch(input_ids, Some(attention_mask), &b)
+        }
+    }
+}

--- a/model/src/xlm_roberta/mod.rs
+++ b/model/src/xlm_roberta/mod.rs
@@ -1,0 +1,35 @@
+//! XLM-RoBERTa — multilingual transformer encoder backbone.
+//!
+//! Pure-Rust port of the XLM-RoBERTa-large architecture: absolute learned
+//! position embeddings (with the fairseq `make_positions` offset), post-norm
+//! encoder layers, separate biased Q/K/V/O projections.
+//!
+//! Consumed by [`crate::bgem3`] (BGE-M3 embedder + reranker). Computes in bf16
+//! on the AMD target; f32 for CPU parity. Tokenization is out-of-band — the
+//! API takes pre-computed `input_ids`.
+
+pub mod attention;
+pub mod config;
+pub mod embeddings;
+pub mod encoder;
+pub mod encoder_layer;
+pub mod error;
+pub mod feed_forward;
+pub mod jit;
+pub mod model;
+pub mod normalization;
+pub mod pooling;
+pub mod position_ids;
+
+pub use attention::XlmRobertaAttention;
+pub use config::{XlmRobertaConfig, xlm_roberta_large};
+pub use embeddings::XlmRobertaEmbeddings;
+pub use encoder::XlmRobertaEncoder;
+pub use encoder_layer::EncoderLayer;
+pub use error::{Error, Result};
+pub use feed_forward::FeedForwardWeights;
+pub use jit::XlmRobertaJit;
+pub use model::XlmRobertaModel;
+pub use normalization::LayerNormWeights;
+pub use pooling::cls;
+pub use position_ids::position_ids_from_input_ids;

--- a/model/src/xlm_roberta/model.rs
+++ b/model/src/xlm_roberta/model.rs
@@ -1,0 +1,122 @@
+//! Root XLM-RoBERTa backbone: embeddings → encoder stack.
+//!
+//! Loads from a HuggingFace `pytorch_model.bin` checkpoint (the published
+//! `BAAI/bge-m3` layout — there is no safetensors variant). Compute dtype is
+//! `config.dtype` (bf16 by default, f32 for CPU parity tests); weights load at
+//! their stored dtype and are cast to `config.dtype` on read.
+
+use std::path::Path;
+
+use snafu::ResultExt;
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::XlmRobertaConfig;
+use super::embeddings::XlmRobertaEmbeddings;
+use super::encoder::XlmRobertaEncoder;
+use super::error::{HubSnafu, PickleSnafu, Result, StateSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct XlmRobertaModel {
+    pub config: XlmRobertaConfig,
+    pub embeddings: XlmRobertaEmbeddings,
+    pub encoder: XlmRobertaEncoder,
+}
+
+impl XlmRobertaModel {
+    pub fn empty(config: XlmRobertaConfig) -> Self {
+        let eps = config.layer_norm_eps;
+        let dtype = config.dtype.clone();
+        let embeddings = XlmRobertaEmbeddings::empty(
+            config.vocab_size,
+            config.hidden_size,
+            config.max_position_embeddings,
+            config.type_vocab_size,
+            eps,
+            config.pad_token_id,
+            dtype.clone(),
+        );
+        let encoder = XlmRobertaEncoder::empty(&config);
+        Self { config, embeddings, encoder }
+    }
+
+    /// Eager forward: `input_ids` `(B, L)` int + optional `padding_mask`
+    /// `(B, L)` bool → last-hidden-state `(B, L, D)`.
+    pub fn forward(&self, input_ids: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let x = self.embeddings.forward(input_ids)?;
+        self.encoder.forward(&x, padding_mask)
+    }
+
+    /// JIT-path variant: `input_ids` / `padding_mask` are sized for the JIT
+    /// plan's `max_batch`; `b` shrinks the leading batch dim to the live value
+    /// at execute time.
+    pub fn forward_batch(
+        &self,
+        input_ids: &Tensor,
+        padding_mask: Option<&Tensor>,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let bv = b.as_sint();
+        let input_ids = input_ids.try_shrink([Some((SInt::Const(0), bv.clone())), None]).context(TensorSnafu)?;
+        let padding_mask = match padding_mask {
+            Some(m) => Some(m.try_shrink([Some((SInt::Const(0), bv)), None]).context(TensorSnafu)?),
+            None => None,
+        };
+        self.forward(&input_ids, padding_mask.as_ref())
+    }
+
+    /// Download `config.json` + `pytorch_model.bin` from a HuggingFace Hub
+    /// repository and load the backbone.
+    pub fn from_hub(model_id: &str, mut config: XlmRobertaConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut XlmRobertaConfig) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = XlmRobertaConfig::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let weights_path = repo.get("pytorch_model.bin").context(HubSnafu)?;
+        Self::from_pytorch_bin(&weights_path, config.clone())
+    }
+
+    /// Load from a `pytorch_model.bin` checkpoint. Weights are cast to
+    /// `config.dtype` as they are read.
+    pub fn from_pytorch_bin(path: &Path, config: XlmRobertaConfig) -> Result<Self> {
+        let sd = crate::wespeaker::pickle::load_flat_pytorch_bin(path, "").context(PickleSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Build from a preloaded state dict. Each weight is cast to
+    /// `config.dtype`.
+    pub fn from_state_dict(sd: &StateDict, config: XlmRobertaConfig) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let mut model = Self::empty(config);
+        model.load_state_dict(&state::cast_all(sd, dtype), "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for XlmRobertaModel {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.extend(self.embeddings.state_dict(&prefix_or(prefix, "embeddings")));
+        sd.extend(self.encoder.state_dict(&prefix_or(prefix, "encoder")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.embeddings.load_state_dict(sd, &prefix_or(prefix, "embeddings"))?;
+        self.encoder.load_state_dict(sd, &prefix_or(prefix, "encoder"))?;
+        Ok(())
+    }
+}
+
+fn prefix_or(prefix: &str, suffix: &str) -> String {
+    if prefix.is_empty() { suffix.to_string() } else { format!("{prefix}.{suffix}") }
+}

--- a/model/src/xlm_roberta/normalization.rs
+++ b/model/src/xlm_roberta/normalization.rs
@@ -1,0 +1,59 @@
+//! Affine layer normalization with an optional bias.
+//!
+//! The `Tensor::layernorm` op upcasts to f32 internally before casting back,
+//! so this is numerically exact in bf16.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::ones;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, TensorSnafu};
+
+#[derive(Clone)]
+pub struct LayerNormWeights {
+    pub weight: Tensor,
+    pub bias: Option<Tensor>,
+    pub eps: f64,
+}
+
+impl LayerNormWeights {
+    pub fn empty(size: usize, dtype: DType) -> Self {
+        Self { weight: ones(&[size], dtype), bias: None, eps: 1e-5 }
+    }
+
+    pub fn with_eps(size: usize, eps: f64, dtype: DType) -> Self {
+        Self { weight: ones(&[size], dtype), bias: None, eps }
+    }
+
+    /// Apply LayerNorm over the last axis then affine:
+    /// `(x - μ)/√(σ²+ε) * γ + β?`.
+    pub fn apply(&self, x: &Tensor) -> Result<Tensor> {
+        let normed = x.layernorm(-1, self.eps).context(TensorSnafu)?;
+        let scaled = normed.try_mul(&self.weight).context(TensorSnafu)?;
+        match &self.bias {
+            Some(b) => scaled.try_add(b).context(TensorSnafu),
+            None => Ok(scaled),
+        }
+    }
+}
+
+impl HasStateDict for LayerNormWeights {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        if let Some(b) = &self.bias {
+            sd.insert(prefixed(prefix, "bias"), b.clone());
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        let bias_key = prefixed(prefix, "bias");
+        self.bias = sd.get(&bias_key).cloned();
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/pooling.rs
+++ b/model/src/xlm_roberta/pooling.rs
@@ -1,0 +1,12 @@
+//! CLS pooling: take the first token's embedding.
+
+use snafu::ResultExt;
+use svod_tensor::{Tensor, s};
+
+use super::error::{Result, TensorSnafu};
+
+/// CLS pooling: take the first token's embedding. `hidden_states`: `(B, L, D)`
+/// → `(B, D)`.
+pub fn cls(hidden_states: &Tensor) -> Result<Tensor> {
+    hidden_states.getitem(s![.., 0, ..]).context(TensorSnafu)
+}

--- a/model/src/xlm_roberta/position_ids.rs
+++ b/model/src/xlm_roberta/position_ids.rs
@@ -1,0 +1,34 @@
+//! XLM-RoBERTa position-ID computation.
+//!
+//! XLM-RoBERTa (and RoBERTa) compute position IDs from `input_ids` using the
+//! fairseq `make_positions` convention:
+//!
+//! ```text
+//! mask          = (input_ids != padding_idx).int()
+//! incremental   = cumsum(mask, dim=-1) * mask
+//! position_ids  = incremental + padding_idx
+//! ```
+//!
+//! This means real tokens start at position `padding_idx + 1` (= 2 for
+//! `pad_token_id = 1`), and padding tokens map to `padding_idx` (= 1), which
+//! indexes the zeroed row of the position embedding table. Position rows 0 and
+//! 1 are never used for real tokens.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use super::error::{Result, TensorSnafu};
+
+/// Compute XLM-RoBERTa position IDs from `input_ids`.
+///
+/// `input_ids`: `(B, L)` int. Returns `(B, L)` int32 position IDs where real
+/// tokens are numbered starting from `padding_idx + 1` and padding positions
+/// are set to `padding_idx`.
+pub fn position_ids_from_input_ids(input_ids: &Tensor, padding_idx: usize) -> Result<Tensor> {
+    let pad = Tensor::const_(padding_idx as i64, DType::Int32);
+    let mask = input_ids.try_ne(&pad).context(TensorSnafu)?.cast(DType::Int32).context(TensorSnafu)?;
+    let cumsum = mask.cumsum(-1).context(TensorSnafu)?;
+    let incremental = cumsum.try_mul(&mask).context(TensorSnafu)?;
+    incremental.try_add(&pad).context(TensorSnafu)
+}

--- a/schedule/src/gpudims.rs
+++ b/schedule/src/gpudims.rs
@@ -603,9 +603,9 @@ fn get_contraction(original_dims: &[Arc<UOp>], limited_dims: &[Arc<UOp>]) -> Opt
         if is_one(acc) {
             split.push(0);
         } else {
-            match acc_old.iter().position(|o| Arc::ptr_eq(o, acc)) {
-                Some(idx) => split.push(idx + 1),
-                None => return None,
+            {
+                let idx = acc_old.iter().position(|o| Arc::ptr_eq(o, acc))?;
+                split.push(idx + 1)
             }
         }
     }

--- a/schedule/src/rangeify/patterns.rs
+++ b/schedule/src/rangeify/patterns.rs
@@ -469,10 +469,9 @@ fn cleanup_dead_axes_bufferize(
         } else {
             // Live axis: keep range and original dimension
             new_ranges.push(Arc::clone(range));
-            if let Some(dim) = original_shape.get(i) {
+            {
+                let dim = original_shape.get(i)?;
                 reshape_dims.push(dim.clone());
-            } else {
-                return None; // Shape mismatch
             }
         }
     }

--- a/scripts/convert_bgem3.py
+++ b/scripts/convert_bgem3.py
@@ -1,0 +1,128 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "numpy", "safetensors", "transformers", "huggingface_hub"]
+# ///
+"""Generate BGE-M3 parity fixtures for the Rust `svod-model` port.
+
+Downloads `BAAI/bge-m3`, runs the backbone and all three embedding heads
+(dense, sparse, ColBERT) on a fixed input sequence, and dumps a
+`golden.safetensors` storing:
+
+  - `input_ids`          (T,)  int64 — the exact token ids fed to the model
+  - `attention_mask`     (T,)  int64 — 1=real, 0=pad
+  - `input_ids_shape`    (2,)  int64 — (batch, seq_len)
+  - `last_hidden_state`  (B, T, D)    f32 — `model(...).last_hidden_state`
+  - `dense_vecs`         (B, D)       f32 — CLS-pooled L2-normalized dense embedding
+  - `sparse_vecs`        (B, V)       f32 — sparse lexical embedding (full vocab)
+  - `colbert_vecs`       (B, L-1, Dc) f32 — ColBERT multi-vector embeddings
+
+Usage:
+  uv run scripts/convert_bgem3.py
+  uv run scripts/convert_bgem3.py --out path/to/golden.safetensors
+
+Run the Rust parity test with the local fixture:
+  SVOD_BGEM3=$PWD/data/bgem3 \
+      cargo test -p svod-model --lib bgem3::parity -- --ignored
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors.numpy import save_file
+from transformers import AutoModel, AutoTokenizer
+
+HUB = "BAAI/bge-m3"
+DEFAULT_PROMPT = "What is BGE-M3?"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--prompt", default=DEFAULT_PROMPT, help="text to tokenize for the golden forward")
+    p.add_argument("--out", type=Path, default=None, help="output golden.safetensors path")
+    p.add_argument("--max-length", type=int, default=32, help="tokenizer max_length / padding target")
+    args = p.parse_args()
+
+    out = args.out or (Path(__file__).resolve().parent.parent / "data" / "bgem3" / "golden.safetensors")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    tok = AutoTokenizer.from_pretrained(HUB)
+    model = AutoModel.from_pretrained(HUB, torch_dtype=torch.float32)
+    model.eval()
+
+    enc = tok(args.prompt, return_tensors="pt", padding="max_length", max_length=args.max_length, truncation=True)
+    input_ids = enc["input_ids"]  # (1, T)
+    attn = enc["attention_mask"]  # (1, T)
+
+    with torch.no_grad():
+        out_t = model(input_ids=input_ids, attention_mask=attn).last_hidden_state  # (1, T, D)
+
+    # Dense embedding: CLS pooling + L2 normalize.
+    dense_vecs = out_t[:, 0]  # (1, D)
+    dense_vecs = torch.nn.functional.normalize(dense_vecs, dim=-1)
+
+    # ColBERT vectors: skip CLS, project + mask + normalize.
+    # We need to load the colbert_linear weights from the .pt file.
+    import os
+    from huggingface_hub import hf_hub_download
+
+    colbert_path = hf_hub_download(repo_id=HUB, filename="colbert_linear.pt")
+    sparse_path = hf_hub_download(repo_id=HUB, filename="sparse_linear.pt")
+    colbert_sd = torch.load(colbert_path, map_location="cpu", weights_only=True)
+    sparse_sd = torch.load(sparse_path, map_location="cpu", weights_only=True)
+
+    colbert_linear = torch.nn.Linear(model.config.hidden_size, model.config.hidden_size)
+    colbert_linear.load_state_dict(colbert_sd)
+    colbert_linear.eval()
+    sparse_linear = torch.nn.Linear(model.config.hidden_size, 1)
+    sparse_linear.load_state_dict(sparse_sd)
+    sparse_linear.eval()
+
+    with torch.no_grad():
+        # ColBERT: skip CLS, linear, mask, normalize.
+        colbert_vecs = colbert_linear(out_t[:, 1:])  # (1, T-1, Dc)
+        colbert_vecs = colbert_vecs * attn[:, 1:].unsqueeze(-1).float()
+        colbert_vecs = torch.nn.functional.normalize(colbert_vecs, dim=-1)
+
+        # Sparse: relu(linear(hidden)) → scatter to vocab.
+        token_weights = torch.relu(sparse_linear(out_t)).squeeze(-1)  # (1, T)
+        sparse_vecs = torch.zeros(1, model.config.vocab_size, dtype=token_weights.dtype)
+        sparse_vecs = sparse_vecs.scatter_reduce(
+            dim=-1, index=input_ids, src=token_weights, reduce="amax"
+        )
+        unused_tokens = [
+            tok.cls_token_id, tok.eos_token_id, tok.pad_token_id, tok.unk_token_id,
+        ]
+        sparse_vecs[:, unused_tokens] *= 0.0
+
+    ids_np = input_ids.squeeze(0).to(torch.int64).numpy()
+    attn_np = attn.squeeze(0).to(torch.int64).numpy()
+    hidden_np = out_t.squeeze(0).to(torch.float32).numpy()
+    dense_np = dense_vecs.squeeze(0).to(torch.float32).numpy()
+    sparse_np = sparse_vecs.squeeze(0).to(torch.float32).numpy()
+    colbert_np = colbert_vecs.squeeze(0).to(torch.float32).numpy()
+    shape_np = np.array(input_ids.shape, dtype=np.int64)
+
+    save_file(
+        {
+            "input_ids": ids_np,
+            "attention_mask": attn_np,
+            "input_ids_shape": shape_np,
+            "last_hidden_state": hidden_np,
+            "dense_vecs": dense_np,
+            "sparse_vecs": sparse_np,
+            "colbert_vecs": colbert_np,
+        },
+        str(out),
+    )
+    print(f"wrote {out}")
+    print(
+        f"  input_ids {tuple(ids_np.shape)}  hidden {tuple(hidden_np.shape)}  "
+        f"dense {tuple(dense_np.shape)}  sparse {tuple(sparse_np.shape)}  "
+        f"colbert {tuple(colbert_np.shape)}  ({HUB})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_bgem3_reranker.py
+++ b/scripts/convert_bgem3_reranker.py
@@ -1,0 +1,90 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "numpy", "safetensors", "transformers", "huggingface_hub"]
+# ///
+"""Generate BGE-reranker-v2-m3 parity fixtures for the Rust `svod-model` port.
+
+Downloads `BAAI/bge-reranker-v2-m3`, runs the cross-encoder on a fixed
+query-passage pair, and dumps a `golden_reranker.safetensors` storing:
+
+  - `input_ids`          (T,)  int64 — the exact token ids (query+passage pair)
+  - `attention_mask`     (T,)  int64 — 1=real, 0=pad
+  - `input_ids_shape`    (2,)  int64 — (batch, seq_len)
+  - `logits`             (B, 1) f32 — raw cross-encoder logits
+  - `normalized_scores`  (B, 1) f32 — sigmoid(logits)
+
+Usage:
+  uv run scripts/convert_bgem3_reranker.py
+  uv run scripts/convert_bgem3_reranker.py --out path/to/golden_reranker.safetensors
+
+Run the Rust parity test with the local fixture:
+  SVOD_BGEM3=$PWD/data/bgem3 \
+      cargo test -p svod-model --lib bgem3::parity::reranker -- --ignored
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors.numpy import save_file
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+HUB = "BAAI/bge-reranker-v2-m3"
+DEFAULT_QUERY = "What is BGE-M3?"
+DEFAULT_PASSAGE = "BGE-M3 is an embedding model supporting dense retrieval, lexical matching and multi-vector interaction."
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--query", default=DEFAULT_QUERY)
+    p.add_argument("--passage", default=DEFAULT_PASSAGE)
+    p.add_argument("--out", type=Path, default=None)
+    p.add_argument("--max-length", type=int, default=64)
+    args = p.parse_args()
+
+    out = args.out or (Path(__file__).resolve().parent.parent / "data" / "bgem3" / "golden_reranker.safetensors")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    tok = AutoTokenizer.from_pretrained(HUB)
+    model = AutoModelForSequenceClassification.from_pretrained(HUB, torch_dtype=torch.float32)
+    model.eval()
+
+    # Tokenize as a query-passage pair (cross-encoder convention).
+    enc = tok(
+        args.query,
+        args.passage,
+        return_tensors="pt",
+        padding="max_length",
+        max_length=args.max_length,
+        truncation=True,
+    )
+    input_ids = enc["input_ids"]  # (1, T)
+    attn = enc["attention_mask"]  # (1, T)
+
+    with torch.no_grad():
+        logits = model(input_ids=input_ids, attention_mask=attn).logits  # (1, 1)
+        scores = torch.sigmoid(logits)
+
+    ids_np = input_ids.squeeze(0).to(torch.int64).numpy()
+    attn_np = attn.squeeze(0).to(torch.int64).numpy()
+    logits_np = logits.squeeze(0).to(torch.float32).numpy()  # (1,)
+    scores_np = scores.squeeze(0).to(torch.float32).numpy()
+    shape_np = np.array(input_ids.shape, dtype=np.int64)
+
+    save_file(
+        {
+            "input_ids": ids_np,
+            "attention_mask": attn_np,
+            "input_ids_shape": shape_np,
+            "logits": logits_np,
+            "normalized_scores": scores_np,
+        },
+        str(out),
+    )
+    print(f"wrote {out}")
+    print(f"  input_ids {tuple(ids_np.shape)}  logits {tuple(logits_np.shape)}  ({HUB})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds three text models on top of two encoder backbones, plus sliding-window SDPA in the tensor layer.

## Models
- BGE-M3 — three retrieval heads (dense CLS+L2, sparse ReLU+scatter-amax, ColBERT per-token MaxSim) + hybrid scoring. Parity: <1e-3 vs BAAI/bge-m3.
- BGE-reranker-v2-m3 — cross-encoder (dense→tanh→out_proj). Parity: <1e-3 vs BAAI/bge-reranker-v2-m3.

## Backbones
- XLM-RoBERTa-large — absolute position embeddings, post-norm, fairseq make_positions offset. Consumed by BGE-M3/reranker.

## Tensor layer
- scaled_dot_product_attention gains optional window: (left, right) for sliding-window attention. The keep-mask (causal ^ window ^ padding) is applied pre- and post-softmax so fully-masked rows can't leak. All 51 existing SDPA tests pass unchanged.
- Tensor::embedding rewritten to mirror tinygrad's one-hot approach — symbolic batch dims pass through, only the vocab axis must be concrete.