### PR TITLE
model: ModernBERT config cleanup

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -14,6 +14,7 @@ plans.
 | `state` | `HasStateDict` + `state_field!` macros for loading PyTorch / safetensors checkpoints into Rust weight structs. |
 | `blocks` | Shared `Conv2dWeights`, `BatchNormWeights`, `BasicBlock`, `Bottleneck`, `ResidualStage` reused by every ResNet-shaped backbone. timm/torchvision key convention. |
 | `wavlm` | WavLM speech-representation backbone (Conv1d feature extractor + gated rel-pos Transformer, per-layer pruning) consumed by `diarizen`. |
+| `xlm_roberta` | XLM-RoBERTa text encoder backbone (absolute position embeddings, post-norm Transformer) consumed by `bgem3`. |
 | `sentencepiece` | Minimal SentencePiece `.model` protobuf loader (vocab piece extraction). |
 
 ## Models
@@ -25,6 +26,8 @@ plans.
 | Silero VAD 16k | Voice activity | `silero_vad` | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) | [`vpermilp/silero-vad`](https://huggingface.co/vpermilp/silero-vad) |
 | DiariZen segmentation (WavLM + Conformer) | Speaker diarization | `diarizen` | [BUT-FIT/DiariZen](https://github.com/BUTSpeechFIT/DiariZen) | [`BUT-FIT/diarizen-wavlm-large-s80-md-v2`](https://huggingface.co/BUT-FIT/diarizen-wavlm-large-s80-md-v2) |
 | ModernBERT (base / large) | Text embeddings, fill-mask (MLM) | `modernbert` | [Answer.AI ModernBERT](https://github.com/AnswerDotAI/ModernBERT) | [`answerdotai/ModernBERT-base`](https://huggingface.co/answerdotai/ModernBERT-base) |
+| BGE-M3 (dense / sparse / ColBERT) | Text embeddings, retrieval | `bgem3` | [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3) (XLM-RoBERTa-large) | [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3) |
+| BGE-reranker-v2-m3 | Cross-encoder reranking | `bgem3` | [BAAI/bge-reranker-v2-m3](https://huggingface.co/BAAI/bge-reranker-v2-m3) | [`BAAI/bge-reranker-v2-m3`](https://huggingface.co/BAAI/bge-reranker-v2-m3) |
 | ResNet (18 / 34 / 50 / 101 / 152) | Vision | `resnet` | [He et al. 2015](https://arxiv.org/abs/1512.03385) | [`timm/resnet*.a1_in1k`](https://huggingface.co/timm) |
 | WeSpeaker ResNet34 | Speaker embedding | `wespeaker` | [wenet-e2e/wespeaker](https://github.com/wenet-e2e/wespeaker) | [`pyannote/wespeaker-voxceleb-resnet34-LM`](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM) |
 
@@ -33,6 +36,12 @@ FireRedVAD ships two variants: the non-streaming model (`FireRedVadSplitter`
 the causal `Stream-VAD` checkpoint (`FireRedVadStreamer` — incremental
 push/flush API with per-layer conv caches recycled on-device between
 chunks).
+
+BGE-M3 loads from `pytorch_model.bin` (pickle, no safetensors variant) with
+the three retrieval heads in separate `.pt` files (`sparse_linear.pt`,
+`colbert_linear.pt`). The reranker loads from `model.safetensors` with a
+`roberta.` prefix on backbone keys. Both share the XLM-RoBERTa-large
+backbone (`xlm_roberta` module).
 
 ## Examples
 

--- a/model/README.md
+++ b/model/README.md
@@ -15,6 +15,7 @@ plans.
 | `blocks` | Shared `Conv2dWeights`, `BatchNormWeights`, `BasicBlock`, `Bottleneck`, `ResidualStage` reused by every ResNet-shaped backbone. timm/torchvision key convention. |
 | `wavlm` | WavLM speech-representation backbone (Conv1d feature extractor + gated rel-pos Transformer, per-layer pruning) consumed by `diarizen`. |
 | `xlm_roberta` | XLM-RoBERTa text encoder backbone (absolute position embeddings, post-norm Transformer) consumed by `bgem3`. |
+| `qwen3` | Qwen3 decoder-only LLM backbone (causal attention, GQA, per-head Q/K RMSNorm, RoPE, SwiGLU) consumed by embedding models. |
 | `sentencepiece` | Minimal SentencePiece `.model` protobuf loader (vocab piece extraction). |
 
 ## Models
@@ -28,20 +29,10 @@ plans.
 | ModernBERT (base / large) | Text embeddings, fill-mask (MLM) | `modernbert` | [Answer.AI ModernBERT](https://github.com/AnswerDotAI/ModernBERT) | [`answerdotai/ModernBERT-base`](https://huggingface.co/answerdotai/ModernBERT-base) |
 | BGE-M3 (dense / sparse / ColBERT) | Text embeddings, retrieval | `bgem3` | [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3) (XLM-RoBERTa-large) | [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3) |
 | BGE-reranker-v2-m3 | Cross-encoder reranking | `bgem3` | [BAAI/bge-reranker-v2-m3](https://huggingface.co/BAAI/bge-reranker-v2-m3) | [`BAAI/bge-reranker-v2-m3`](https://huggingface.co/BAAI/bge-reranker-v2-m3) |
+| Qwen3-Embedding-0.6B | Text embeddings, retrieval | `qwen3` | [Qwen team](https://huggingface.co/Qwen) (Qwen3 LLM) | [`Qwen/Qwen3-Embedding-0.6B`](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) |
+| Qwen3-Reranker-0.6B | Cross-encoder reranking | `qwen3` | [Qwen team](https://huggingface.co/Qwen) (Qwen3 LLM) | [`Qwen/Qwen3-Reranker-0.6B`](https://huggingface.co/Qwen/Qwen3-Reranker-0.6B) |
 | ResNet (18 / 34 / 50 / 101 / 152) | Vision | `resnet` | [He et al. 2015](https://arxiv.org/abs/1512.03385) | [`timm/resnet*.a1_in1k`](https://huggingface.co/timm) |
 | WeSpeaker ResNet34 | Speaker embedding | `wespeaker` | [wenet-e2e/wespeaker](https://github.com/wenet-e2e/wespeaker) | [`pyannote/wespeaker-voxceleb-resnet34-LM`](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM) |
-
-FireRedVAD ships two variants: the non-streaming model (`FireRedVadSplitter`
-— the whole DFSMN runs as one batched device JIT, no host recurrence) and
-the causal `Stream-VAD` checkpoint (`FireRedVadStreamer` — incremental
-push/flush API with per-layer conv caches recycled on-device between
-chunks).
-
-BGE-M3 loads from `pytorch_model.bin` (pickle, no safetensors variant) with
-the three retrieval heads in separate `.pt` files (`sparse_linear.pt`,
-`colbert_linear.pt`). The reranker loads from `model.safetensors` with a
-`roberta.` prefix on backbone keys. Both share the XLM-RoBERTa-large
-backbone (`xlm_roberta` module).
 
 ## Examples
 

--- a/model/src/bgem3/colbert_head.rs
+++ b/model/src/bgem3/colbert_head.rs
@@ -1,0 +1,88 @@
+//! BGE-M3 ColBERT multi-vector embedding head.
+//!
+//! Per-token `Linear(D, colbert_dim, bias)` applied to hidden states excluding
+//! the CLS token, with padding masked to zero. Optional L2 normalization.
+//!
+//! Weights are loaded from `colbert_linear.pt` (PyTorch pickle with bare
+//! `weight` / `bias` keys).
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::{Tensor, s};
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+use crate::xlm_roberta::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct ColbertHead {
+    pub weight: Tensor,
+    pub bias: Tensor,
+    pub colbert_dim: usize,
+    pub normalize: bool,
+}
+
+impl ColbertHead {
+    pub fn empty(hidden_size: usize, colbert_dim: usize, dtype: DType) -> Self {
+        Self {
+            weight: fan_in_uniform(&[colbert_dim, hidden_size], hidden_size, dtype.clone()),
+            bias: zeros(&[colbert_dim], dtype),
+            colbert_dim,
+            normalize: true,
+        }
+    }
+
+    /// Load from a `colbert_linear.pt` checkpoint (bare `weight`/`bias` keys).
+    pub fn from_pytorch_bin(path: &std::path::Path, colbert_dim: usize, dtype: DType) -> Result<Self> {
+        let sd = crate::wespeaker::pickle::load_flat_pytorch_bin(path, "")
+            .map_err(|e| crate::xlm_roberta::Error::Pickle { source: Box::new(e) })?;
+        Self::from_state_dict(&sd, "", colbert_dim, dtype)
+    }
+
+    /// Build from a preloaded state dict, casting to `dtype`.
+    pub fn from_state_dict(sd: &StateDict, prefix: &str, colbert_dim: usize, dtype: DType) -> Result<Self> {
+        let sd = state::cast_all(sd, dtype.clone());
+        let mut head = Self::empty(0, colbert_dim, dtype);
+        head.load_state_dict(&sd, prefix).map_err(|e| crate::xlm_roberta::Error::State { source: Box::new(e) })?;
+        Ok(head)
+    }
+
+    /// Forward. `hidden`: `(B, L, D)`, `attention_mask`: optional `(B, L)` bool
+    /// where `true` = real token. Returns `(B, L-1, colbert_dim)` — the CLS
+    /// token (position 0) is dropped.
+    pub fn forward(&self, hidden: &Tensor, attention_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = hidden.shape().context(TensorSnafu)?;
+        let _l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "colbert_head" })?;
+
+        let hidden_no_cls = hidden.getitem(s![.., 1.., ..]).context(TensorSnafu)?;
+
+        let vecs = hidden_no_cls.linear().weight(&self.weight).bias(&self.bias).call().context(TensorSnafu)?;
+
+        let vecs = match attention_mask {
+            Some(m) => {
+                let m_no_cls = m.getitem(s![.., 1..]).context(TensorSnafu)?;
+                let m_3d =
+                    m_no_cls.cast(vecs.uop().dtype()).context(TensorSnafu)?.try_unsqueeze(-1).context(TensorSnafu)?;
+                vecs.try_mul(&m_3d).context(TensorSnafu)?
+            }
+            None => vecs,
+        };
+
+        if self.normalize { vecs.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(vecs) }
+    }
+}
+
+impl HasStateDict for ColbertHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd.insert(prefixed(prefix, "bias"), self.bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        self.bias = get_tensor(sd, &prefixed(prefix, "bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/bgem3/embedder.rs
+++ b/model/src/bgem3/embedder.rs
@@ -1,0 +1,145 @@
+//! BGE-M3 composite model: XLM-RoBERTa backbone + dense / sparse / ColBERT heads.
+//!
+//! `BAAI/bge-m3` produces three types of embeddings simultaneously:
+//! - **Dense**: CLS pooling + L2 normalize → `(B, D)`
+//! - **Sparse**: Linear → ReLU → scatter-to-vocab → `(B, vocab_size)`
+//! - **ColBERT**: per-token Linear (skip CLS) + L2 normalize → `(B, L-1, Dc)`
+//!
+//! Loads from HuggingFace Hub: `config.json` + `pytorch_model.bin` (backbone)
+//! + `sparse_linear.pt` + `colbert_linear.pt` (heads).
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::xlm_roberta::config::XlmRobertaConfig;
+use crate::xlm_roberta::error::{HubSnafu, Result, SymbolicShapeSnafu, TensorSnafu};
+use crate::xlm_roberta::model::XlmRobertaModel;
+use crate::xlm_roberta::pooling::cls;
+
+use super::colbert_head::ColbertHead;
+use super::sparse_head::SparseHead;
+
+/// Output of [`BgeM3::encode`]: any combination of the three embedding types.
+#[derive(Clone, Default)]
+pub struct BgeM3Output {
+    pub dense_vecs: Option<Tensor>,
+    pub sparse_vecs: Option<Tensor>,
+    pub colbert_vecs: Option<Tensor>,
+}
+
+/// Flags controlling which embedding types to compute.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EncodeOpts {
+    pub return_dense: bool,
+    pub return_sparse: bool,
+    pub return_colbert: bool,
+}
+
+impl EncodeOpts {
+    pub fn dense() -> Self {
+        Self { return_dense: true, return_sparse: false, return_colbert: false }
+    }
+    pub fn all() -> Self {
+        Self { return_dense: true, return_sparse: true, return_colbert: true }
+    }
+}
+
+#[derive(Clone)]
+pub struct BgeM3 {
+    pub model: XlmRobertaModel,
+    pub sparse_head: Option<SparseHead>,
+    pub colbert_head: Option<ColbertHead>,
+    pub normalize_dense: bool,
+}
+
+impl BgeM3 {
+    pub fn empty(config: XlmRobertaConfig) -> Self {
+        let dtype = config.dtype.clone();
+        let hidden = config.hidden_size;
+        let vocab = config.vocab_size;
+        let model = XlmRobertaModel::empty(config);
+        Self {
+            model,
+            sparse_head: Some(SparseHead::empty(hidden, vocab, dtype.clone())),
+            colbert_head: Some(ColbertHead::empty(hidden, hidden, dtype)),
+            normalize_dense: true,
+        }
+    }
+
+    /// Eager forward computing all requested embedding types.
+    pub fn encode(&self, input_ids: &Tensor, attention_mask: &Tensor, opts: EncodeOpts) -> Result<BgeM3Output> {
+        let hidden = self.model.forward(input_ids, Some(attention_mask))?;
+        let mut out = BgeM3Output::default();
+
+        if opts.return_dense {
+            let dense = cls(&hidden)?;
+            out.dense_vecs =
+                Some(if self.normalize_dense { dense.lp_normalize(-1, 2).context(TensorSnafu)? } else { dense });
+        }
+        if opts.return_sparse {
+            let head = self.sparse_head.as_ref().context(SymbolicShapeSnafu { what: "sparse_head" })?;
+            out.sparse_vecs = Some(head.forward(&hidden, input_ids)?);
+        }
+        if opts.return_colbert {
+            let head = self.colbert_head.as_ref().context(SymbolicShapeSnafu { what: "colbert_head" })?;
+            out.colbert_vecs = Some(head.forward(&hidden, Some(attention_mask))?);
+        }
+        Ok(out)
+    }
+
+    /// Dense-only forward (most common path). Returns `(B, D)`.
+    pub fn encode_dense(&self, input_ids: &Tensor, attention_mask: &Tensor) -> Result<Tensor> {
+        let hidden = self.model.forward(input_ids, Some(attention_mask))?;
+        let dense = cls(&hidden)?;
+        if self.normalize_dense { dense.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(dense) }
+    }
+
+    /// JIT-path dense forward with rebindable batch. Returns `(B, D)`.
+    pub fn encode_dense_batch(&self, input_ids: &Tensor, attention_mask: &Tensor, b: &BoundVariable) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, Some(attention_mask), b)?;
+        let dense = cls(&hidden)?;
+        if self.normalize_dense { dense.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(dense) }
+    }
+
+    /// JIT-path ColBERT forward with rebindable batch. Returns `(B, L-1, Dc)`.
+    pub fn encode_colbert_batch(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, Some(attention_mask), b)?;
+        let head = self.colbert_head.as_ref().context(SymbolicShapeSnafu { what: "colbert_head" })?;
+        head.forward(&hidden, Some(attention_mask))
+    }
+
+    /// Download all files from HuggingFace Hub and load the full BGE-M3 model.
+    pub fn from_hub(model_id: &str, mut config: XlmRobertaConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut XlmRobertaConfig) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = XlmRobertaConfig::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let weights_path = repo.get("pytorch_model.bin").context(HubSnafu)?;
+        let dtype = config.dtype.clone();
+        let model = XlmRobertaModel::from_pytorch_bin(&weights_path, config.clone())?;
+
+        let sparse_head = match repo.get("sparse_linear.pt") {
+            Ok(path) => Some(SparseHead::from_pytorch_bin(&path, config.vocab_size, dtype.clone())?),
+            Err(_) => None,
+        };
+        let colbert_head = match repo.get("colbert_linear.pt") {
+            Ok(path) => Some(ColbertHead::from_pytorch_bin(&path, config.hidden_size, dtype)?),
+            Err(_) => None,
+        };
+
+        Ok(Self { model, sparse_head, colbert_head, normalize_dense: true })
+    }
+}

--- a/model/src/bgem3/jit.rs
+++ b/model/src/bgem3/jit.rs
@@ -1,0 +1,53 @@
+//! JIT wrappers for BGE-M3 and BGE-reranker-v2-m3.
+
+extern crate self as svod_model;
+
+use svod_macros::jit_wrapper;
+
+use super::embedder::BgeM3;
+use super::reranker::BgeRerankerV2M3;
+
+jit_wrapper! {
+    BgeM3DenseJit(BgeM3) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.encode_dense_batch(input_ids, attention_mask, &b)
+        }
+    }
+}
+
+jit_wrapper! {
+    BgeM3ColbertJit(BgeM3) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.encode_colbert_batch(input_ids, attention_mask, &b)
+        }
+    }
+}
+
+jit_wrapper! {
+    BgeRerankerJit(BgeRerankerV2M3) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.forward_batch(input_ids, Some(attention_mask), &b)
+        }
+    }
+}

--- a/model/src/bgem3/mod.rs
+++ b/model/src/bgem3/mod.rs
@@ -1,0 +1,24 @@
+//! BGE-M3 — multilingual embedding model and reranker (`BAAI/bge-m3`).
+//!
+//! Built on the [`crate::xlm_roberta`] backbone. Three retrieval heads:
+//!
+//! - **Dense**: CLS pooling + L2 normalize → `(B, D)`
+//! - **Sparse**: Linear → ReLU → scatter-to-vocab → `(B, vocab_size)`
+//! - **ColBERT**: per-token Linear (skip CLS) + L2 normalize → `(B, L-1, Dc)`
+//!
+//! Also provides [`BgeRerankerV2M3`] (`BAAI/bge-reranker-v2-m3`), a cross-encoder
+//! reranker sharing the same XLM-RoBERTa backbone with a classification head.
+
+mod colbert_head;
+mod embedder;
+mod jit;
+mod reranker;
+mod scoring;
+mod sparse_head;
+
+pub use colbert_head::ColbertHead;
+pub use embedder::{BgeM3, BgeM3Output, EncodeOpts};
+pub use jit::{BgeM3ColbertJit, BgeM3DenseJit, BgeRerankerJit};
+pub use reranker::BgeRerankerV2M3;
+pub use scoring::{colbert_score, dense_score, hybrid_score, sparse_score};
+pub use sparse_head::SparseHead;

--- a/model/src/bgem3/reranker.rs
+++ b/model/src/bgem3/reranker.rs
@@ -1,0 +1,164 @@
+//! BGE-reranker-v2-m3: XLM-RoBERTa backbone + sequence classification head.
+//!
+//! Cross-encoder reranker fine-tuned from `BAAI/bge-m3`. The tokenizer
+//! concatenates `(query, passage)` into a single input sequence with
+//! `<s> query </s></s> passage </s>`; the model runs the backbone, takes the
+//! CLS token, applies the two-layer classification head (`dense → tanh →
+//! out_proj`), and optionally sigmoid-normalizes.
+//!
+//! Same backbone as [`crate::xlm_roberta::XlmRobertaModel`] — only the head
+//! differs. Loads from `model.safetensors` with `roberta.` prefix on backbone
+//! keys.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, cast_all, get_tensor, prefixed};
+use crate::xlm_roberta::config::XlmRobertaConfig;
+use crate::xlm_roberta::error::{HubSnafu, Result, StateSnafu, TensorSnafu};
+use crate::xlm_roberta::model::XlmRobertaModel;
+use crate::xlm_roberta::pooling::cls;
+
+/// `RobertaClassificationHead`: `dense(D, D) → tanh → out_proj(D, num_labels)`.
+#[derive(Clone)]
+pub struct ClassificationHead {
+    pub dense_weight: Tensor,
+    pub dense_bias: Tensor,
+    pub out_proj_weight: Tensor,
+    pub out_proj_bias: Tensor,
+}
+
+impl ClassificationHead {
+    pub fn empty(hidden_size: usize, num_labels: usize, dtype: DType) -> Self {
+        Self {
+            dense_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            dense_bias: zeros(&[hidden_size], dtype.clone()),
+            out_proj_weight: fan_in_uniform(&[num_labels, hidden_size], hidden_size, dtype.clone()),
+            out_proj_bias: zeros(&[num_labels], dtype),
+        }
+    }
+
+    /// Forward: `CLS → dense → tanh → out_proj → (B, num_labels)`.
+    pub fn forward(&self, hidden: &Tensor) -> Result<Tensor> {
+        let cls_emb = cls(hidden)?;
+        let h = cls_emb.linear().weight(&self.dense_weight).bias(&self.dense_bias).call().context(TensorSnafu)?;
+        let h = h.tanh().context(TensorSnafu)?;
+        h.linear().weight(&self.out_proj_weight).bias(&self.out_proj_bias).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for ClassificationHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "dense.weight"), self.dense_weight.clone());
+        sd.insert(prefixed(prefix, "dense.bias"), self.dense_bias.clone());
+        sd.insert(prefixed(prefix, "out_proj.weight"), self.out_proj_weight.clone());
+        sd.insert(prefixed(prefix, "out_proj.bias"), self.out_proj_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.dense_weight = get_tensor(sd, &prefixed(prefix, "dense.weight"))?;
+        self.dense_bias = get_tensor(sd, &prefixed(prefix, "dense.bias"))?;
+        self.out_proj_weight = get_tensor(sd, &prefixed(prefix, "out_proj.weight"))?;
+        self.out_proj_bias = get_tensor(sd, &prefixed(prefix, "out_proj.bias"))?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct BgeRerankerV2M3 {
+    pub model: XlmRobertaModel,
+    pub classifier: ClassificationHead,
+}
+
+impl BgeRerankerV2M3 {
+    pub fn empty(config: XlmRobertaConfig) -> Self {
+        let dtype = config.dtype.clone();
+        let hidden = config.hidden_size;
+        Self { model: XlmRobertaModel::empty(config), classifier: ClassificationHead::empty(hidden, 1, dtype) }
+    }
+
+    /// Forward: backbone → classification head → logits `(B, 1)`.
+    pub fn forward(&self, input_ids: &Tensor, attention_mask: Option<&Tensor>) -> Result<Tensor> {
+        let hidden = self.model.forward(input_ids, attention_mask)?;
+        self.classifier.forward(&hidden)
+    }
+
+    /// Score with optional sigmoid normalization. Returns `(B, 1)`.
+    pub fn compute_score(&self, input_ids: &Tensor, attention_mask: &Tensor, normalize: bool) -> Result<Tensor> {
+        let logits = self.forward(input_ids, Some(attention_mask))?;
+        if normalize { logits.sigmoid().context(TensorSnafu) } else { Ok(logits) }
+    }
+
+    /// JIT-path forward with rebindable batch. Returns `(B, 1)`.
+    pub fn forward_batch(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: Option<&Tensor>,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, attention_mask, b)?;
+        self.classifier.forward(&hidden)
+    }
+
+    /// Download from HuggingFace Hub and load.
+    pub fn from_hub(model_id: &str, mut config: XlmRobertaConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut XlmRobertaConfig) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = XlmRobertaConfig::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let weights_path = repo.get("model.safetensors").context(HubSnafu)?;
+        Self::from_safetensors(&weights_path, config.clone())
+    }
+
+    /// Load from a `model.safetensors` checkpoint. Strips the `roberta.`
+    /// prefix from backbone keys.
+    pub fn from_safetensors(path: &std::path::Path, config: XlmRobertaConfig) -> Result<Self> {
+        let sd = crate::state::load_safetensors(path).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Build from a preloaded state dict. Strips `roberta.` prefix.
+    pub fn from_state_dict(sd: &StateDict, config: XlmRobertaConfig) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let stripped = strip_roberta_prefix(sd);
+        let sd_cast = cast_all(&stripped, dtype);
+        let mut model = Self::empty(config);
+        model.load_state_dict(&sd_cast, "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for BgeRerankerV2M3 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.model.state_dict(prefix);
+        sd.extend(self.classifier.state_dict(&prefixed(prefix, "classifier")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.model.load_state_dict(sd, prefix)?;
+        self.classifier.load_state_dict(sd, &prefixed(prefix, "classifier"))?;
+        Ok(())
+    }
+}
+
+fn strip_roberta_prefix(sd: &StateDict) -> StateDict {
+    sd.iter()
+        .map(|(k, v)| {
+            let stripped = k.strip_prefix("roberta.").unwrap_or(k);
+            (stripped.to_string(), v.clone())
+        })
+        .collect()
+}

--- a/model/src/bgem3/scoring.rs
+++ b/model/src/bgem3/scoring.rs
@@ -1,0 +1,60 @@
+//! Scoring functions for BGE-M3 multi-modal retrieval.
+//!
+//! All functions operate on **pre-computed** embeddings, so they can be used
+//! with stored/indexed vectors without re-running the model.
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::Tensor;
+
+use crate::xlm_roberta::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// Dense retrieval score: `q @ p^T`. `q`: `(Bq, D)`, `p`: `(Bp, D)` → `(Bq, Bp)`.
+pub fn dense_score(q: &Tensor, p: &Tensor) -> Result<Tensor> {
+    q.matmul(&p.try_transpose(-1, -2).context(TensorSnafu)?).context(TensorSnafu)
+}
+
+/// Sparse (lexical) retrieval score: `q @ p^T`. Same operation as dense but on
+/// `(B, vocab_size)` sparse vectors.
+pub fn sparse_score(q: &Tensor, p: &Tensor) -> Result<Tensor> {
+    q.matmul(&p.try_transpose(-1, -2).context(TensorSnafu)?).context(TensorSnafu)
+}
+
+/// ColBERT MaxSim score for a single query-passage pair.
+///
+/// `q`: `(Lq, Dc)` query token vectors, `p`: `(Lp, Dc)` passage token vectors.
+/// Returns a scalar: `sum_i(max_j(q_i · p_j)) / Lq`.
+pub fn colbert_score(q: &Tensor, p: &Tensor) -> Result<Tensor> {
+    let token_scores = Tensor::einsum("in,jn->ij", &[q, p]).context(TensorSnafu)?;
+    let max_per_q = token_scores.max(-1).context(TensorSnafu)?;
+    let sum = max_per_q.sum(()).context(TensorSnafu)?;
+    let lq = q.shape().context(TensorSnafu)?;
+    let lq_val = Tensor::const_(
+        lq[0].as_const().context(SymbolicShapeSnafu { what: "colbert_score" })? as f64,
+        sum.uop().dtype(),
+    );
+    sum.try_div(&lq_val).context(TensorSnafu)
+}
+
+/// Hybrid score: weighted combination of dense, sparse, and colbert scores.
+///
+/// `weights = [dense_w, sparse_w, colbert_w]`. Combined as
+/// `(dense*w0 + sparse*w1 + colbert*w2) / (w0 + w1 + w2)`.
+pub fn hybrid_score(dense: &Tensor, sparse: &Tensor, colbert: &Tensor, weights: &[f32; 3]) -> Result<Tensor> {
+    let dtype = dense.uop().dtype();
+    let w_sum = weights.iter().map(|w| *w as f64).sum::<f64>();
+    let w_sum_t = Tensor::const_(w_sum, dtype.clone());
+
+    let w0 = Tensor::const_(weights[0] as f64, dtype.clone());
+    let w1 = Tensor::const_(weights[1] as f64, dtype.clone());
+    let w2 = Tensor::const_(weights[2] as f64, dtype.clone());
+
+    let combined = dense
+        .try_mul(&w0)
+        .context(TensorSnafu)?
+        .try_add(&sparse.try_mul(&w1).context(TensorSnafu)?)
+        .context(TensorSnafu)?
+        .try_add(&colbert.try_mul(&w2).context(TensorSnafu)?)
+        .context(TensorSnafu)?;
+
+    combined.try_div(&w_sum_t).context(TensorSnafu)
+}

--- a/model/src/bgem3/sparse_head.rs
+++ b/model/src/bgem3/sparse_head.rs
@@ -1,0 +1,111 @@
+//! BGE-M3 sparse (lexical) embedding head.
+//!
+//! `Linear(D, 1, bias) → ReLU → scatter_reduce(input_ids, vocab, amax)`.
+//! Produces a `(B, vocab_size)` sparse embedding vector where each position
+//! holds the maximum ReLU activation across all tokens with that ID.
+//!
+//! Unused token positions (CLS, EOS, PAD, UNK) are zeroed post-scatter to
+//! match the FlagEmbedding convention.
+//!
+//! Weights are loaded from `sparse_linear.pt` (PyTorch pickle with bare
+//! `weight` / `bias` keys).
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+use svod_tensor::indexing::ScatterReduction;
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+use crate::xlm_roberta::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// XLM-RoBERTa special token IDs — always zeroed in sparse output.
+/// `<s>`=0, `<pad>`=1, `</s>`=2, `<unk>`=3.
+const XLM_R_SPECIAL_IDS: &[usize] = &[0, 1, 2, 3];
+
+#[derive(Clone)]
+pub struct SparseHead {
+    pub weight: Tensor,
+    pub bias: Tensor,
+    pub vocab_size: usize,
+}
+
+impl SparseHead {
+    pub fn empty(hidden_size: usize, vocab_size: usize, dtype: DType) -> Self {
+        Self {
+            weight: fan_in_uniform(&[1, hidden_size], hidden_size, dtype.clone()),
+            bias: zeros(&[1], dtype),
+            vocab_size,
+        }
+    }
+
+    /// Load from a `sparse_linear.pt` checkpoint (bare `weight`/`bias` keys).
+    pub fn from_pytorch_bin(path: &std::path::Path, vocab_size: usize, dtype: DType) -> Result<Self> {
+        let sd = crate::wespeaker::pickle::load_flat_pytorch_bin(path, "")
+            .map_err(|e| crate::xlm_roberta::Error::Pickle { source: Box::new(e) })?;
+        Self::from_state_dict(&sd, "", vocab_size, dtype)
+    }
+
+    /// Build from a preloaded state dict, casting to `dtype`.
+    pub fn from_state_dict(sd: &StateDict, prefix: &str, vocab_size: usize, dtype: DType) -> Result<Self> {
+        let sd = state::cast_all(sd, dtype.clone());
+        let mut head = Self::empty(0, vocab_size, dtype);
+        head.load_state_dict(&sd, prefix).map_err(|e| crate::xlm_roberta::Error::State { source: Box::new(e) })?;
+        Ok(head)
+    }
+
+    /// Forward. `hidden`: `(B, L, D)`, `input_ids`: `(B, L)` int.
+    /// Returns `(B, vocab_size)` sparse embedding with special-token positions zeroed.
+    pub fn forward(&self, hidden: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
+        let shape = hidden.shape().context(TensorSnafu)?;
+        let b: usize = shape[0].as_const().context(SymbolicShapeSnafu { what: "sparse_head" })?;
+
+        let token_weights = hidden
+            .linear()
+            .weight(&self.weight)
+            .bias(&self.bias)
+            .call()
+            .context(TensorSnafu)?
+            .relu()
+            .context(TensorSnafu)?;
+
+        let token_weights = token_weights.try_squeeze(Some(-1)).context(TensorSnafu)?;
+
+        let zeros = Tensor::zeros(&[b, self.vocab_size], hidden.uop().dtype()).expect("non-empty shape");
+        let sparse =
+            zeros.scatter_reduce(-1, input_ids, &token_weights, ScatterReduction::Amax, true).context(TensorSnafu)?;
+
+        let mask = self.unused_token_mask(hidden.uop().dtype())?;
+        sparse.try_mul(&mask).context(TensorSnafu)
+    }
+
+    fn unused_token_mask(&self, dtype: DType) -> Result<Tensor> {
+        let mut vals = vec![1.0f32; self.vocab_size];
+        for &id in XLM_R_SPECIAL_IDS {
+            if id < self.vocab_size {
+                vals[id] = 0.0;
+            }
+        }
+        let mask = Tensor::from_slice(&vals)
+            .try_reshape([1isize, self.vocab_size as isize])
+            .context(TensorSnafu)?
+            .cast(dtype)
+            .context(TensorSnafu)?;
+        Ok(mask)
+    }
+}
+
+impl HasStateDict for SparseHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd.insert(prefixed(prefix, "bias"), self.bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        self.bias = get_tensor(sd, &prefixed(prefix, "bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/gigaam/remap.rs
+++ b/model/src/gigaam/remap.rs
@@ -62,7 +62,7 @@ fn remap_key(key: &str, config: &GigaAmConfig) -> Option<String> {
     }
 
     if parts.len() >= 4 && parts[..2] == ["head", "decoder_layers"] {
-        return Some(format!("head.{}", &parts[3..].join(".")));
+        return Some(format!("head.{}", parts[3..].join(".")));
     }
 
     // RNN-T predictor: head.decoder.embed.weight, head.decoder.lstm.{w,b}_{ih,hh}_l{N}.

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod bgem3;
 pub mod blocks;
 pub mod diarizen;
 pub mod firered_vad;
@@ -12,6 +13,7 @@ pub mod silero_vad;
 pub mod state;
 pub mod wavlm;
 pub mod wespeaker;
+pub mod xlm_roberta;
 
 #[cfg(test)]
 mod test;

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gigaam;
 pub(crate) mod init;
 pub mod jit;
 pub mod modernbert;
+pub mod qwen3;
 pub mod resnet;
 pub mod sentencepiece;
 pub mod silero_vad;

--- a/model/src/modernbert/config.rs
+++ b/model/src/modernbert/config.rs
@@ -94,53 +94,29 @@ impl ModernBertConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Predefined configs — values from the published `config.json`.
-// ---------------------------------------------------------------------------
-
-/// `answerdotai/ModernBERT-base`: 22 layers, hidden 768, intermediate 1152,
-/// 12 heads (head_dim 64), vocab 50368.
-pub fn modernbert_base() -> ModernBertConfig {
-    ModernBertConfig {
-        vocab_size: 50368,
-        hidden_size: 768,
-        num_hidden_layers: 22,
-        num_attention_heads: 12,
-        intermediate_size: 1152,
-        max_position_embeddings: 8192,
-        layer_norm_eps: 1e-5,
-        global_rope_theta: 160_000.0,
-        local_rope_theta: 10_000.0,
-        local_attention: 128,
-        global_attn_every_n_layers: 3,
-        pad_token_id: 50283,
-        tie_word_embeddings: true,
-        decoder_bias: true,
-        dtype: DType::BFloat16,
-        max_batch_size: 1,
-    }
-}
-
-/// `answerdotai/ModernBERT-large`: 28 layers, hidden 1024, intermediate 2624,
-/// 16 heads (head_dim 64), vocab 50368.
-pub fn modernbert_large() -> ModernBertConfig {
-    ModernBertConfig {
-        vocab_size: 50368,
-        hidden_size: 1024,
-        num_hidden_layers: 28,
-        num_attention_heads: 16,
-        intermediate_size: 2624,
-        max_position_embeddings: 8192,
-        layer_norm_eps: 1e-5,
-        global_rope_theta: 160_000.0,
-        local_rope_theta: 10_000.0,
-        local_attention: 128,
-        global_attn_every_n_layers: 3,
-        pad_token_id: 50283,
-        tie_word_embeddings: true,
-        decoder_bias: true,
-        dtype: DType::BFloat16,
-        max_batch_size: 1,
+impl Default for ModernBertConfig {
+    /// Placeholder config — structural fields are zero since [`from_hub`]
+    /// overwrites them all from `config.json`. Only `dtype` and
+    /// `max_batch_size` are caller-chosen.
+    fn default() -> Self {
+        Self {
+            vocab_size: 0,
+            hidden_size: 0,
+            num_hidden_layers: 0,
+            num_attention_heads: 0,
+            intermediate_size: 0,
+            max_position_embeddings: 0,
+            layer_norm_eps: 0.0,
+            global_rope_theta: 0.0,
+            local_rope_theta: 0.0,
+            local_attention: 0,
+            global_attn_every_n_layers: 0,
+            pad_token_id: 0,
+            tie_word_embeddings: false,
+            decoder_bias: false,
+            dtype: DType::BFloat16,
+            max_batch_size: 1,
+        }
     }
 }
 
@@ -165,28 +141,24 @@ impl ModernBertConfig {
     }
 
     fn from_raw(raw: RawModernBertConfig) -> Self {
-        // Defaults from ModernBERT-base; the `large` checkpoint overrides every
-        // structural field so the base fallback only matters for a truncated
-        // or hand-written config.
-        let base = modernbert_base();
+        let d = ModernBertConfig::default();
         ModernBertConfig {
-            vocab_size: raw.vocab_size.unwrap_or(base.vocab_size),
-            hidden_size: raw.hidden_size.unwrap_or(base.hidden_size),
-            num_hidden_layers: raw.num_hidden_layers.unwrap_or(base.num_hidden_layers),
-            num_attention_heads: raw.num_attention_heads.unwrap_or(base.num_attention_heads),
-            intermediate_size: raw.intermediate_size.unwrap_or(base.intermediate_size),
-            max_position_embeddings: raw.max_position_embeddings.unwrap_or(base.max_position_embeddings),
-            layer_norm_eps: raw.layer_norm_eps.or(raw.norm_eps).unwrap_or(base.layer_norm_eps),
-            global_rope_theta: raw.global_rope_theta.unwrap_or(base.global_rope_theta),
-            local_rope_theta: raw.local_rope_theta.unwrap_or(base.local_rope_theta),
-            local_attention: raw.local_attention.unwrap_or(base.local_attention),
-            global_attn_every_n_layers: raw.global_attn_every_n_layers.unwrap_or(base.global_attn_every_n_layers),
-            pad_token_id: raw.pad_token_id.unwrap_or(base.pad_token_id),
-            tie_word_embeddings: raw.tie_word_embeddings.unwrap_or(base.tie_word_embeddings),
-            decoder_bias: raw.decoder_bias.unwrap_or(base.decoder_bias),
-            // Compute dtype is caller-chosen, not from config.json.
-            dtype: base.dtype,
-            max_batch_size: base.max_batch_size,
+            vocab_size: raw.vocab_size.unwrap_or(d.vocab_size),
+            hidden_size: raw.hidden_size.unwrap_or(d.hidden_size),
+            num_hidden_layers: raw.num_hidden_layers.unwrap_or(d.num_hidden_layers),
+            num_attention_heads: raw.num_attention_heads.unwrap_or(d.num_attention_heads),
+            intermediate_size: raw.intermediate_size.unwrap_or(d.intermediate_size),
+            max_position_embeddings: raw.max_position_embeddings.unwrap_or(d.max_position_embeddings),
+            layer_norm_eps: raw.layer_norm_eps.or(raw.norm_eps).unwrap_or(d.layer_norm_eps),
+            global_rope_theta: raw.global_rope_theta.unwrap_or(d.global_rope_theta),
+            local_rope_theta: raw.local_rope_theta.unwrap_or(d.local_rope_theta),
+            local_attention: raw.local_attention.unwrap_or(d.local_attention),
+            global_attn_every_n_layers: raw.global_attn_every_n_layers.unwrap_or(d.global_attn_every_n_layers),
+            pad_token_id: raw.pad_token_id.unwrap_or(d.pad_token_id),
+            tie_word_embeddings: raw.tie_word_embeddings.unwrap_or(d.tie_word_embeddings),
+            decoder_bias: raw.decoder_bias.unwrap_or(d.decoder_bias),
+            dtype: d.dtype,
+            max_batch_size: d.max_batch_size,
         }
     }
 }

--- a/model/src/modernbert/mod.rs
+++ b/model/src/modernbert/mod.rs
@@ -20,7 +20,7 @@ mod pooling;
 mod rotary;
 
 pub use attention::ModernBertAttention;
-pub use config::{ModernBertConfig, modernbert_base, modernbert_large};
+pub use config::ModernBertConfig;
 pub use encoder::Encoder;
 pub use encoder_layer::EncoderLayer;
 pub use error::{Error, Result};

--- a/model/src/qwen3/attention.rs
+++ b/model/src/qwen3/attention.rs
@@ -1,0 +1,182 @@
+//! Qwen3 attention with Grouped Query Attention (GQA), per-head Q/K RMSNorm,
+//! and RoPE.
+//!
+//! Key differences from ModernBERT attention:
+//! - **Separate Q/K/V/O projections** (not fused QKV)
+//! - **GQA**: K/V have `num_key_value_heads < num_attention_heads`; KV heads
+//!   are expanded via [`repeat_kv`] before SDPA
+//! - **Per-head Q/K RMSNorm** (Qwen3 signature feature): `q_norm`/`k_norm`
+//!   normalize over `head_dim` only, applied AFTER view-to-heads, BEFORE RoPE
+//! - **Causal attention**: `is_causal = true` in SDPA
+//! - **No bias** on any projection (`attention_bias = false`)
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+use super::rms_norm::RmsNormWeights;
+use super::rotary::RotaryTable;
+
+/// Expand KV heads to match Q head count for GQA.
+///
+/// `(B, n_kv, L, hd) → (B, n_kv * n_rep, L, hd)` via unsqueeze-insert,
+/// broadcast-expand, reshape-merge. The `n_rep` factor is a compile-time
+/// constant, so the expand target is concrete on the head axis. Symbolic
+/// batch dim `b` passes through.
+fn repeat_kv(x: &Tensor, n_rep: usize) -> Result<Tensor> {
+    if n_rep == 1 {
+        return Ok(x.clone());
+    }
+    let shape = x.shape().context(TensorSnafu)?;
+    let b = shape[0].clone();
+    let l = shape[2].clone();
+    let n_kv: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "repeat_kv" })?;
+    let hd: usize = shape[3].as_const().context(SymbolicShapeSnafu { what: "repeat_kv" })?;
+    let total = n_kv * n_rep;
+    x.try_reshape([b.clone(), SInt::from(n_kv as isize), SInt::from(1isize), l.clone(), SInt::from(hd as isize)])
+        .context(TensorSnafu)?
+        .try_expand([
+            b.clone(),
+            SInt::from(n_kv as isize),
+            SInt::from(n_rep as isize),
+            l.clone(),
+            SInt::from(hd as isize),
+        ])
+        .context(TensorSnafu)?
+        .try_reshape([b, SInt::from(total as isize), l, SInt::from(hd as isize)])
+        .context(TensorSnafu)
+}
+
+#[derive(Clone)]
+pub struct Qwen3Attention {
+    pub hidden_size: usize,
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub eps: f64,
+    pub q_proj_weight: Tensor,
+    pub k_proj_weight: Tensor,
+    pub v_proj_weight: Tensor,
+    pub o_proj_weight: Tensor,
+    pub q_norm: RmsNormWeights,
+    pub k_norm: RmsNormWeights,
+}
+
+impl Qwen3Attention {
+    pub fn empty(
+        hidden_size: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        eps: f64,
+        dtype: svod_dtype::DType,
+    ) -> Self {
+        let q_proj_weight = fan_in_uniform(&[num_heads * head_dim, hidden_size], hidden_size, dtype.clone());
+        let k_proj_weight = fan_in_uniform(&[num_kv_heads * head_dim, hidden_size], hidden_size, dtype.clone());
+        let v_proj_weight = fan_in_uniform(&[num_kv_heads * head_dim, hidden_size], hidden_size, dtype.clone());
+        let o_proj_weight = fan_in_uniform(&[hidden_size, num_heads * head_dim], num_heads * head_dim, dtype.clone());
+        let q_norm = RmsNormWeights::empty(head_dim, eps, dtype.clone());
+        let k_norm = RmsNormWeights::empty(head_dim, eps, dtype);
+        Self {
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            eps,
+            q_proj_weight,
+            k_proj_weight,
+            v_proj_weight,
+            o_proj_weight,
+            q_norm,
+            k_norm,
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)` → `(B, L, D)`.
+    /// `rotary`: the shared cos/sin table. `padding_mask`: optional bool
+    /// `(B, 1, 1, L)` where `true` = masked out (padding) position.
+    pub fn forward(&self, x: &Tensor, rotary: &RotaryTable, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = x.shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+        let l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "qwen3 attention" })?;
+        let h = self.num_heads as isize;
+        let kv_h = self.num_kv_heads as isize;
+        let hd = self.head_dim as isize;
+        let bsint: SInt = b;
+
+        // Separate projections.
+        let q = x.linear().weight(&self.q_proj_weight).call().context(TensorSnafu)?;
+        let k = x.linear().weight(&self.k_proj_weight).call().context(TensorSnafu)?;
+        let v = x.linear().weight(&self.v_proj_weight).call().context(TensorSnafu)?;
+
+        // (B, L, H*kv_hd) → (B, L, n, hd) → (B, n, L, hd)
+        let to_heads = |t: Tensor, n: isize| -> Result<Tensor> {
+            t.view([bsint.clone(), l.into(), n.into(), hd.into()])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)
+        };
+
+        let q = to_heads(q, h)?;
+        let k = to_heads(k, kv_h)?;
+        let v = to_heads(v, kv_h)?;
+
+        // Per-head Q/K RMSNorm (BEFORE RoPE) — Qwen3 signature feature.
+        let q = self.q_norm.apply(&q)?;
+        let k = self.k_norm.apply(&k)?;
+
+        // RoPE applied to Q and K.
+        let q = rotary.apply(&q)?;
+        let k = rotary.apply(&k)?;
+
+        // GQA: expand K/V from num_kv_heads to num_heads.
+        let n_rep = self.num_heads / self.num_kv_heads;
+        let k = repeat_kv(&k, n_rep)?;
+        let v = repeat_kv(&v, n_rep)?;
+
+        // Causal SDPA + optional padding mask.
+        let attn = q
+            .scaled_dot_product_attention()
+            .key(&k)
+            .value(&v)
+            .is_causal(true)
+            .maybe_attn_mask(padding_mask)
+            .call()
+            .context(TensorSnafu)?;
+
+        // (B, H, L, hd) → (B, L, H*hd) → output projection.
+        let attn = attn
+            .try_permute(&[0, 2, 1, 3])
+            .context(TensorSnafu)?
+            .view([bsint, l.into(), (self.num_heads * self.head_dim).into()])
+            .context(TensorSnafu)?;
+        attn.linear().weight(&self.o_proj_weight).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Qwen3Attention {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "q_proj.weight"), self.q_proj_weight.clone());
+        sd.insert(prefixed(prefix, "k_proj.weight"), self.k_proj_weight.clone());
+        sd.insert(prefixed(prefix, "v_proj.weight"), self.v_proj_weight.clone());
+        sd.insert(prefixed(prefix, "o_proj.weight"), self.o_proj_weight.clone());
+        sd.extend(self.q_norm.state_dict(&prefixed(prefix, "q_norm")));
+        sd.extend(self.k_norm.state_dict(&prefixed(prefix, "k_norm")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.q_proj_weight = get_tensor(sd, &prefixed(prefix, "q_proj.weight"))?;
+        self.k_proj_weight = get_tensor(sd, &prefixed(prefix, "k_proj.weight"))?;
+        self.v_proj_weight = get_tensor(sd, &prefixed(prefix, "v_proj.weight"))?;
+        self.o_proj_weight = get_tensor(sd, &prefixed(prefix, "o_proj.weight"))?;
+        self.q_norm.load_state_dict(sd, &prefixed(prefix, "q_norm"))?;
+        self.k_norm.load_state_dict(sd, &prefixed(prefix, "k_norm"))?;
+        Ok(())
+    }
+}

--- a/model/src/qwen3/config.rs
+++ b/model/src/qwen3/config.rs
@@ -1,0 +1,138 @@
+//! Qwen3 configuration, parsed from HuggingFace `config.json`.
+//!
+//! Mirrors the published schema of `Qwen/Qwen3-Embedding-0.6B`. The clean
+//! [`Qwen3Config`] keeps only the fields the Rust backbone consumes and adds
+//! a caller-chosen compute [`DType`] (defaults to bf16 on the AMD target,
+//! f32 for CPU parity tests).
+//!
+//! Key detail: `head_dim` is **explicit** and may differ from
+//! `hidden_size / num_attention_heads`. For the 0.6B checkpoint,
+//! `head_dim = 128` but `hidden_size / num_heads = 1024 / 16 = 64`.
+//! The Q projection outputs `num_heads * head_dim = 2048`, not `hidden_size`.
+
+use std::path::Path;
+
+use serde::Deserialize;
+use svod_dtype::DType;
+
+use super::error::{Error, Result};
+
+#[derive(Clone, Debug)]
+pub struct Qwen3Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    /// Explicit head dimension — NOT derived from `hidden_size / num_heads`.
+    pub head_dim: usize,
+    pub intermediate_size: usize,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+    pub rope_theta: f64,
+    pub attention_bias: bool,
+    pub tie_word_embeddings: bool,
+    pub pad_token_id: usize,
+    pub dtype: DType,
+    pub max_batch_size: usize,
+}
+
+impl Qwen3Config {
+    /// Number of Q heads per KV head (GQA group size).
+    pub fn num_kv_groups(&self) -> usize {
+        self.num_attention_heads / self.num_key_value_heads
+    }
+
+    pub fn merge_structural_from(&mut self, parsed: &Self) {
+        self.vocab_size = parsed.vocab_size;
+        self.hidden_size = parsed.hidden_size;
+        self.num_hidden_layers = parsed.num_hidden_layers;
+        self.num_attention_heads = parsed.num_attention_heads;
+        self.num_key_value_heads = parsed.num_key_value_heads;
+        self.head_dim = parsed.head_dim;
+        self.intermediate_size = parsed.intermediate_size;
+        self.max_position_embeddings = parsed.max_position_embeddings;
+        self.rms_norm_eps = parsed.rms_norm_eps;
+        self.rope_theta = parsed.rope_theta;
+        self.attention_bias = parsed.attention_bias;
+        self.tie_word_embeddings = parsed.tie_word_embeddings;
+        self.pad_token_id = parsed.pad_token_id;
+    }
+}
+
+/// `Qwen/Qwen3-Embedding-0.6B`: 28 layers, hidden 1024, 16 Q heads / 8 KV heads,
+/// head_dim 128, intermediate 3072, vocab 151669.
+pub fn qwen3_embedding_0_6b() -> Qwen3Config {
+    Qwen3Config {
+        vocab_size: 151_669,
+        hidden_size: 1024,
+        num_hidden_layers: 28,
+        num_attention_heads: 16,
+        num_key_value_heads: 8,
+        head_dim: 128,
+        intermediate_size: 3072,
+        max_position_embeddings: 32_768,
+        rms_norm_eps: 1e-6,
+        rope_theta: 1_000_000.0,
+        attention_bias: false,
+        tie_word_embeddings: true,
+        pad_token_id: 151_643,
+        dtype: DType::BFloat16,
+        max_batch_size: 1,
+    }
+}
+
+impl Qwen3Config {
+    pub fn from_json(path: &Path) -> Result<Self> {
+        let data = std::fs::read_to_string(path)
+            .map_err(|e| Error::Config { message: format!("reading config.json: {e}") })?;
+        Self::from_json_str(&data)
+    }
+
+    pub fn from_json_str(data: &str) -> Result<Self> {
+        let raw: RawQwen3Config =
+            serde_json::from_str(data).map_err(|e| Error::Config { message: format!("JSON parse error: {e}") })?;
+        Ok(Self::from_raw(raw))
+    }
+
+    fn from_raw(raw: RawQwen3Config) -> Self {
+        let base = qwen3_embedding_0_6b();
+        let head_dim = raw.head_dim.unwrap_or_else(|| {
+            raw.hidden_size.unwrap_or(base.hidden_size) / raw.num_attention_heads.unwrap_or(base.num_attention_heads)
+        });
+        Qwen3Config {
+            vocab_size: raw.vocab_size.unwrap_or(base.vocab_size),
+            hidden_size: raw.hidden_size.unwrap_or(base.hidden_size),
+            num_hidden_layers: raw.num_hidden_layers.unwrap_or(base.num_hidden_layers),
+            num_attention_heads: raw.num_attention_heads.unwrap_or(base.num_attention_heads),
+            num_key_value_heads: raw.num_key_value_heads.unwrap_or(base.num_key_value_heads),
+            head_dim,
+            intermediate_size: raw.intermediate_size.unwrap_or(base.intermediate_size),
+            max_position_embeddings: raw.max_position_embeddings.unwrap_or(base.max_position_embeddings),
+            rms_norm_eps: raw.rms_norm_eps.unwrap_or(base.rms_norm_eps),
+            rope_theta: raw.rope_theta.unwrap_or(base.rope_theta),
+            attention_bias: raw.attention_bias.unwrap_or(base.attention_bias),
+            tie_word_embeddings: raw.tie_word_embeddings.unwrap_or(base.tie_word_embeddings),
+            pad_token_id: raw.pad_token_id.unwrap_or(base.pad_token_id),
+            dtype: base.dtype,
+            max_batch_size: base.max_batch_size,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RawQwen3Config {
+    vocab_size: Option<usize>,
+    hidden_size: Option<usize>,
+    num_hidden_layers: Option<usize>,
+    num_attention_heads: Option<usize>,
+    num_key_value_heads: Option<usize>,
+    head_dim: Option<usize>,
+    intermediate_size: Option<usize>,
+    max_position_embeddings: Option<usize>,
+    rms_norm_eps: Option<f64>,
+    rope_theta: Option<f64>,
+    attention_bias: Option<bool>,
+    tie_word_embeddings: Option<bool>,
+    pad_token_id: Option<usize>,
+}

--- a/model/src/qwen3/decoder_layer.rs
+++ b/model/src/qwen3/decoder_layer.rs
@@ -1,0 +1,74 @@
+//! Qwen3 pre-norm decoder layer.
+//!
+//! Standard pre-norm residual structure:
+//! ```text
+//! h = x + attn(input_layernorm(x))
+//! y = h + mlp(post_attention_layernorm(h))
+//! ```
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::attention::Qwen3Attention;
+use super::error::{Result, TensorSnafu};
+use super::feed_forward::Qwen3MLP;
+use super::rms_norm::RmsNormWeights;
+use super::rotary::RotaryTable;
+
+#[derive(Clone)]
+pub struct Qwen3DecoderLayer {
+    pub input_layernorm: RmsNormWeights,
+    pub attention: Qwen3Attention,
+    pub post_attention_layernorm: RmsNormWeights,
+    pub mlp: Qwen3MLP,
+}
+
+impl Qwen3DecoderLayer {
+    pub fn empty(config: &super::Qwen3Config) -> Self {
+        let dtype = config.dtype.clone();
+        Self {
+            input_layernorm: RmsNormWeights::empty(config.hidden_size, config.rms_norm_eps, dtype.clone()),
+            attention: Qwen3Attention::empty(
+                config.hidden_size,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                config.head_dim,
+                config.rms_norm_eps,
+                dtype.clone(),
+            ),
+            post_attention_layernorm: RmsNormWeights::empty(config.hidden_size, config.rms_norm_eps, dtype.clone()),
+            mlp: Qwen3MLP::empty(config.hidden_size, config.intermediate_size, dtype),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor, rotary: &RotaryTable, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let normed = self.input_layernorm.apply(x)?;
+        let delta = self.attention.forward(&normed, rotary, padding_mask)?;
+        let h = x.try_add(&delta).context(TensorSnafu)?;
+
+        let normed = self.post_attention_layernorm.apply(&h)?;
+        let delta = self.mlp.forward(&normed)?;
+        h.try_add(&delta).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Qwen3DecoderLayer {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.extend(self.input_layernorm.state_dict(&format!("{prefix}.input_layernorm")));
+        sd.extend(self.attention.state_dict(&format!("{prefix}.self_attn")));
+        sd.extend(self.post_attention_layernorm.state_dict(&format!("{prefix}.post_attention_layernorm")));
+        sd.extend(self.mlp.state_dict(&format!("{prefix}.mlp")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.input_layernorm.load_state_dict(sd, &format!("{prefix}.input_layernorm"))?;
+        self.attention.load_state_dict(sd, &format!("{prefix}.self_attn"))?;
+        self.post_attention_layernorm.load_state_dict(sd, &format!("{prefix}.post_attention_layernorm"))?;
+        self.mlp.load_state_dict(sd, &format!("{prefix}.mlp"))?;
+        Ok(())
+    }
+}

--- a/model/src/qwen3/embedder.rs
+++ b/model/src/qwen3/embedder.rs
@@ -1,0 +1,105 @@
+//! Qwen3 embedding model: decoder backbone + last-token pooling + L2 normalize.
+//!
+//! The pipeline (matching `sentence-transformers` `modules.json`):
+//! 1. Qwen3 decoder forward → `(B, L, D)` last hidden states
+//! 2. Last-token pooling → `(B, D)` (select position `L-1`)
+//! 3. L2 normalize → `(B, D)` unit-norm embeddings
+//!
+//! **Padding convention**: requires **left-padding** (standard for decoder
+//! embedding inference). With left-padding the last real token is at position
+//! `L-1`, a compile-time constant — so last-token pooling works in JIT
+//! (identical to CLS pooling in ModernBERT).
+//!
+//! Loads from the same `model.safetensors` as [`Qwen3Model`] (bare keys,
+//! no `model.` prefix).
+
+use std::path::Path;
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::{BoundVariable, Tensor, s};
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::Qwen3Config;
+use super::error::{HubSnafu, Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::model::Qwen3Model;
+
+#[derive(Clone)]
+pub struct Qwen3Embedding {
+    pub model: Qwen3Model,
+    pub normalize: bool,
+}
+
+impl Qwen3Embedding {
+    pub fn empty(config: Qwen3Config) -> Self {
+        let model = Qwen3Model::empty(config);
+        Self { model, normalize: true }
+    }
+
+    /// Eager forward: `input_ids` `(B, L)` + `attention_mask` `(B, L)` →
+    /// embeddings `(B, D)`.
+    pub fn encode(&self, input_ids: &Tensor, attention_mask: &Tensor) -> Result<Tensor> {
+        let hidden = self.model.forward(input_ids, Some(attention_mask))?;
+        self.pool_and_normalize(&hidden)
+    }
+
+    /// JIT-path variant with rebindable batch. Returns `(B, D)`.
+    pub fn encode_batch(&self, input_ids: &Tensor, attention_mask: &Tensor, b: &BoundVariable) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, Some(attention_mask), b)?;
+        self.pool_and_normalize(&hidden)
+    }
+
+    fn pool_and_normalize(&self, hidden: &Tensor) -> Result<Tensor> {
+        let shape = hidden.shape().context(TensorSnafu)?;
+        let l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "qwen3 pooling" })?;
+
+        // Last-token pooling: take position L-1 (requires left-padding).
+        let pooled = hidden.getitem(s![.., (l - 1) as i64, ..]).context(TensorSnafu)?;
+
+        if self.normalize { pooled.lp_normalize(-1, 2).context(TensorSnafu) } else { Ok(pooled) }
+    }
+
+    pub fn from_hub(model_id: &str, mut config: Qwen3Config) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut Qwen3Config) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = Qwen3Config::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let dir = crate::qwen3::download_safetensors(&repo)?;
+        Self::from_safetensors_dir(&dir, config.clone())
+    }
+
+    pub fn from_safetensors(path: &Path, config: Qwen3Config) -> Result<Self> {
+        let sd = state::load_safetensors(path).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Load from a directory containing `model.safetensors` or multi-shard files.
+    pub fn from_safetensors_dir(dir: &Path, config: Qwen3Config) -> Result<Self> {
+        let sd = state::load_safetensors_dir(dir).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: Qwen3Config) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let mut model = Self::empty(config);
+        model.load_state_dict(&state::cast_all(sd, dtype), "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for Qwen3Embedding {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        self.model.state_dict(prefix)
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.model.load_state_dict(sd, prefix)
+    }
+}

--- a/model/src/qwen3/embeddings.rs
+++ b/model/src/qwen3/embeddings.rs
@@ -1,0 +1,46 @@
+//! Qwen3 token embeddings — plain `nn.Embedding` lookup with no norm.
+//!
+//! Position information enters via RoPE in attention, not via embedding
+//! tables. Unlike ModernBERT (which LayerNorms after embedding), Qwen3
+//! applies the first norm inside the decoder layer.
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct Qwen3Embeddings {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub embed_weight: Tensor,
+}
+
+impl Qwen3Embeddings {
+    pub fn empty(vocab_size: usize, hidden_size: usize, dtype: DType) -> Self {
+        Self { vocab_size, hidden_size, embed_weight: fan_in_uniform(&[vocab_size, hidden_size], hidden_size, dtype) }
+    }
+
+    pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let shape = input_ids.shape().context(TensorSnafu)?;
+        let _l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "qwen3 embeddings" })?;
+        self.embed_weight.embedding(input_ids).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Qwen3Embeddings {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.embed_weight.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.embed_weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        Ok(())
+    }
+}

--- a/model/src/qwen3/error.rs
+++ b/model/src/qwen3/error.rs
@@ -1,0 +1,30 @@
+//! Error type for the Qwen3 module.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    #[snafu(display("tensor op failed"))]
+    Tensor {
+        #[snafu(source(from(svod_tensor::error::Error, Box::new)))]
+        source: Box<svod_tensor::error::Error>,
+    },
+
+    #[snafu(display("state-dict op failed"))]
+    State {
+        #[snafu(source(from(crate::state::Error, Box::new)))]
+        source: Box<crate::state::Error>,
+    },
+
+    #[snafu(display("HF Hub op failed"))]
+    Hub { source: hf_hub::api::sync::ApiError },
+
+    #[snafu(display("reading config failed: {message}"))]
+    Config { message: String },
+
+    #[snafu(display("{what} requires a concrete sequence length, got a symbolic dim"))]
+    SymbolicShape { what: &'static str },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/model/src/qwen3/feed_forward.rs
+++ b/model/src/qwen3/feed_forward.rs
@@ -1,0 +1,55 @@
+//! Qwen3 gated feed-forward (SwiGLU): `down(silu(gate(x)) * up(x))`.
+//!
+//! No biases. Three separate projections (gate, up, down) — not a fused
+//! 2×intermediate matrix like ModernBERT.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, TensorSnafu};
+
+#[derive(Clone)]
+pub struct Qwen3MLP {
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub gate_weight: Tensor,
+    pub up_weight: Tensor,
+    pub down_weight: Tensor,
+}
+
+impl Qwen3MLP {
+    pub fn empty(hidden_size: usize, intermediate_size: usize, dtype: DType) -> Self {
+        let gate_weight = fan_in_uniform(&[intermediate_size, hidden_size], hidden_size, dtype.clone());
+        let up_weight = fan_in_uniform(&[intermediate_size, hidden_size], hidden_size, dtype.clone());
+        let down_weight = fan_in_uniform(&[hidden_size, intermediate_size], intermediate_size, dtype);
+        Self { hidden_size, intermediate_size, gate_weight, up_weight, down_weight }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = x.linear().weight(&self.gate_weight).call().context(TensorSnafu)?;
+        let up = x.linear().weight(&self.up_weight).call().context(TensorSnafu)?;
+        let act = gate.silu().context(TensorSnafu)?.try_mul(&up).context(TensorSnafu)?;
+        act.linear().weight(&self.down_weight).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Qwen3MLP {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "gate_proj.weight"), self.gate_weight.clone());
+        sd.insert(prefixed(prefix, "up_proj.weight"), self.up_weight.clone());
+        sd.insert(prefixed(prefix, "down_proj.weight"), self.down_weight.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.gate_weight = get_tensor(sd, &prefixed(prefix, "gate_proj.weight"))?;
+        self.up_weight = get_tensor(sd, &prefixed(prefix, "up_proj.weight"))?;
+        self.down_weight = get_tensor(sd, &prefixed(prefix, "down_proj.weight"))?;
+        Ok(())
+    }
+}

--- a/model/src/qwen3/jit.rs
+++ b/model/src/qwen3/jit.rs
@@ -1,0 +1,41 @@
+//! JIT wrapper for [`Qwen3Embedding`]. Bakes the `input_ids` /
+//! `attention_mask` shapes into the plan and exposes `b` as the rebindable
+//! batch variable. The entire pipeline (backbone + last-token pooling +
+//! L2 normalize) runs in one JIT plan.
+
+extern crate self as svod_model;
+
+use svod_macros::jit_wrapper;
+
+use super::embedder::Qwen3Embedding;
+use super::reranker::Qwen3Reranker;
+
+jit_wrapper! {
+    Qwen3EmbeddingJit(Qwen3Embedding) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.encode_batch(input_ids, attention_mask, &b)
+        }
+    }
+}
+
+jit_wrapper! {
+    Qwen3RerankerJit(Qwen3Reranker) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.forward_batch(input_ids, attention_mask, &b)
+        }
+    }
+}

--- a/model/src/qwen3/mod.rs
+++ b/model/src/qwen3/mod.rs
@@ -1,0 +1,69 @@
+//! Qwen3 — decoder-only LLM backbone and embedding model.
+//!
+//! Pure-Rust port of the Qwen3 architecture (as used by
+//! `Qwen/Qwen3-Embedding-0.6B`): token embeddings → causal RoPE decoder
+//! stack (GQA, per-head Q/K RMSNorm, SwiGLU) → final RMSNorm.
+//!
+//! The embedding model adds last-token pooling + L2 normalization.
+//! Computes in bf16 on the AMD target; f32 for CPU parity. Tokenization is
+//! out-of-band — the API takes pre-computed `input_ids`.
+
+mod attention;
+mod config;
+mod decoder_layer;
+mod embedder;
+mod embeddings;
+mod error;
+mod feed_forward;
+mod jit;
+mod model;
+mod reranker;
+mod rms_norm;
+mod rotary;
+
+pub use attention::Qwen3Attention;
+pub use config::{Qwen3Config, qwen3_embedding_0_6b};
+pub use decoder_layer::Qwen3DecoderLayer;
+pub use embedder::Qwen3Embedding;
+pub use embeddings::Qwen3Embeddings;
+pub use error::{Error, Result};
+pub use feed_forward::Qwen3MLP;
+pub use jit::{Qwen3EmbeddingJit, Qwen3RerankerJit};
+pub use model::Qwen3Model;
+pub use reranker::Qwen3Reranker;
+pub use rms_norm::RmsNormWeights;
+pub use rotary::RotaryTable;
+
+use std::path::PathBuf;
+
+use hf_hub::api::sync::ApiRepo;
+use snafu::ResultExt;
+
+/// Download all safetensors weight files from a HuggingFace repo into the
+/// hub cache and return the cache directory containing them.
+///
+/// Handles both single-file (`model.safetensors`) and multi-shard
+/// (`model-NNNNN-of-NNNNN.safetensors` + `model.safetensors.index.json`).
+pub(crate) fn download_safetensors(repo: &ApiRepo) -> Result<PathBuf> {
+    // Try single-file first.
+    if let Ok(path) = repo.get("model.safetensors") {
+        return Ok(path.parent().expect("non-root cache dir").to_path_buf());
+    }
+
+    // Multi-shard: parse the index to discover shard filenames.
+    let index_path = repo.get("model.safetensors.index.json").context(error::HubSnafu)?;
+    let dir = index_path.parent().expect("non-root cache dir").to_path_buf();
+
+    // The index file is already downloaded. But we need to ensure all shard
+    // files are too — `repo.get` downloads on demand.
+    let index_data = std::fs::read_to_string(&index_path)
+        .map_err(|e| Error::Config { message: format!("reading safetensors index: {e}") })?;
+    let index: crate::state::SafetensorsIndex = serde_json::from_str(&index_data)
+        .map_err(|e| Error::Config { message: format!("parsing safetensors index: {e}") })?;
+
+    for shard in index.unique_shards() {
+        repo.get(&shard).context(error::HubSnafu)?;
+    }
+
+    Ok(dir)
+}

--- a/model/src/qwen3/model.rs
+++ b/model/src/qwen3/model.rs
@@ -1,0 +1,148 @@
+//! Root Qwen3 decoder backbone: token embeddings → RoPE decoder stack →
+//! final RMSNorm. Exposes `forward` returning the `(B, L, D)` last-hidden-state.
+//!
+//! Loads from a HuggingFace `model.safetensors` checkpoint with bare keys
+//! (`embed_tokens.weight`, `layers.N.*`, `norm.weight` — no `model.` prefix).
+//! Compute dtype is `config.dtype` (bf16 by default, f32 for CPU parity).
+
+use std::path::Path;
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::Qwen3Config;
+use super::decoder_layer::Qwen3DecoderLayer;
+use super::embeddings::Qwen3Embeddings;
+use super::error::{HubSnafu, Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::rms_norm::RmsNormWeights;
+use super::rotary::RotaryTable;
+
+#[derive(Clone)]
+pub struct Qwen3Model {
+    pub config: Qwen3Config,
+    pub embeddings: Qwen3Embeddings,
+    pub layers: Vec<Qwen3DecoderLayer>,
+    pub norm: RmsNormWeights,
+}
+
+impl Qwen3Model {
+    pub fn empty(config: Qwen3Config) -> Self {
+        let dtype = config.dtype.clone();
+        let embeddings = Qwen3Embeddings::empty(config.vocab_size, config.hidden_size, dtype.clone());
+        let layers = (0..config.num_hidden_layers).map(|_| Qwen3DecoderLayer::empty(&config)).collect();
+        let norm = RmsNormWeights::empty(config.hidden_size, config.rms_norm_eps, dtype);
+        Self { config, embeddings, layers, norm }
+    }
+
+    /// Eager forward: `input_ids` `(B, L)` + optional `padding_mask` `(B, L)`
+    /// bool → last-hidden-state `(B, L, D)`.
+    pub fn forward(&self, input_ids: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let x = self.embeddings.forward(input_ids)?;
+        let shape = x.shape().context(TensorSnafu)?;
+        let b_dim = shape[0].clone();
+        let seq_len: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "qwen3 forward seq_len" })?;
+
+        // Build the rotary table once — shared across all layers.
+        let rotary =
+            RotaryTable::new(self.config.rope_theta, seq_len, self.config.head_dim, self.config.dtype.clone())?;
+
+        // Build SDPA key-axis mask: bool (B,1,1,L), True = masked out.
+        let mask_4d = match padding_mask {
+            Some(m) => {
+                let m2 = m.try_reshape([b_dim.clone(), SInt::from(seq_len)]).context(TensorSnafu)?;
+                let inverted = m2.logical_not().context(TensorSnafu)?;
+                Some(inverted.try_unsqueeze(1).context(TensorSnafu)?.try_unsqueeze(1).context(TensorSnafu)?)
+            }
+            None => None,
+        };
+
+        let mut h = x;
+        for layer in &self.layers {
+            h = layer.forward(&h, &rotary, mask_4d.as_ref())?;
+        }
+        self.norm.apply(&h)
+    }
+
+    /// JIT-path variant: shrinks the leading batch dim to the live value.
+    pub fn forward_batch(
+        &self,
+        input_ids: &Tensor,
+        padding_mask: Option<&Tensor>,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let bv = b.as_sint();
+        let input_ids = input_ids.try_shrink([Some((SInt::Const(0), bv.clone())), None]).context(TensorSnafu)?;
+        let padding_mask = match padding_mask {
+            Some(m) => Some(m.try_shrink([Some((SInt::Const(0), bv)), None]).context(TensorSnafu)?),
+            None => None,
+        };
+        self.forward(&input_ids, padding_mask.as_ref())
+    }
+
+    pub fn from_hub(model_id: &str, mut config: Qwen3Config) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut Qwen3Config) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = Qwen3Config::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let dir = crate::qwen3::download_safetensors(&repo)?;
+        Self::from_safetensors_dir(&dir, config.clone())
+    }
+
+    pub fn from_safetensors(path: &Path, config: Qwen3Config) -> Result<Self> {
+        let sd = state::load_safetensors(path).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Load from a directory containing `model.safetensors` (single-file) or
+    /// `model.safetensors.index.json` + shards (multi-shard).
+    pub fn from_safetensors_dir(dir: &Path, config: Qwen3Config) -> Result<Self> {
+        let sd = state::load_safetensors_dir(dir).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: Qwen3Config) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let mut model = Self::empty(config);
+        model.load_state_dict(&state::cast_all(sd, dtype), "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for Qwen3Model {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.extend(self.embeddings.state_dict(&prefix_or(prefix, "embed_tokens")));
+        for (i, layer) in self.layers.iter().enumerate() {
+            sd.extend(layer.state_dict(&prefixed_index(prefix, "layers", i)));
+        }
+        sd.extend(self.norm.state_dict(&prefix_or(prefix, "norm")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.embeddings.load_state_dict(sd, &prefix_or(prefix, "embed_tokens"))?;
+        for (i, layer) in self.layers.iter_mut().enumerate() {
+            layer.load_state_dict(sd, &prefixed_index(prefix, "layers", i))?;
+        }
+        self.norm.load_state_dict(sd, &prefix_or(prefix, "norm"))?;
+        Ok(())
+    }
+}
+
+fn prefix_or(prefix: &str, suffix: &str) -> String {
+    if prefix.is_empty() { suffix.to_string() } else { format!("{prefix}.{suffix}") }
+}
+
+fn prefixed_index(prefix: &str, name: &str, i: usize) -> String {
+    if prefix.is_empty() { format!("{name}.{i}") } else { format!("{prefix}.{name}.{i}") }
+}

--- a/model/src/qwen3/reranker.rs
+++ b/model/src/qwen3/reranker.rs
@@ -1,0 +1,140 @@
+//! Qwen3 reranker: decoder backbone + tied LM head + last-token "Yes" logit score.
+//!
+//! `Qwen/Qwen3-Reranker-{0.6B,4B,8B}` are causal LMs fine-tuned for
+//! cross-encoder reranking. The relevance score is the logit at the **"Yes"
+//! token** (`yes_loc = 9454`) from the last non-pad position, optionally
+//! passed through sigmoid.
+//!
+//! Pipeline (matching FlagEmbedding `FlagLLMReranker`):
+//! 1. Qwen3 decoder forward → `(B, L, D)` hidden states
+//! 2. Tied LM head: `hidden @ embed_tokens.weight.T` → `(B, L, V)` logits
+//! 3. Last-token logit: `logits[:, L-1, :]` → `(B, V)` (requires left-padding)
+//! 4. Score: `logits[:, yes_loc]` → `(B,)`
+//! 5. Optional sigmoid → `(B,)` normalized scores
+//!
+//! The checkpoint (`model.safetensors`) uses `model.` prefix on backbone keys
+//! (standard `Qwen3ForCausalLM` convention). The loader strips this prefix.
+
+use std::path::Path;
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::{BoundVariable, Tensor, s};
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::Qwen3Config;
+use super::error::{HubSnafu, Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::model::Qwen3Model;
+
+/// Token ID for "Yes" in the Qwen tokenizer — the reranker's positive class.
+const YES_LOC: usize = 9454;
+
+#[derive(Clone)]
+pub struct Qwen3Reranker {
+    pub model: Qwen3Model,
+    /// Tied LM head weight — a clone of `embed_tokens.weight`.
+    pub lm_head_weight: Tensor,
+    pub yes_loc: usize,
+    pub normalize: bool,
+}
+
+impl Qwen3Reranker {
+    pub fn empty(config: Qwen3Config) -> Self {
+        let model = Qwen3Model::empty(config);
+        let hidden = model.config.hidden_size;
+        let vocab = model.config.vocab_size;
+        let dtype = model.config.dtype.clone();
+        let lm_head_weight = crate::init::fan_in_uniform(&[vocab, hidden], hidden, dtype);
+        Self { model, lm_head_weight, yes_loc: YES_LOC, normalize: true }
+    }
+
+    /// Eager forward: returns `(B,)` relevance scores.
+    pub fn forward(&self, input_ids: &Tensor, attention_mask: &Tensor) -> Result<Tensor> {
+        let hidden = self.model.forward(input_ids, Some(attention_mask))?;
+        self.score(&hidden)
+    }
+
+    /// JIT-path variant with rebindable batch. Returns `(B,)`.
+    pub fn forward_batch(&self, input_ids: &Tensor, attention_mask: &Tensor, b: &BoundVariable) -> Result<Tensor> {
+        let hidden = self.model.forward_batch(input_ids, Some(attention_mask), b)?;
+        self.score(&hidden)
+    }
+
+    fn score(&self, hidden: &Tensor) -> Result<Tensor> {
+        let shape = hidden.shape().context(TensorSnafu)?;
+        let l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "qwen3 reranker" })?;
+
+        // Last-token hidden state: (B, D) — slice BEFORE the LM head to avoid
+        // computing logits for all L positions when we only need one.
+        let last_hidden = hidden.getitem(s![.., (l - 1) as i64, ..]).context(TensorSnafu)?;
+
+        // LM head: (B, D) @ (D, V) → (B, V)
+        let logits = last_hidden.linear().weight(&self.lm_head_weight).call().context(TensorSnafu)?;
+
+        // Extract the "Yes" logit: (B,)
+        let scores = logits.getitem(s![.., self.yes_loc as i64]).context(TensorSnafu)?;
+
+        if self.normalize { scores.sigmoid().context(TensorSnafu) } else { Ok(scores) }
+    }
+
+    pub fn from_hub(model_id: &str, mut config: Qwen3Config) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut Qwen3Config) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = Qwen3Config::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let dir = crate::qwen3::download_safetensors(&repo)?;
+        Self::from_safetensors_dir(&dir, config.clone())
+    }
+
+    pub fn from_safetensors(path: &Path, config: Qwen3Config) -> Result<Self> {
+        let sd = state::load_safetensors(path).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Load from a directory containing `model.safetensors` or multi-shard files.
+    pub fn from_safetensors_dir(dir: &Path, config: Qwen3Config) -> Result<Self> {
+        let sd = state::load_safetensors_dir(dir).context(StateSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: Qwen3Config) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let stripped = strip_model_prefix(sd);
+        let mut model = Self::empty(config);
+        model.load_state_dict(&state::cast_all(&stripped, dtype), "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for Qwen3Reranker {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        self.model.state_dict(prefix)
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.model.load_state_dict(sd, prefix)?;
+        // Tie LM head to embed_tokens.weight.
+        let embed_key =
+            if prefix.is_empty() { "embed_tokens.weight".to_string() } else { format!("{prefix}.embed_tokens.weight") };
+        self.lm_head_weight =
+            sd.get(&embed_key).cloned().ok_or_else(|| state::Error::MissingKey { key: embed_key.clone() })?;
+        Ok(())
+    }
+}
+
+/// Strip the `model.` prefix from checkpoint keys (standard CausalLM convention).
+fn strip_model_prefix(sd: &StateDict) -> StateDict {
+    sd.iter()
+        .map(|(k, v)| {
+            let stripped = k.strip_prefix("model.").unwrap_or(k);
+            (stripped.to_string(), v.clone())
+        })
+        .collect()
+}

--- a/model/src/qwen3/rms_norm.rs
+++ b/model/src/qwen3/rms_norm.rs
@@ -1,0 +1,49 @@
+//! RMSNorm weights for Qwen3.
+//!
+//! Used in three roles:
+//! - Per-head Q/K norm (weight shape `[head_dim]`, applied to `(B, H, L, head_dim)`)
+//! - Layer norm before attention / MLP (weight shape `[hidden_size]`)
+//! - Final norm (weight shape `[hidden_size]`)
+//!
+//! `Tensor::rms_norm` upcasts to f32 internally and normalizes over all
+//! trailing axes from `axis` onward. With `axis = -1` only the last dim is
+//! the normalization axis, which is correct for all three roles.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::ones;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, TensorSnafu};
+
+#[derive(Clone)]
+pub struct RmsNormWeights {
+    pub weight: Tensor,
+    pub eps: f64,
+}
+
+impl RmsNormWeights {
+    pub fn empty(size: usize, eps: f64, dtype: DType) -> Self {
+        Self { weight: ones(&[size], dtype), eps }
+    }
+
+    pub fn apply(&self, x: &Tensor) -> Result<Tensor> {
+        let normed = x.rms_norm(-1, self.eps).context(TensorSnafu)?;
+        normed.try_mul(&self.weight).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for RmsNormWeights {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        Ok(())
+    }
+}

--- a/model/src/qwen3/rotary.rs
+++ b/model/src/qwen3/rotary.rs
@@ -1,0 +1,55 @@
+//! Rotary position embedding (RoPE) for Qwen3.
+//!
+//! GPT-NeoX-style (non-interleaved) rotation, matching transformers'
+//! `rotate_half`. `inv_freq`, `cos`, and `sin` are precomputed in **f32**
+//! and cast to the compute dtype for application.
+//!
+//! Single rotary base (`rope_theta = 1_000_000`) shared across all layers.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use super::error::{Result, TensorSnafu};
+
+/// Precomputed `(cos, sin)` table, shaped `(1, 1, seq_len, head_dim/2)` so it
+/// broadcasts against q/k of shape `(B, H, seq_len, head_dim)`.
+#[derive(Clone)]
+pub struct RotaryTable {
+    pub cos: Tensor,
+    pub sin: Tensor,
+}
+
+impl RotaryTable {
+    pub fn new(theta: f64, seq_len: usize, head_dim: usize, dtype: DType) -> Result<Self> {
+        let half = head_dim / 2;
+        let inv_freq: Vec<f32> = (0..half)
+            .map(|i| {
+                let exponent = -2.0 * i as f64 / head_dim as f64;
+                theta.powf(exponent) as f32
+            })
+            .collect();
+
+        let mut freqs = vec![0.0f32; seq_len * half];
+        for s in 0..seq_len {
+            for i in 0..half {
+                freqs[s * half + i] = s as f32 * inv_freq[i];
+            }
+        }
+
+        let cos_f32 =
+            Tensor::from_slice(freqs.clone()).try_reshape([seq_len as isize, half as isize]).context(TensorSnafu)?;
+        let sin_f32 = Tensor::from_slice(freqs).try_reshape([seq_len as isize, half as isize]).context(TensorSnafu)?;
+        let cos_f32 = cos_f32.cos().context(TensorSnafu)?;
+        let sin_f32 = sin_f32.sin().context(TensorSnafu)?;
+
+        let cos = cos_f32.try_unsqueeze(0).context(TensorSnafu)?.try_unsqueeze(0).context(TensorSnafu)?;
+        let sin = sin_f32.try_unsqueeze(0).context(TensorSnafu)?.try_unsqueeze(0).context(TensorSnafu)?;
+
+        Ok(Self { cos: cos.cast(dtype.clone()).context(TensorSnafu)?, sin: sin.cast(dtype).context(TensorSnafu)? })
+    }
+
+    pub fn apply(&self, x: &Tensor) -> Result<Tensor> {
+        x.apply_rotary_emb(&self.cos, &self.sin, false).context(TensorSnafu)
+    }
+}

--- a/model/src/state.rs
+++ b/model/src/state.rs
@@ -40,6 +40,48 @@ pub fn load_safetensors(path: &Path) -> Result<StateDict> {
     Ok(sd)
 }
 
+/// Load safetensors weights from a HuggingFace checkpoint directory.
+///
+/// Handles both single-file (`model.safetensors`) and multi-shard
+/// (`model-00001-of-0000N.safetensors` + `model.safetensors.index.json`)
+/// checkpoints. For single-file, loads `model.safetensors` directly. For
+/// multi-shard, parses the index JSON to find all shard files, loads each,
+/// and merges into one [`StateDict`].
+pub fn load_safetensors_dir(dir: &Path) -> Result<StateDict> {
+    let single = dir.join("model.safetensors");
+    if single.exists() {
+        return load_safetensors(&single);
+    }
+
+    let index_path = dir.join("model.safetensors.index.json");
+    let index_data = std::fs::read_to_string(&index_path).context(IoSnafu)?;
+    let index: SafetensorsIndex =
+        serde_json::from_str(&index_data).map_err(|e| Error::Io { source: std::io::Error::other(e.to_string()) })?;
+
+    let mut sd = StateDict::new();
+    for shard_file in index.unique_shards() {
+        let shard_path = dir.join(&shard_file);
+        let shard_sd = load_safetensors(&shard_path)?;
+        sd.extend(shard_sd);
+    }
+    Ok(sd)
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct SafetensorsIndex {
+    #[serde(rename = "weight_map")]
+    weight_map: HashMap<String, String>,
+}
+
+impl SafetensorsIndex {
+    pub(crate) fn unique_shards(&self) -> Vec<String> {
+        let mut shards: Vec<String> = self.weight_map.values().cloned().collect();
+        shards.sort();
+        shards.dedup();
+        shards
+    }
+}
+
 fn convert_dtype(dt: safetensors::Dtype) -> Result<DType> {
     use safetensors::Dtype as ST;
     match dt {

--- a/model/src/test/unit/bgem3/bge_m3.rs
+++ b/model/src/test/unit/bgem3/bge_m3.rs
@@ -1,0 +1,71 @@
+use crate::bgem3::{BgeM3, BgeRerankerV2M3, EncodeOpts};
+use crate::state::HasStateDict;
+use crate::xlm_roberta::XlmRobertaConfig;
+use svod_dtype::DType;
+
+fn tiny_cfg() -> XlmRobertaConfig {
+    XlmRobertaConfig {
+        vocab_size: 100,
+        hidden_size: 32,
+        num_hidden_layers: 2,
+        num_attention_heads: 4,
+        intermediate_size: 64,
+        max_position_embeddings: 20,
+        type_vocab_size: 1,
+        layer_norm_eps: 1e-5,
+        pad_token_id: 1,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}
+
+#[test]
+fn bgem3_encode_dense_shape() {
+    let model = BgeM3::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2]).try_reshape([1isize, 4]).unwrap();
+    let mask = svod_tensor::Tensor::from_slice([1i64, 1, 1, 1]).try_reshape([1isize, 4]).unwrap();
+    let mut dense = model.encode_dense(&ids, &mask).unwrap();
+    dense.realize().unwrap();
+    let s = dense.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 32);
+}
+
+#[test]
+fn bgem3_encode_all_modalities() {
+    let model = BgeM3::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2]).try_reshape([1isize, 4]).unwrap();
+    let mask = svod_tensor::Tensor::from_slice([1i64, 1, 1, 1]).try_reshape([1isize, 4]).unwrap();
+    let out = model.encode(&ids, &mask, EncodeOpts::all()).unwrap();
+    assert!(out.dense_vecs.is_some());
+    assert!(out.sparse_vecs.is_some());
+    assert!(out.colbert_vecs.is_some());
+}
+
+#[test]
+fn reranker_forward_shape() {
+    let model = BgeRerankerV2M3::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2, 1]).try_reshape([1isize, 5]).unwrap();
+    let mask = svod_tensor::Tensor::from_slice([1i64, 1, 1, 1, 0]).try_reshape([1isize, 5]).unwrap();
+    let mut out = model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 1);
+}
+
+#[test]
+fn reranker_state_dict_round_trip() {
+    let model = BgeRerankerV2M3::empty(tiny_cfg());
+    let sd = model.state_dict("");
+    assert!(sd.contains_key("classifier.dense.weight"));
+    assert!(sd.contains_key("classifier.out_proj.weight"));
+    assert!(sd.contains_key("embeddings.word_embeddings.weight"));
+    let mut model2 = BgeRerankerV2M3::empty(tiny_cfg());
+    model2.load_state_dict(&sd, "").unwrap();
+    let mut k1: Vec<String> = sd.keys().cloned().collect();
+    let mut k2: Vec<String> = model2.state_dict("").keys().cloned().collect();
+    k1.sort();
+    k2.sort();
+    assert_eq!(k1, k2);
+}

--- a/model/src/test/unit/bgem3/heads.rs
+++ b/model/src/test/unit/bgem3/heads.rs
@@ -1,0 +1,42 @@
+use crate::bgem3::{ColbertHead, SparseHead};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+#[test]
+fn sparse_head_forward_shape() {
+    let head = SparseHead::empty(32, 100, DType::Float32);
+    let hidden = Tensor::zeros(&[2, 5, 32], DType::Float32).unwrap();
+    let ids = Tensor::from_slice([0i64, 10, 20, 2, 1, 0, 10, 20, 2, 1]).try_reshape([2, 5]).unwrap();
+    let mut out = head.forward(&hidden, &ids).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 2);
+    assert_eq!(s[1].as_const().unwrap(), 100);
+}
+
+#[test]
+fn sparse_head_zeros_special_tokens() {
+    let head = SparseHead::empty(32, 100, DType::Float32);
+    let hidden = Tensor::ones(&[1, 3, 32], DType::Float32).unwrap();
+    let ids = Tensor::from_slice([0i64, 50, 2]).try_reshape([1, 3]).unwrap();
+    let mut out = head.forward(&hidden, &ids).unwrap();
+    out.realize().unwrap();
+    let vals = out.as_vec::<f32>().unwrap();
+    assert_eq!(vals[0], 0.0); // CLS
+    assert_eq!(vals[1], 0.0); // PAD
+    assert_eq!(vals[2], 0.0); // EOS
+    assert_eq!(vals[3], 0.0); // UNK
+}
+
+#[test]
+fn colbert_head_forward_shape() {
+    let head = ColbertHead::empty(32, 32, DType::Float32);
+    let hidden = Tensor::zeros(&[2, 6, 32], DType::Float32).unwrap();
+    let mask = Tensor::from_slice([1i64, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0]).try_reshape([2, 6]).unwrap();
+    let mut out = head.forward(&hidden, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 2);
+    assert_eq!(s[1].as_const().unwrap(), 5);
+    assert_eq!(s[2].as_const().unwrap(), 32);
+}

--- a/model/src/test/unit/bgem3/mod.rs
+++ b/model/src/test/unit/bgem3/mod.rs
@@ -1,0 +1,4 @@
+mod bge_m3;
+mod heads;
+mod parity;
+mod scoring;

--- a/model/src/test/unit/bgem3/parity.rs
+++ b/model/src/test/unit/bgem3/parity.rs
@@ -1,0 +1,173 @@
+//! Parity tests comparing Rust model outputs against PyTorch/HuggingFace golden
+//! reference outputs.
+//!
+//! Run with:
+//!   SVOD_BGEM3=$PWD/data/bgem3 cargo test -p svod-model --lib bgem3::parity -- --ignored
+
+use crate::bgem3::{BgeM3, BgeRerankerV2M3, EncodeOpts};
+use crate::state::{self, StateDict};
+use crate::xlm_roberta::XlmRobertaConfig;
+use std::path::PathBuf;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+const HUB_REPO: &str = "BAAI/bge-m3";
+const RERANKER_HUB: &str = "BAAI/bge-reranker-v2-m3";
+
+fn real_file(name: &str) -> PathBuf {
+    resolve_file(name, HUB_REPO)
+}
+
+fn real_file_reranker(name: &str) -> PathBuf {
+    resolve_file(name, RERANKER_HUB)
+}
+
+fn resolve_file(name: &str, hub_repo: &str) -> PathBuf {
+    if let Ok(dir) = std::env::var("SVOD_BGEM3") {
+        let p = PathBuf::from(dir).join(name);
+        if p.exists() {
+            return p;
+        }
+    }
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../data/bgem3").join(name);
+    if p.exists() {
+        return p;
+    }
+    let api = hf_hub::api::sync::Api::new().expect("HF Hub API");
+    let repo = hf_hub::Repo::with_revision(hub_repo.into(), hf_hub::RepoType::Model, "main".into());
+    api.repo(repo).get(name).unwrap_or_else(|_| panic!("download {name} from {hub_repo}"))
+}
+
+fn load_fixture() -> (BgeM3, StateDict) {
+    let golden = state::load_safetensors(&real_file("golden.safetensors")).expect("golden");
+    let mut cfg = XlmRobertaConfig::from_json(&real_file("config.json")).expect("config");
+    cfg.dtype = DType::Float32;
+    let dtype = cfg.dtype.clone();
+    let backbone = crate::xlm_roberta::XlmRobertaModel::from_pytorch_bin(&real_file("pytorch_model.bin"), cfg).unwrap();
+    let sparse = real_file("sparse_linear.pt");
+    let sparse = if sparse.exists() {
+        Some(crate::bgem3::SparseHead::from_pytorch_bin(&sparse, backbone.config.vocab_size, dtype.clone()).unwrap())
+    } else {
+        None
+    };
+    let colbert = real_file("colbert_linear.pt");
+    let colbert = if colbert.exists() {
+        Some(crate::bgem3::ColbertHead::from_pytorch_bin(&colbert, backbone.config.hidden_size, dtype).unwrap())
+    } else {
+        None
+    };
+    (BgeM3 { model: backbone, sparse_head: sparse, colbert_head: colbert, normalize_dense: true }, golden)
+}
+
+fn load_golden_vec<T: Clone + Default + svod_dtype::ext::HasDType>(sd: &StateDict, key: &str) -> Vec<T> {
+    let mut t = sd.get(key).unwrap_or_else(|| panic!("missing golden key: {key}")).clone();
+    t.realize().unwrap();
+    t.as_vec::<T>().unwrap()
+}
+
+fn max_abs_delta(got: &[f32], want: &[f32]) -> f32 {
+    assert_eq!(got.len(), want.len());
+    got.iter().zip(want.iter()).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max)
+}
+
+fn prep_inputs(golden: &StateDict) -> (Tensor, Tensor) {
+    let ids = load_golden_vec::<i64>(golden, "input_ids");
+    let shape = load_golden_vec::<i64>(golden, "input_ids_shape");
+    let (b, t) = (shape[0] as usize, shape[1] as usize);
+    let mask = load_golden_vec::<i64>(golden, "attention_mask");
+    let input_ids = Tensor::from_slice(&ids).try_reshape([b as isize, t as isize]).unwrap();
+    let mask = Tensor::from_slice(&mask).try_reshape([b as isize, t as isize]).unwrap();
+    (input_ids, mask)
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn last_hidden_state_matches_pytorch() {
+    let (model, golden) = load_fixture();
+    let (ids, mask) = prep_inputs(&golden);
+    let mut out = model.model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let delta = max_abs_delta(&out.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "last_hidden_state"));
+    assert!(delta < 1e-3, "last_hidden_state max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn dense_vecs_match_pytorch() {
+    let (model, golden) = load_fixture();
+    let (ids, mask) = prep_inputs(&golden);
+    let mut dense = model.encode_dense(&ids, &mask).unwrap();
+    dense.realize().unwrap();
+    let delta = max_abs_delta(&dense.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "dense_vecs"));
+    assert!(delta < 1e-3, "dense_vecs max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn sparse_vecs_match_pytorch() {
+    let (model, golden) = load_fixture();
+    if model.sparse_head.is_none() {
+        eprintln!("skipping: no sparse_linear.pt");
+        return;
+    }
+    let (ids, mask) = prep_inputs(&golden);
+    let out = model
+        .encode(&ids, &mask, EncodeOpts { return_dense: false, return_sparse: true, return_colbert: false })
+        .unwrap();
+    let mut sparse = out.sparse_vecs.unwrap();
+    sparse.realize().unwrap();
+    let delta = max_abs_delta(&sparse.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "sparse_vecs"));
+    assert!(delta < 1e-3, "sparse_vecs max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn colbert_vecs_match_pytorch() {
+    let (model, golden) = load_fixture();
+    if model.colbert_head.is_none() {
+        eprintln!("skipping: no colbert_linear.pt");
+        return;
+    }
+    let (ids, mask) = prep_inputs(&golden);
+    let out = model
+        .encode(&ids, &mask, EncodeOpts { return_dense: false, return_sparse: false, return_colbert: true })
+        .unwrap();
+    let mut colbert = out.colbert_vecs.unwrap();
+    colbert.realize().unwrap();
+    let delta = max_abs_delta(&colbert.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "colbert_vecs"));
+    assert!(delta < 1e-2, "colbert_vecs max |delta| = {delta:.6}");
+}
+
+#[test]
+#[ignore = "heavy: real BGE-M3 weights + PyTorch golden"]
+fn ignoring_padding_diverges_from_golden() {
+    let (model, golden) = load_fixture();
+    let (ids, _) = prep_inputs(&golden);
+    let t = load_golden_vec::<i64>(&golden, "input_ids_shape")[1] as usize;
+    let mask = Tensor::from_slice(vec![1i64; t]).try_reshape([1isize, t as isize]).unwrap();
+    let mut out = model.model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let delta = max_abs_delta(&out.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "last_hidden_state"));
+    assert!(delta > 1e-2, "all-ones mask did NOT diverge (delta={delta:.6})");
+}
+
+// --- Reranker ---
+
+fn load_reranker_fixture() -> (BgeRerankerV2M3, StateDict) {
+    let golden = state::load_safetensors(&real_file("golden_reranker.safetensors")).expect("golden");
+    let mut cfg = XlmRobertaConfig::from_json(&real_file_reranker("config.json")).expect("config");
+    cfg.dtype = DType::Float32;
+    let model = BgeRerankerV2M3::from_safetensors(&real_file_reranker("model.safetensors"), cfg).unwrap();
+    (model, golden)
+}
+
+#[test]
+#[ignore = "heavy: real BGE-reranker-v2-m3 weights + PyTorch golden"]
+fn reranker_logits_match_pytorch() {
+    let (model, golden) = load_reranker_fixture();
+    let (ids, mask) = prep_inputs(&golden);
+    let mut out = model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let delta = max_abs_delta(&out.as_vec::<f32>().unwrap(), &load_golden_vec(&golden, "logits"));
+    assert!(delta < 1e-3, "reranker logits max |delta| = {delta:.6}");
+}

--- a/model/src/test/unit/bgem3/scoring.rs
+++ b/model/src/test/unit/bgem3/scoring.rs
@@ -1,0 +1,29 @@
+use crate::bgem3::{colbert_score, dense_score, sparse_score};
+use svod_tensor::Tensor;
+
+#[test]
+fn dense_score_identity() {
+    let q = Tensor::from_slice([1.0f32, 0.0, 0.0]).try_reshape([1, 3]).unwrap();
+    let p = Tensor::from_slice([1.0f32, 0.0, 0.0]).try_reshape([1, 3]).unwrap();
+    let mut s = dense_score(&q, &p).unwrap();
+    s.realize().unwrap();
+    assert!((s.as_vec::<f32>().unwrap()[0] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn sparse_score_basic() {
+    let q = Tensor::from_slice([0.0f32, 2.0, 0.0, 3.0]).try_reshape([1, 4]).unwrap();
+    let p = Tensor::from_slice([0.0f32, 1.0, 0.0, 1.0]).try_reshape([1, 4]).unwrap();
+    let mut s = sparse_score(&q, &p).unwrap();
+    s.realize().unwrap();
+    assert!((s.as_vec::<f32>().unwrap()[0] - 5.0).abs() < 1e-6);
+}
+
+#[test]
+fn colbert_score_basic() {
+    let q = Tensor::from_slice([1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0]).try_reshape([2, 3]).unwrap();
+    let p = Tensor::from_slice([1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]).try_reshape([3, 3]).unwrap();
+    let mut s = colbert_score(&q, &p).unwrap();
+    s.realize().unwrap();
+    assert!((s.as_vec::<f32>().unwrap()[0] - 1.0).abs() < 1e-5);
+}

--- a/model/src/test/unit/mod.rs
+++ b/model/src/test/unit/mod.rs
@@ -1,5 +1,6 @@
 mod audio;
 mod batch;
+mod bgem3;
 mod bounds;
 mod config;
 mod diarizen;
@@ -17,3 +18,4 @@ mod state_dict;
 mod transcribe;
 mod wavlm;
 mod wespeaker;
+mod xlm_roberta;

--- a/model/src/test/unit/mod.rs
+++ b/model/src/test/unit/mod.rs
@@ -10,6 +10,7 @@ mod jit;
 mod jit_recurrent;
 mod mel;
 mod modernbert;
+mod qwen3;
 mod remap;
 mod resnet;
 mod silero_vad;

--- a/model/src/test/unit/modernbert/attention.rs
+++ b/model/src/test/unit/modernbert/attention.rs
@@ -1,10 +1,20 @@
-use crate::modernbert::{EncoderLayer, ModernBertAttention, modernbert_base};
+use crate::modernbert::{EncoderLayer, ModernBertAttention, ModernBertConfig};
+
+fn test_cfg() -> ModernBertConfig {
+    ModernBertConfig {
+        hidden_size: 768,
+        num_attention_heads: 12,
+        local_attention: 128,
+        global_attn_every_n_layers: 3,
+        ..ModernBertConfig::default()
+    }
+}
 
 /// Global layers carry `window = None`; local layers carry the configured
 /// sliding window. This is the structural contract the encoder relies on.
 #[test]
 fn window_set_per_layer_kind() {
-    let cfg = modernbert_base();
+    let cfg = test_cfg();
     // Layer 0, 3 are global (id % 3 == 0) → no window.
     let l0 = EncoderLayer::empty(&cfg, 0);
     assert!(l0.attention.window.is_none(), "layer 0 (global) must not have a window");
@@ -20,7 +30,7 @@ fn window_set_per_layer_kind() {
 /// The fused QKV weight has shape `(3*hidden, hidden)`; output proj `(hidden, hidden)`.
 #[test]
 fn attention_weight_shapes() {
-    let cfg = modernbert_base();
+    let cfg = test_cfg();
     let attn = ModernBertAttention::empty(cfg.hidden_size, cfg.num_attention_heads, cfg.head_dim(), None, cfg.dtype);
     let qkv = attn.qkv_weight.shape().unwrap();
     let out = attn.out_weight.shape().unwrap();

--- a/model/src/test/unit/modernbert/config.rs
+++ b/model/src/test/unit/modernbert/config.rs
@@ -1,39 +1,26 @@
-use crate::modernbert::{ModernBertConfig, modernbert_base, modernbert_large};
+use crate::modernbert::ModernBertConfig;
 
-#[test]
-fn base_dims() {
-    let c = modernbert_base();
-    assert_eq!(c.hidden_size, 768);
-    assert_eq!(c.num_hidden_layers, 22);
-    assert_eq!(c.num_attention_heads, 12);
-    assert_eq!(c.head_dim(), 64);
-    assert_eq!(c.intermediate_size, 1152);
-    assert_eq!(c.vocab_size, 50368);
-    assert_eq!(c.local_attention, 128);
-    assert_eq!(c.global_attn_every_n_layers, 3);
-    assert_eq!(c.global_rope_theta, 160_000.0);
-    assert_eq!(c.local_rope_theta, 10_000.0);
-}
-
-#[test]
-fn large_dims() {
-    let c = modernbert_large();
-    assert_eq!(c.hidden_size, 1024);
-    assert_eq!(c.num_hidden_layers, 28);
-    assert_eq!(c.num_attention_heads, 16);
-    assert_eq!(c.head_dim(), 64);
-    assert_eq!(c.intermediate_size, 2624);
+fn test_cfg() -> ModernBertConfig {
+    ModernBertConfig {
+        hidden_size: 768,
+        num_attention_heads: 12,
+        local_attention: 128,
+        global_attn_every_n_layers: 3,
+        global_rope_theta: 160_000.0,
+        local_rope_theta: 10_000.0,
+        ..ModernBertConfig::default()
+    }
 }
 
 #[test]
 fn local_window_split_evenly() {
-    let c = modernbert_base();
+    let c = test_cfg();
     assert_eq!(c.local_window(), (64, 64));
 }
 
 #[test]
 fn global_layer_pattern() {
-    let c = modernbert_base();
+    let c = test_cfg();
     assert!(c.is_global_layer(0));
     assert!(c.is_global_layer(3));
     assert!(c.is_global_layer(21));
@@ -44,7 +31,7 @@ fn global_layer_pattern() {
 
 #[test]
 fn rope_theta_per_layer() {
-    let c = modernbert_base();
+    let c = test_cfg();
     assert_eq!(c.rope_theta(0), 160_000.0); // global
     assert_eq!(c.rope_theta(3), 160_000.0); // global
     assert_eq!(c.rope_theta(1), 10_000.0); // local
@@ -52,11 +39,10 @@ fn rope_theta_per_layer() {
     assert_eq!(c.rope_theta(20), 10_000.0); // local (20 % 3 == 2)
 }
 
-/// Round-trip a synthetic `config.json` (minimal fields) through
-/// `from_json_str` and confirm the parsed values land on the right fields,
-/// with absent fields falling back to base defaults.
+/// Round-trip a synthetic `config.json` through `from_json_str` and confirm
+/// the parsed values land on the right fields.
 #[test]
-fn parse_minimal_config_json() {
+fn parse_config_json() {
     let json = r#"{
         "model_type": "modernbert",
         "hidden_size": 1024,
@@ -65,13 +51,20 @@ fn parse_minimal_config_json() {
         "intermediate_size": 2624,
         "vocab_size": 50368,
         "global_rope_theta": 160000.0,
-        "local_rope_theta": 10000.0
+        "local_rope_theta": 10000.0,
+        "local_attention": 128,
+        "global_attn_every_n_layers": 3,
+        "layer_norm_eps": 1e-5,
+        "pad_token_id": 50283,
+        "tie_word_embeddings": true,
+        "decoder_bias": true
     }"#;
     let c = ModernBertConfig::from_json_str(json).expect("parse");
     assert_eq!(c.hidden_size, 1024);
     assert_eq!(c.num_hidden_layers, 28);
     assert_eq!(c.num_attention_heads, 16);
-    // Absent fields fall back to base defaults.
+    assert_eq!(c.intermediate_size, 2624);
+    assert_eq!(c.vocab_size, 50368);
     assert_eq!(c.local_attention, 128);
     assert_eq!(c.global_attn_every_n_layers, 3);
     assert_eq!(c.layer_norm_eps, 1e-5);

--- a/model/src/test/unit/qwen3/attention.rs
+++ b/model/src/test/unit/qwen3/attention.rs
@@ -1,0 +1,78 @@
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::qwen3::{Qwen3Attention, RotaryTable, qwen3_embedding_0_6b};
+
+fn tiny_attn() -> Qwen3Attention {
+    Qwen3Attention::empty(64, 4, 2, 32, 1e-5, DType::Float32)
+}
+
+#[test]
+fn gqa_projection_shapes() {
+    let attn = tiny_attn();
+    let q_shape = attn.q_proj_weight.shape().unwrap();
+    let k_shape = attn.k_proj_weight.shape().unwrap();
+    let v_shape = attn.v_proj_weight.shape().unwrap();
+    let o_shape = attn.o_proj_weight.shape().unwrap();
+
+    // q: (4*32, 64) = (128, 64), k/v: (2*32, 64) = (64, 64), o: (64, 128)
+    assert_eq!(q_shape[0].as_const().unwrap(), 128);
+    assert_eq!(q_shape[1].as_const().unwrap(), 64);
+    assert_eq!(k_shape[0].as_const().unwrap(), 64);
+    assert_eq!(v_shape[0].as_const().unwrap(), 64);
+    assert_eq!(o_shape[0].as_const().unwrap(), 64);
+    assert_eq!(o_shape[1].as_const().unwrap(), 128);
+}
+
+#[test]
+fn qk_norm_dims() {
+    let attn = tiny_attn();
+    let qn = attn.q_norm.weight.shape().unwrap();
+    let kn = attn.k_norm.weight.shape().unwrap();
+    assert_eq!(qn[0].as_const().unwrap(), 32);
+    assert_eq!(kn[0].as_const().unwrap(), 32);
+}
+
+#[test]
+fn forward_output_shape() {
+    let attn = tiny_attn();
+
+    let x = Tensor::from_slice([0.5f32; 512]).try_reshape([1isize, 8, 64]).unwrap();
+    let rotary = RotaryTable::new(10000.0, 8, 32, DType::Float32).unwrap();
+
+    let out = attn.forward(&x, &rotary, None).unwrap();
+    let mut out = out;
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 8);
+    assert_eq!(s[2].as_const().unwrap(), 64);
+
+    let v = out.as_vec::<f32>().unwrap();
+    assert!(v.iter().all(|x| x.is_finite()));
+}
+
+#[test]
+fn published_weight_shapes() {
+    let cfg = qwen3_embedding_0_6b();
+    let attn = Qwen3Attention::empty(
+        cfg.hidden_size,
+        cfg.num_attention_heads,
+        cfg.num_key_value_heads,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
+        DType::BFloat16,
+    );
+    let q = attn.q_proj_weight.shape().unwrap();
+    let k = attn.k_proj_weight.shape().unwrap();
+    let o = attn.o_proj_weight.shape().unwrap();
+    // q: (16*128, 1024) = (2048, 1024)
+    assert_eq!(q[0].as_const().unwrap(), 2048);
+    assert_eq!(q[1].as_const().unwrap(), 1024);
+    // k: (8*128, 1024) = (1024, 1024)
+    assert_eq!(k[0].as_const().unwrap(), 1024);
+    assert_eq!(k[1].as_const().unwrap(), 1024);
+    // o: (1024, 2048)
+    assert_eq!(o[0].as_const().unwrap(), 1024);
+    assert_eq!(o[1].as_const().unwrap(), 2048);
+}

--- a/model/src/test/unit/qwen3/config.rs
+++ b/model/src/test/unit/qwen3/config.rs
@@ -1,0 +1,73 @@
+use svod_dtype::DType;
+
+use crate::qwen3::{Qwen3Config, qwen3_embedding_0_6b};
+
+#[test]
+fn predefined_config_dims() {
+    let cfg = qwen3_embedding_0_6b();
+    assert_eq!(cfg.vocab_size, 151_669);
+    assert_eq!(cfg.hidden_size, 1024);
+    assert_eq!(cfg.num_hidden_layers, 28);
+    assert_eq!(cfg.num_attention_heads, 16);
+    assert_eq!(cfg.num_key_value_heads, 8);
+    assert_eq!(cfg.head_dim, 128);
+    assert_eq!(cfg.intermediate_size, 3072);
+    assert_eq!(cfg.rope_theta, 1_000_000.0);
+    assert_eq!(cfg.rms_norm_eps, 1e-6);
+    assert!(!cfg.attention_bias);
+    assert!(cfg.tie_word_embeddings);
+}
+
+#[test]
+fn head_dim_not_derived() {
+    let cfg = qwen3_embedding_0_6b();
+    assert_ne!(cfg.head_dim, cfg.hidden_size / cfg.num_attention_heads);
+    assert_eq!(cfg.num_attention_heads * cfg.head_dim, 2048);
+}
+
+#[test]
+fn gqa_ratio() {
+    let cfg = qwen3_embedding_0_6b();
+    assert_eq!(cfg.num_kv_groups(), 2);
+}
+
+#[test]
+fn json_parse() {
+    let json = r#"{
+        "model_type": "qwen3",
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "intermediate_size": 128,
+        "max_position_embeddings": 512,
+        "rms_norm_eps": 1e-5,
+        "rope_theta": 10000.0,
+        "attention_bias": false,
+        "tie_word_embeddings": true,
+        "pad_token_id": 0
+    }"#;
+    let cfg = Qwen3Config::from_json_str(json).unwrap();
+    assert_eq!(cfg.vocab_size, 100);
+    assert_eq!(cfg.hidden_size, 64);
+    assert_eq!(cfg.head_dim, 32);
+    assert_eq!(cfg.num_key_value_heads, 2);
+    assert_eq!(cfg.rope_theta, 10000.0);
+}
+
+#[test]
+fn merge_preserves_dtype_and_batch() {
+    let mut cfg = qwen3_embedding_0_6b();
+    cfg.dtype = DType::Float32;
+    cfg.max_batch_size = 8;
+
+    let mut parsed = qwen3_embedding_0_6b();
+    parsed.vocab_size = 999;
+    cfg.merge_structural_from(&parsed);
+
+    assert_eq!(cfg.vocab_size, 999);
+    assert_eq!(cfg.dtype, DType::Float32);
+    assert_eq!(cfg.max_batch_size, 8);
+}

--- a/model/src/test/unit/qwen3/mod.rs
+++ b/model/src/test/unit/qwen3/mod.rs
@@ -1,0 +1,5 @@
+mod attention;
+mod config;
+mod model;
+mod parity;
+mod reranker;

--- a/model/src/test/unit/qwen3/model.rs
+++ b/model/src/test/unit/qwen3/model.rs
@@ -1,0 +1,112 @@
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::qwen3::{Qwen3Config, Qwen3Embedding, Qwen3Model};
+use crate::state::HasStateDict;
+
+fn tiny_cfg() -> Qwen3Config {
+    Qwen3Config {
+        vocab_size: 100,
+        hidden_size: 64,
+        num_hidden_layers: 2,
+        num_attention_heads: 4,
+        num_key_value_heads: 2,
+        head_dim: 32,
+        intermediate_size: 128,
+        max_position_embeddings: 64,
+        rms_norm_eps: 1e-5,
+        rope_theta: 10000.0,
+        attention_bias: false,
+        tie_word_embeddings: true,
+        pad_token_id: 0,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}
+
+#[test]
+fn forward_output_shape() {
+    let model = Qwen3Model::empty(tiny_cfg());
+    let ids = Tensor::from_slice([0i64, 1, 2, 3, 4, 5, 6, 7]).try_reshape([1isize, 8]).unwrap();
+
+    let mut out = model.forward(&ids, None).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 8);
+    assert_eq!(s[2].as_const().unwrap(), 64);
+
+    let v = out.as_vec::<f32>().unwrap();
+    assert!(v.iter().all(|x| x.is_finite()));
+}
+
+#[test]
+fn embedding_output_shape() {
+    let emb = Qwen3Embedding::empty(tiny_cfg());
+    let ids = Tensor::from_slice([0i64, 1, 2, 3, 4, 5, 6, 7]).try_reshape([1isize, 8]).unwrap();
+    let mask = Tensor::from_slice([1i64, 1, 1, 1, 1, 1, 1, 1]).try_reshape([1isize, 8]).unwrap();
+
+    let mut out = emb.encode(&ids, &mask).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    assert_eq!(s[0].as_const().unwrap(), 1);
+    assert_eq!(s[1].as_const().unwrap(), 64);
+
+    let v = out.as_vec::<f32>().unwrap();
+    assert!(v.iter().all(|x| x.is_finite()));
+}
+
+#[test]
+fn state_dict_round_trip() {
+    let model = Qwen3Model::empty(tiny_cfg());
+    let sd = model.state_dict("");
+
+    assert!(sd.contains_key("embed_tokens.weight"));
+    assert!(sd.contains_key("norm.weight"));
+    assert!(sd.contains_key("layers.0.input_layernorm.weight"));
+    assert!(sd.contains_key("layers.0.self_attn.q_proj.weight"));
+    assert!(sd.contains_key("layers.0.self_attn.q_norm.weight"));
+    assert!(sd.contains_key("layers.0.mlp.gate_proj.weight"));
+
+    let mut model2 = Qwen3Model::empty(tiny_cfg());
+    model2.load_state_dict(&sd, "").unwrap();
+
+    let mut k1: Vec<String> = sd.keys().cloned().collect();
+    let mut k2: Vec<String> = model2.state_dict("").keys().cloned().collect();
+    k1.sort();
+    k2.sort();
+    assert_eq!(k1, k2);
+}
+
+#[test]
+fn key_count_matches_checkpoint_layout() {
+    let cfg = qwen3_0_6b_structural();
+    let model = Qwen3Model::empty(cfg);
+    let sd = model.state_dict("");
+    // 1 embed + 28 layers × 13 + 1 norm = 366
+    // 13 per layer: input_layernorm, q/k/v/o_proj, q/k_norm, post_attention_layernorm,
+    //               gate/up/down_proj = 3+2+2+1+3 = 11... wait: input_ln(1) + q(1)+k(1)+v(1)+o(1) + qn(1)+kn(1) + post_ln(1) + gate(1)+up(1)+down(1) = 11
+    // 1 + 28*11 + 1 = 310
+    let expected = 1 + 28 * 11 + 1;
+    assert_eq!(sd.len(), expected, "expected {expected} keys, got {}", sd.len());
+}
+
+fn qwen3_0_6b_structural() -> Qwen3Config {
+    Qwen3Config {
+        vocab_size: 151_669,
+        hidden_size: 1024,
+        num_hidden_layers: 28,
+        num_attention_heads: 16,
+        num_key_value_heads: 8,
+        head_dim: 128,
+        intermediate_size: 3072,
+        max_position_embeddings: 32_768,
+        rms_norm_eps: 1e-6,
+        rope_theta: 1_000_000.0,
+        attention_bias: false,
+        tie_word_embeddings: true,
+        pad_token_id: 151_643,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}

--- a/model/src/test/unit/qwen3/parity.rs
+++ b/model/src/test/unit/qwen3/parity.rs
@@ -1,0 +1,230 @@
+//! Golden parity tests against real `Qwen/Qwen3-Embedding-0.6B` weights.
+//!
+//! Run with:
+//! ```text
+//! SVOD_QWEN3=$PWD/data/qwen3 cargo test -p svod-model --lib qwen3::parity -- --ignored
+//! ```
+
+use std::path::PathBuf;
+
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::qwen3::{Qwen3Config, Qwen3Embedding, Qwen3Model, Qwen3Reranker};
+use crate::state;
+
+const HUB_REPO: &str = "Qwen/Qwen3-Embedding-0.6B";
+const RERANKER_HUB_REPO: &str = "Qwen/Qwen3-Reranker-0.6B";
+
+fn resolve_file(name: &str) -> PathBuf {
+    if let Ok(dir) = std::env::var("SVOD_QWEN3") {
+        let p = PathBuf::from(dir).join(name);
+        if p.exists() {
+            return p;
+        }
+    }
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../data/qwen3").join(name);
+    if p.exists() {
+        return p;
+    }
+    let api = hf_hub::api::sync::Api::new().expect("HF Hub API");
+    let repo = hf_hub::Repo::with_revision(HUB_REPO.into(), hf_hub::RepoType::Model, "main".into());
+    api.repo(repo).get(name).unwrap_or_else(|_| panic!("download {name} from {HUB_REPO}"))
+}
+
+fn load_cfg() -> Qwen3Config {
+    let cfg_path = resolve_file("config.json");
+    let mut cfg = Qwen3Config::from_json(&cfg_path).expect("config");
+    cfg.dtype = DType::Float32;
+    cfg
+}
+
+fn load_model() -> Qwen3Model {
+    let cfg = load_cfg();
+    let weights_path = resolve_file("model.safetensors");
+    Qwen3Model::from_safetensors(&weights_path, cfg).expect("load model")
+}
+
+fn load_golden_vec(key: &str) -> Vec<f32> {
+    let golden_path = resolve_file("golden.safetensors");
+    let sd = state::load_safetensors(&golden_path).expect("load golden");
+    let mut t = sd.get(key).unwrap_or_else(|| panic!("missing golden key: {key}")).clone();
+    t.realize().unwrap();
+    t.as_vec::<f32>().unwrap()
+}
+
+fn load_golden_i64(key: &str) -> Vec<i64> {
+    let golden_path = resolve_file("golden.safetensors");
+    let sd = state::load_safetensors(&golden_path).expect("load golden");
+    let mut t = sd.get(key).unwrap_or_else(|| panic!("missing golden key: {key}")).clone();
+    t.realize().unwrap();
+    t.as_vec::<i64>().unwrap()
+}
+
+fn max_abs_delta(got: &[f32], want: &[f32]) -> f32 {
+    got.iter().zip(want).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max)
+}
+
+fn real_token_max_delta(got: &[f32], want: &[f32], mask: &[i64], batch: usize, seq_len: usize, hidden: usize) -> f32 {
+    let mut worst = 0.0f32;
+    for b in 0..batch {
+        for s in 0..seq_len {
+            if mask[b * seq_len + s] == 0 {
+                continue;
+            }
+            let off = (b * seq_len + s) * hidden;
+            for d in 0..hidden {
+                worst = worst.max((got[off + d] - want[off + d]).abs());
+            }
+        }
+    }
+    worst
+}
+
+#[test]
+#[ignore = "heavy: real Qwen3-Embedding-0.6B weights + PyTorch golden"]
+fn last_hidden_state_matches_pytorch() {
+    let model = load_model();
+
+    let shape_vec = load_golden_i64("input_ids_shape");
+    let batch = shape_vec[0] as usize;
+    let seq_len = shape_vec[1] as usize;
+
+    let ids_vec = load_golden_i64("input_ids");
+    let mask_vec = load_golden_i64("attention_mask");
+
+    let ids = Tensor::from_slice(&ids_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+    let mask = Tensor::from_slice(&mask_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+
+    let mut out = model.forward(&ids, Some(&mask)).unwrap();
+    out.realize().unwrap();
+    let got = out.as_vec::<f32>().unwrap();
+
+    let want = load_golden_vec("last_hidden_state");
+    assert_eq!(got.len(), want.len());
+
+    let mask_vec = load_golden_i64("attention_mask");
+    let delta = real_token_max_delta(&got, &want, &mask_vec, batch, seq_len, 1024);
+    assert!(delta < 1e-3, "real-token max_abs_delta = {delta:.6} (threshold 1e-3)");
+}
+
+#[test]
+#[ignore = "heavy: real Qwen3-Embedding-0.6B weights + PyTorch golden"]
+fn embeddings_match_pytorch() {
+    let model = load_model();
+    let emb = Qwen3Embedding { model, normalize: true };
+
+    let shape_vec = load_golden_i64("input_ids_shape");
+    let batch = shape_vec[0] as usize;
+    let seq_len = shape_vec[1] as usize;
+
+    let ids_vec = load_golden_i64("input_ids");
+    let mask_vec = load_golden_i64("attention_mask");
+
+    let ids = Tensor::from_slice(&ids_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+    let mask = Tensor::from_slice(&mask_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+
+    let mut out = emb.encode(&ids, &mask).unwrap();
+    out.realize().unwrap();
+    let got = out.as_vec::<f32>().unwrap();
+
+    let want = load_golden_vec("embeddings");
+    assert_eq!(got.len(), want.len());
+    let delta = max_abs_delta(&got, &want);
+    assert!(delta < 1e-3, "max_abs_delta = {delta:.6} (threshold 1e-3)");
+}
+
+#[test]
+#[ignore = "heavy: negative control — all-ones mask must diverge"]
+fn ignoring_padding_diverges_from_golden() {
+    let model = load_model();
+
+    let shape_vec = load_golden_i64("input_ids_shape");
+    let batch = shape_vec[0] as usize;
+    let seq_len = shape_vec[1] as usize;
+
+    let ids_vec = load_golden_i64("input_ids");
+    let ids = Tensor::from_slice(&ids_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+
+    let ones_mask =
+        Tensor::from_slice(vec![1i64; batch * seq_len]).try_reshape([batch as isize, seq_len as isize]).unwrap();
+
+    let mut out = model.forward(&ids, Some(&ones_mask)).unwrap();
+    out.realize().unwrap();
+    let got = out.as_vec::<f32>().unwrap();
+
+    let want = load_golden_vec("last_hidden_state");
+    let delta = max_abs_delta(&got, &want);
+    assert!(delta > 1e-2, "all-ones mask did NOT diverge (delta={delta:.6})");
+}
+
+// --- Reranker parity ---
+
+fn resolve_reranker_file(name: &str) -> PathBuf {
+    if let Ok(dir) = std::env::var("SVOD_QWEN3") {
+        let p = PathBuf::from(dir).join(name);
+        if p.exists() {
+            return p;
+        }
+    }
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../data/qwen3").join(name);
+    if p.exists() {
+        return p;
+    }
+    let api = hf_hub::api::sync::Api::new().expect("HF Hub API");
+    let repo = hf_hub::Repo::with_revision(RERANKER_HUB_REPO.into(), hf_hub::RepoType::Model, "main".into());
+    api.repo(repo).get(name).unwrap_or_else(|_| panic!("download {name} from {RERANKER_HUB_REPO}"))
+}
+
+fn load_reranker() -> Qwen3Reranker {
+    let cfg_path = resolve_reranker_file("config.json");
+    let mut cfg = Qwen3Config::from_json(&cfg_path).expect("config");
+    cfg.dtype = DType::Float32;
+    let weights_path = resolve_reranker_file("reranker_model.safetensors");
+    Qwen3Reranker::from_safetensors(&weights_path, cfg).expect("load reranker")
+}
+
+#[test]
+#[ignore = "heavy: real Qwen3-Reranker-0.6B weights + PyTorch golden"]
+fn reranker_scores_match_pytorch() {
+    let reranker = load_reranker();
+
+    let golden_path = resolve_file("golden_reranker.safetensors");
+    let sd = state::load_safetensors(&golden_path).expect("load golden reranker");
+
+    let shape_vec = {
+        let mut t = sd.get("input_ids_shape").unwrap().clone();
+        t.realize().unwrap();
+        t.as_vec::<i64>().unwrap()
+    };
+    let batch = shape_vec[0] as usize;
+    let seq_len = shape_vec[1] as usize;
+
+    let ids_vec = {
+        let mut t = sd.get("input_ids").unwrap().clone();
+        t.realize().unwrap();
+        t.as_vec::<i64>().unwrap()
+    };
+    let mask_vec = {
+        let mut t = sd.get("attention_mask").unwrap().clone();
+        t.realize().unwrap();
+        t.as_vec::<i64>().unwrap()
+    };
+
+    let ids = Tensor::from_slice(ids_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+    let mask = Tensor::from_slice(mask_vec).try_reshape([batch as isize, seq_len as isize]).unwrap();
+
+    let mut out = reranker.forward(&ids, &mask).unwrap();
+    out.realize().unwrap();
+    let got = out.as_vec::<f32>().unwrap();
+
+    let want = {
+        let mut t = sd.get("scores").unwrap().clone();
+        t.realize().unwrap();
+        t.as_vec::<f32>().unwrap()
+    };
+
+    assert_eq!(got.len(), want.len());
+    let delta = max_abs_delta(&got, &want);
+    assert!(delta < 1e-3, "max_abs_delta = {delta:.6} (threshold 1e-3)");
+}

--- a/model/src/test/unit/qwen3/reranker.rs
+++ b/model/src/test/unit/qwen3/reranker.rs
@@ -1,0 +1,53 @@
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::qwen3::{Qwen3Config, Qwen3Reranker};
+
+fn tiny_cfg() -> Qwen3Config {
+    Qwen3Config {
+        vocab_size: 100,
+        hidden_size: 64,
+        num_hidden_layers: 2,
+        num_attention_heads: 4,
+        num_key_value_heads: 2,
+        head_dim: 32,
+        intermediate_size: 128,
+        max_position_embeddings: 64,
+        rms_norm_eps: 1e-5,
+        rope_theta: 10000.0,
+        attention_bias: false,
+        tie_word_embeddings: true,
+        pad_token_id: 0,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}
+
+#[test]
+fn forward_output_shape() {
+    let mut reranker = Qwen3Reranker::empty(tiny_cfg());
+    reranker.yes_loc = 5; // within tiny vocab_size=100
+    let ids = Tensor::from_slice([0i64, 1, 2, 3, 4, 5, 6, 7]).try_reshape([1isize, 8]).unwrap();
+    let mask = Tensor::from_slice([1i64, 1, 1, 1, 1, 1, 1, 1]).try_reshape([1isize, 8]).unwrap();
+
+    let mut out = reranker.forward(&ids, &mask).unwrap();
+    out.realize().unwrap();
+    let s = out.shape().unwrap();
+    // (B,) scalar score per row (after sigmoid)
+    assert_eq!(s.len(), 1);
+    assert_eq!(s[0].as_const().unwrap(), 1);
+
+    let v = out.as_vec::<f32>().unwrap();
+    assert!(v.iter().all(|x| x.is_finite()));
+    // sigmoid output must be in (0, 1)
+    assert!(v[0] > 0.0 && v[0] < 1.0);
+}
+
+#[test]
+fn lm_head_tied_to_embeddings() {
+    let reranker = Qwen3Reranker::empty(tiny_cfg());
+    // The lm_head_weight should have the same shape as embed_tokens.weight
+    let lm_shape = reranker.lm_head_weight.shape().unwrap();
+    assert_eq!(lm_shape[0].as_const().unwrap(), 100); // vocab_size
+    assert_eq!(lm_shape[1].as_const().unwrap(), 64); // hidden_size
+}

--- a/model/src/test/unit/xlm_roberta/config.rs
+++ b/model/src/test/unit/xlm_roberta/config.rs
@@ -1,0 +1,44 @@
+use crate::xlm_roberta::{XlmRobertaConfig, xlm_roberta_large};
+use svod_dtype::DType;
+
+#[test]
+fn large_dims() {
+    let cfg = xlm_roberta_large();
+    assert_eq!(cfg.vocab_size, 250002);
+    assert_eq!(cfg.hidden_size, 1024);
+    assert_eq!(cfg.num_hidden_layers, 24);
+    assert_eq!(cfg.num_attention_heads, 16);
+    assert_eq!(cfg.head_dim(), 64);
+    assert_eq!(cfg.intermediate_size, 4096);
+    assert_eq!(cfg.max_position_embeddings, 8194);
+    assert_eq!(cfg.type_vocab_size, 1);
+    assert_eq!(cfg.pad_token_id, 1);
+    assert_eq!(cfg.layer_norm_eps, 1e-5);
+}
+
+#[test]
+fn parse_config_json() {
+    let json = r#"{
+        "vocab_size": 250002, "hidden_size": 1024, "num_hidden_layers": 24,
+        "num_attention_heads": 16, "intermediate_size": 4096,
+        "max_position_embeddings": 8194, "type_vocab_size": 1,
+        "layer_norm_eps": 1e-05, "pad_token_id": 1
+    }"#;
+    let cfg = XlmRobertaConfig::from_json_str(json).unwrap();
+    assert_eq!(cfg.vocab_size, 250002);
+    assert_eq!(cfg.pad_token_id, 1);
+}
+
+#[test]
+fn parse_norm_eps_alias() {
+    let cfg = XlmRobertaConfig::from_json_str(r#"{"norm_eps": 1e-5}"#).unwrap();
+    assert!((cfg.layer_norm_eps - 1e-5).abs() < 1e-12);
+}
+
+#[test]
+fn merge_preserves_dtype() {
+    let mut caller = XlmRobertaConfig { dtype: DType::Float32, max_batch_size: 4, ..xlm_roberta_large() };
+    caller.merge_structural_from(&xlm_roberta_large());
+    assert_eq!(caller.dtype, DType::Float32);
+    assert_eq!(caller.max_batch_size, 4);
+}

--- a/model/src/test/unit/xlm_roberta/mod.rs
+++ b/model/src/test/unit/xlm_roberta/mod.rs
@@ -1,0 +1,3 @@
+mod config;
+mod model;
+mod position_ids;

--- a/model/src/test/unit/xlm_roberta/model.rs
+++ b/model/src/test/unit/xlm_roberta/model.rs
@@ -1,0 +1,45 @@
+use crate::state::HasStateDict;
+use crate::xlm_roberta::{XlmRobertaConfig, XlmRobertaModel};
+use svod_dtype::DType;
+
+fn tiny_cfg() -> XlmRobertaConfig {
+    XlmRobertaConfig {
+        vocab_size: 100,
+        hidden_size: 32,
+        num_hidden_layers: 2,
+        num_attention_heads: 4,
+        intermediate_size: 64,
+        max_position_embeddings: 20,
+        type_vocab_size: 1,
+        layer_norm_eps: 1e-5,
+        pad_token_id: 1,
+        dtype: DType::Float32,
+        max_batch_size: 1,
+    }
+}
+
+#[test]
+fn forward_output_shape() {
+    let model = XlmRobertaModel::empty(tiny_cfg());
+    let ids = svod_tensor::Tensor::from_slice([0i64, 10, 20, 2, 1]).try_reshape([1isize, 5]).unwrap();
+    let mut out = model.forward(&ids, None).unwrap();
+    out.realize().unwrap();
+    let v = out.as_vec::<f32>().unwrap();
+    assert_eq!(v.len(), 5 * 32);
+    assert!(v.iter().all(|x| x.is_finite()));
+}
+
+#[test]
+fn state_dict_round_trip() {
+    let model = XlmRobertaModel::empty(tiny_cfg());
+    let sd = model.state_dict("");
+    assert!(sd.contains_key("embeddings.word_embeddings.weight"));
+    assert!(sd.contains_key("encoder.layer.0.attention.self.query.weight"));
+    let mut model2 = XlmRobertaModel::empty(tiny_cfg());
+    model2.load_state_dict(&sd, "").unwrap();
+    let mut k1: Vec<String> = sd.keys().cloned().collect();
+    let mut k2: Vec<String> = model2.state_dict("").keys().cloned().collect();
+    k1.sort();
+    k2.sort();
+    assert_eq!(k1, k2);
+}

--- a/model/src/test/unit/xlm_roberta/position_ids.rs
+++ b/model/src/test/unit/xlm_roberta/position_ids.rs
@@ -1,0 +1,26 @@
+use crate::xlm_roberta::position_ids_from_input_ids;
+use svod_tensor::Tensor;
+
+#[test]
+fn position_ids_basic() {
+    let ids = Tensor::from_slice([0i64, 100, 200, 300, 2, 1, 1]).try_reshape([1, 7]).unwrap();
+    let mut pos = position_ids_from_input_ids(&ids, 1).unwrap();
+    pos.realize().unwrap();
+    assert_eq!(pos.as_vec::<i32>().unwrap(), vec![2, 3, 4, 5, 6, 1, 1]);
+}
+
+#[test]
+fn position_ids_all_real() {
+    let ids = Tensor::from_slice([0i64, 100, 200, 2]).try_reshape([1, 4]).unwrap();
+    let mut pos = position_ids_from_input_ids(&ids, 1).unwrap();
+    pos.realize().unwrap();
+    assert_eq!(pos.as_vec::<i32>().unwrap(), vec![2, 3, 4, 5]);
+}
+
+#[test]
+fn position_ids_leading_padding() {
+    let ids = Tensor::from_slice([1i64, 1, 0, 100, 2]).try_reshape([1, 5]).unwrap();
+    let mut pos = position_ids_from_input_ids(&ids, 1).unwrap();
+    pos.realize().unwrap();
+    assert_eq!(pos.as_vec::<i32>().unwrap(), vec![1, 1, 2, 3, 4]);
+}

--- a/model/src/wespeaker/pickle.rs
+++ b/model/src/wespeaker/pickle.rs
@@ -116,8 +116,8 @@ fn load_pytorch_bin_with_state_dict_key(
             unwrap_ordered_dict_items(state_dict_value)
                 .context(StructureSnafu { context: format!("{key} value is not an OrderedDict") })?
         }
-        None => unwrap_ordered_dict_items(toplevel)
-            .or_else(|| unwrap_outer_dict(toplevel))
+        None => unwrap_outer_dict(toplevel)
+            .or_else(|| unwrap_ordered_dict_items(toplevel))
             .context(StructureSnafu { context: "toplevel not recognised as a flat OrderedDict" })?,
     };
 

--- a/model/src/xlm_roberta/attention.rs
+++ b/model/src/xlm_roberta/attention.rs
@@ -1,0 +1,121 @@
+//! XLM-RoBERTa self-attention with separate biased Q/K/V/O projections.
+//!
+//! Standard BERT-style multi-head attention: separate `Linear(D, D, bias)` for
+//! Q, K, V; reshape to `(B, H, L, hd)`; scaled dot-product attention (global,
+//! no window); output `Linear(D, D, bias)`. No RoPE, no relative positions.
+//!
+//! State-dict keys match the published `BAAI/bge-m3` `pytorch_model.bin`:
+//! `attention.self.{query,key,value}.{weight,bias}`,
+//! `attention.output.dense.{weight,bias}`.
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct XlmRobertaAttention {
+    pub hidden_size: usize,
+    pub num_heads: usize,
+    pub head_dim: usize,
+    pub query_weight: Tensor,
+    pub query_bias: Tensor,
+    pub key_weight: Tensor,
+    pub key_bias: Tensor,
+    pub value_weight: Tensor,
+    pub value_bias: Tensor,
+    pub out_weight: Tensor,
+    pub out_bias: Tensor,
+}
+
+impl XlmRobertaAttention {
+    pub fn empty(hidden_size: usize, num_heads: usize, head_dim: usize, dtype: DType) -> Self {
+        Self {
+            hidden_size,
+            num_heads,
+            head_dim,
+            query_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            query_bias: zeros(&[hidden_size], dtype.clone()),
+            key_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            key_bias: zeros(&[hidden_size], dtype.clone()),
+            value_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            value_bias: zeros(&[hidden_size], dtype.clone()),
+            out_weight: fan_in_uniform(&[hidden_size, hidden_size], hidden_size, dtype.clone()),
+            out_bias: zeros(&[hidden_size], dtype),
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)`. Returns `(B, L, D)`.
+    /// `padding_mask`: optional bool `(B, 1, 1, L)` where `true` masks out
+    /// (padding) positions in the KEY axis.
+    pub fn forward(&self, x: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = x.shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+        let l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "attention" })?;
+        let h = self.num_heads as isize;
+        let hd = self.head_dim as isize;
+        let bsint: SInt = b;
+
+        let q = x.linear().weight(&self.query_weight).bias(&self.query_bias).call().context(TensorSnafu)?;
+        let k = x.linear().weight(&self.key_weight).bias(&self.key_bias).call().context(TensorSnafu)?;
+        let v = x.linear().weight(&self.value_weight).bias(&self.value_bias).call().context(TensorSnafu)?;
+
+        let to_heads = |t: Tensor| -> Result<Tensor> {
+            t.view([bsint.clone(), l.into(), h.into(), hd.into()])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)
+        };
+        let q = to_heads(q)?;
+        let k = to_heads(k)?;
+        let v = to_heads(v)?;
+
+        let attn = q
+            .scaled_dot_product_attention()
+            .key(&k)
+            .value(&v)
+            .maybe_attn_mask(padding_mask)
+            .call()
+            .context(TensorSnafu)?;
+
+        let attn = attn
+            .try_permute(&[0, 2, 1, 3])
+            .context(TensorSnafu)?
+            .view([bsint, l.into(), (self.num_heads * self.head_dim).into()])
+            .context(TensorSnafu)?;
+
+        attn.linear().weight(&self.out_weight).bias(&self.out_bias).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for XlmRobertaAttention {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "self.query.weight"), self.query_weight.clone());
+        sd.insert(prefixed(prefix, "self.query.bias"), self.query_bias.clone());
+        sd.insert(prefixed(prefix, "self.key.weight"), self.key_weight.clone());
+        sd.insert(prefixed(prefix, "self.key.bias"), self.key_bias.clone());
+        sd.insert(prefixed(prefix, "self.value.weight"), self.value_weight.clone());
+        sd.insert(prefixed(prefix, "self.value.bias"), self.value_bias.clone());
+        sd.insert(prefixed(prefix, "output.dense.weight"), self.out_weight.clone());
+        sd.insert(prefixed(prefix, "output.dense.bias"), self.out_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.query_weight = get_tensor(sd, &prefixed(prefix, "self.query.weight"))?;
+        self.query_bias = get_tensor(sd, &prefixed(prefix, "self.query.bias"))?;
+        self.key_weight = get_tensor(sd, &prefixed(prefix, "self.key.weight"))?;
+        self.key_bias = get_tensor(sd, &prefixed(prefix, "self.key.bias"))?;
+        self.value_weight = get_tensor(sd, &prefixed(prefix, "self.value.weight"))?;
+        self.value_bias = get_tensor(sd, &prefixed(prefix, "self.value.bias"))?;
+        self.out_weight = get_tensor(sd, &prefixed(prefix, "output.dense.weight"))?;
+        self.out_bias = get_tensor(sd, &prefixed(prefix, "output.dense.bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/config.rs
+++ b/model/src/xlm_roberta/config.rs
@@ -1,0 +1,122 @@
+//! XLM-RoBERTa configuration, parsed from HuggingFace `config.json`.
+//!
+//! Mirrors the published schema of `BAAI/bge-m3` (XLM-RoBERTa-large). The
+//! [`RawXlmRobertaConfig`] serde mirror captures the on-disk shape; the clean
+//! [`XlmRobertaConfig`] keeps only the fields the Rust backbone consumes and
+//! adds a caller-chosen compute [`DType`] (defaults to bf16 on the AMD target,
+//! f32 for CPU parity tests).
+
+use std::path::Path;
+
+use serde::Deserialize;
+use svod_dtype::DType;
+
+use super::error::{Error, Result};
+
+/// Clean, resolved XLM-RoBERTa config.
+#[derive(Clone, Debug)]
+pub struct XlmRobertaConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub intermediate_size: usize,
+    pub max_position_embeddings: usize,
+    pub type_vocab_size: usize,
+    pub layer_norm_eps: f64,
+    /// XLM-RoBERTa padding index (= `pad_token_id`). Position IDs are offset
+    /// by this value: real tokens start at `padding_idx + 1`.
+    pub pad_token_id: usize,
+    /// Caller-chosen compute dtype (bf16 by default; f32 for CPU parity).
+    pub dtype: DType,
+    /// Upper bound on the symbolic batch variable in the JIT wrapper.
+    pub max_batch_size: usize,
+}
+
+impl XlmRobertaConfig {
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+
+    /// Splice in the structural fields parsed from the published `config.json`,
+    /// preserving the caller-chosen `dtype` / `max_batch_size`. Shared by the
+    /// backbone and head Hub loaders so both stay in sync.
+    pub fn merge_structural_from(&mut self, parsed: &Self) {
+        self.vocab_size = parsed.vocab_size;
+        self.hidden_size = parsed.hidden_size;
+        self.num_hidden_layers = parsed.num_hidden_layers;
+        self.num_attention_heads = parsed.num_attention_heads;
+        self.intermediate_size = parsed.intermediate_size;
+        self.max_position_embeddings = parsed.max_position_embeddings;
+        self.type_vocab_size = parsed.type_vocab_size;
+        self.layer_norm_eps = parsed.layer_norm_eps;
+        self.pad_token_id = parsed.pad_token_id;
+    }
+
+    /// Parse a HuggingFace `config.json`. Unrecognized fields are ignored; any
+    /// of the structural fields below that is absent falls back to the
+    /// XLM-RoBERTa-large defaults.
+    pub fn from_json(path: &Path) -> Result<Self> {
+        let data = std::fs::read_to_string(path)
+            .map_err(|e| Error::Config { message: format!("reading config.json: {e}") })?;
+        Self::from_json_str(&data)
+    }
+
+    pub fn from_json_str(data: &str) -> Result<Self> {
+        let raw: RawXlmRobertaConfig =
+            serde_json::from_str(data).map_err(|e| Error::Config { message: format!("JSON parse error: {e}") })?;
+        Ok(Self::from_raw(raw))
+    }
+
+    fn from_raw(raw: RawXlmRobertaConfig) -> Self {
+        let base = xlm_roberta_large();
+        XlmRobertaConfig {
+            vocab_size: raw.vocab_size.unwrap_or(base.vocab_size),
+            hidden_size: raw.hidden_size.unwrap_or(base.hidden_size),
+            num_hidden_layers: raw.num_hidden_layers.unwrap_or(base.num_hidden_layers),
+            num_attention_heads: raw.num_attention_heads.unwrap_or(base.num_attention_heads),
+            intermediate_size: raw.intermediate_size.unwrap_or(base.intermediate_size),
+            max_position_embeddings: raw.max_position_embeddings.unwrap_or(base.max_position_embeddings),
+            type_vocab_size: raw.type_vocab_size.unwrap_or(base.type_vocab_size),
+            layer_norm_eps: raw.layer_norm_eps.or(raw.norm_eps).unwrap_or(base.layer_norm_eps),
+            pad_token_id: raw.pad_token_id.unwrap_or(base.pad_token_id),
+            dtype: base.dtype,
+            max_batch_size: base.max_batch_size,
+        }
+    }
+}
+
+/// `BAAI/bge-m3` / XLM-RoBERTa-large: 24 layers, hidden 1024, intermediate
+/// 4096, 16 heads (head_dim 64), vocab 250002, position embeddings 8194.
+pub fn xlm_roberta_large() -> XlmRobertaConfig {
+    XlmRobertaConfig {
+        vocab_size: 250002,
+        hidden_size: 1024,
+        num_hidden_layers: 24,
+        num_attention_heads: 16,
+        intermediate_size: 4096,
+        max_position_embeddings: 8194,
+        type_vocab_size: 1,
+        layer_norm_eps: 1e-5,
+        pad_token_id: 1,
+        dtype: DType::BFloat16,
+        max_batch_size: 1,
+    }
+}
+
+/// Serde mirror of the published `config.json`. Every field is optional so a
+/// missing field falls back to the large defaults rather than failing.
+#[derive(Deserialize)]
+struct RawXlmRobertaConfig {
+    vocab_size: Option<usize>,
+    hidden_size: Option<usize>,
+    num_hidden_layers: Option<usize>,
+    num_attention_heads: Option<usize>,
+    intermediate_size: Option<usize>,
+    max_position_embeddings: Option<usize>,
+    type_vocab_size: Option<usize>,
+    /// XLM-RoBERTa publishes both `layer_norm_eps` and `norm_eps` (equal).
+    layer_norm_eps: Option<f64>,
+    norm_eps: Option<f64>,
+    pad_token_id: Option<usize>,
+}

--- a/model/src/xlm_roberta/embeddings.rs
+++ b/model/src/xlm_roberta/embeddings.rs
@@ -1,0 +1,85 @@
+//! XLM-RoBERTa embeddings: word + position + token_type → LayerNorm.
+//!
+//! Unlike ModernBERT (which uses RoPE and has no position embeddings),
+//! XLM-RoBERTa uses **absolute learned position embeddings** with the fairseq
+//! `make_positions` offset (see [`super::position_ids`]).
+//!
+//! Token-type embeddings: `type_vocab_size = 1`, so only row 0 exists and is
+//! always selected (token_type_ids are implicitly zeros). We broadcast row 0
+//! directly instead of constructing a zeros index tensor — simpler and avoids
+//! a symbolic-shape dependency on the index.
+
+use snafu::{OptionExt, ResultExt};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+use super::normalization::LayerNormWeights;
+use super::position_ids::position_ids_from_input_ids;
+
+#[derive(Clone)]
+pub struct XlmRobertaEmbeddings {
+    pub word_embeddings: Tensor,
+    pub position_embeddings: Tensor,
+    pub token_type_embeddings: Tensor,
+    pub norm: LayerNormWeights,
+    pub pad_token_id: usize,
+}
+
+impl XlmRobertaEmbeddings {
+    pub fn empty(
+        vocab_size: usize,
+        hidden_size: usize,
+        max_position_embeddings: usize,
+        type_vocab_size: usize,
+        eps: f64,
+        pad_token_id: usize,
+        dtype: DType,
+    ) -> Self {
+        Self {
+            word_embeddings: fan_in_uniform(&[vocab_size, hidden_size], hidden_size, dtype.clone()),
+            position_embeddings: fan_in_uniform(&[max_position_embeddings, hidden_size], hidden_size, dtype.clone()),
+            token_type_embeddings: fan_in_uniform(&[type_vocab_size, hidden_size], hidden_size, dtype.clone()),
+            norm: LayerNormWeights::with_eps(hidden_size, eps, dtype),
+            pad_token_id,
+        }
+    }
+
+    /// Forward. `input_ids`: `(B, L)` int → `(B, L, D)`.
+    pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let shape = input_ids.shape().context(TensorSnafu)?;
+        let _l: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "embeddings" })?;
+
+        let word = self.word_embeddings.embedding(input_ids).context(TensorSnafu)?;
+
+        let pos_ids = position_ids_from_input_ids(input_ids, self.pad_token_id)?;
+        let pos = self.position_embeddings.embedding(&pos_ids).context(TensorSnafu)?;
+
+        let tok_type = self.token_type_embeddings.try_unsqueeze(0).context(TensorSnafu)?;
+
+        let h = word.try_add(&pos).context(TensorSnafu)?.try_add(&tok_type).context(TensorSnafu)?;
+        self.norm.apply(&h)
+    }
+}
+
+impl HasStateDict for XlmRobertaEmbeddings {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "word_embeddings.weight"), self.word_embeddings.clone());
+        sd.insert(prefixed(prefix, "position_embeddings.weight"), self.position_embeddings.clone());
+        sd.insert(prefixed(prefix, "token_type_embeddings.weight"), self.token_type_embeddings.clone());
+        sd.extend(self.norm.state_dict(&format!("{prefix}.LayerNorm")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.word_embeddings = get_tensor(sd, &prefixed(prefix, "word_embeddings.weight"))?;
+        self.position_embeddings = get_tensor(sd, &prefixed(prefix, "position_embeddings.weight"))?;
+        self.token_type_embeddings = get_tensor(sd, &prefixed(prefix, "token_type_embeddings.weight"))?;
+        self.norm.load_state_dict(sd, &format!("{prefix}.LayerNorm"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/encoder.rs
+++ b/model/src/xlm_roberta/encoder.rs
@@ -1,0 +1,63 @@
+//! XLM-RoBERTa transformer encoder: a stack of post-norm [`EncoderLayer`]s.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::XlmRobertaConfig;
+use super::encoder_layer::EncoderLayer;
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct XlmRobertaEncoder {
+    pub config: XlmRobertaConfig,
+    pub layers: Vec<EncoderLayer>,
+}
+
+impl XlmRobertaEncoder {
+    pub fn empty(config: &XlmRobertaConfig) -> Self {
+        let layers = (0..config.num_hidden_layers).map(|_| EncoderLayer::empty(config)).collect();
+        Self { config: config.clone(), layers }
+    }
+
+    /// Run the encoder stack. `x`: `(B, L, D)` → `(B, L, D)`.
+    pub fn forward(&self, x: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let shape = x.shape().context(TensorSnafu)?;
+        let seq_len: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "encoder" })?;
+
+        let mask_4d = match padding_mask {
+            Some(m) => {
+                let b_dim = shape[0].clone();
+                let m2 = m.try_reshape([b_dim, SInt::from(seq_len)]).context(TensorSnafu)?;
+                let inverted = m2.logical_not().context(TensorSnafu)?;
+                Some(inverted.try_unsqueeze(1).context(TensorSnafu)?.try_unsqueeze(1).context(TensorSnafu)?)
+            }
+            None => None,
+        };
+
+        let mut h = x.clone();
+        for layer in &self.layers {
+            h = layer.forward(&h, mask_4d.as_ref())?;
+        }
+        Ok(h)
+    }
+}
+
+impl HasStateDict for XlmRobertaEncoder {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, layer) in self.layers.iter().enumerate() {
+            sd.extend(layer.state_dict(&format!("{prefix}.layer.{i}")));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, layer) in self.layers.iter_mut().enumerate() {
+            layer.load_state_dict(sd, &format!("{prefix}.layer.{i}"))?;
+        }
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/encoder_layer.rs
+++ b/model/src/xlm_roberta/encoder_layer.rs
@@ -1,0 +1,70 @@
+//! XLM-RoBERTa post-norm encoder layer.
+//!
+//! Standard BERT/RoBERTa post-norm:
+//! ```text
+//! attn_out = LayerNorm_attn(x + Attention(x))
+//! layer_out = LayerNorm_ffn(attn_out + FFN(attn_out))
+//! ```
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::attention::XlmRobertaAttention;
+use super::config::XlmRobertaConfig;
+use super::error::{Result, TensorSnafu};
+use super::feed_forward::FeedForwardWeights;
+use super::normalization::LayerNormWeights;
+
+#[derive(Clone)]
+pub struct EncoderLayer {
+    pub attention: XlmRobertaAttention,
+    pub attention_norm: LayerNormWeights,
+    pub feed_forward: FeedForwardWeights,
+    pub ffn_norm: LayerNormWeights,
+}
+
+impl EncoderLayer {
+    pub fn empty(config: &XlmRobertaConfig) -> Self {
+        let hidden = config.hidden_size;
+        let eps = config.layer_norm_eps;
+        let dtype = config.dtype.clone();
+        Self {
+            attention: XlmRobertaAttention::empty(hidden, config.num_attention_heads, config.head_dim(), dtype.clone()),
+            attention_norm: LayerNormWeights::with_eps(hidden, eps, dtype.clone()),
+            feed_forward: FeedForwardWeights::empty(hidden, config.intermediate_size, dtype.clone()),
+            ffn_norm: LayerNormWeights::with_eps(hidden, eps, dtype),
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)` → `(B, L, D)`. Post-norm.
+    pub fn forward(&self, x: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let attn_delta = self.attention.forward(x, padding_mask)?;
+        let x = x.try_add(&attn_delta).context(TensorSnafu)?;
+        let x = self.attention_norm.apply(&x)?;
+
+        let ffn_delta = self.feed_forward.forward(&x)?;
+        let x = x.try_add(&ffn_delta).context(TensorSnafu)?;
+        self.ffn_norm.apply(&x)
+    }
+}
+
+impl HasStateDict for EncoderLayer {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.extend(self.attention.state_dict(&format!("{prefix}.attention")));
+        sd.extend(self.attention_norm.state_dict(&format!("{prefix}.attention.output.LayerNorm")));
+        sd.extend(self.feed_forward.state_dict(prefix));
+        sd.extend(self.ffn_norm.state_dict(&format!("{prefix}.output.LayerNorm")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.attention.load_state_dict(sd, &format!("{prefix}.attention"))?;
+        self.attention_norm.load_state_dict(sd, &format!("{prefix}.attention.output.LayerNorm"))?;
+        self.feed_forward.load_state_dict(sd, prefix)?;
+        self.ffn_norm.load_state_dict(sd, &format!("{prefix}.output.LayerNorm"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/error.rs
+++ b/model/src/xlm_roberta/error.rs
@@ -1,0 +1,29 @@
+use snafu::Snafu;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    #[snafu(display("tensor op failed"))]
+    Tensor {
+        #[snafu(source(from(svod_tensor::error::Error, Box::new)))]
+        source: Box<svod_tensor::error::Error>,
+    },
+    #[snafu(display("state-dict op failed"))]
+    State {
+        #[snafu(source(from(crate::state::Error, Box::new)))]
+        source: Box<crate::state::Error>,
+    },
+    #[snafu(display("pickle load failed"))]
+    Pickle {
+        #[snafu(source(from(crate::wespeaker::pickle::Error, Box::new)))]
+        source: Box<crate::wespeaker::pickle::Error>,
+    },
+    #[snafu(display("HF Hub op failed"))]
+    Hub { source: hf_hub::api::sync::ApiError },
+    #[snafu(display("reading config.json failed: {message}"))]
+    Config { message: String },
+    #[snafu(display("{what} requires a concrete sequence length, got a symbolic dim"))]
+    SymbolicShape { what: &'static str },
+}

--- a/model/src/xlm_roberta/feed_forward.rs
+++ b/model/src/xlm_roberta/feed_forward.rs
@@ -1,0 +1,60 @@
+//! XLM-RoBERTa feed-forward block: `Linear(D, I, bias) → GELU(exact) → Linear(I, D, bias)`.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::{fan_in_uniform, zeros};
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, TensorSnafu};
+
+#[derive(Clone)]
+pub struct FeedForwardWeights {
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub intermediate_weight: Tensor,
+    pub intermediate_bias: Tensor,
+    pub output_weight: Tensor,
+    pub output_bias: Tensor,
+}
+
+impl FeedForwardWeights {
+    pub fn empty(hidden_size: usize, intermediate_size: usize, dtype: DType) -> Self {
+        Self {
+            hidden_size,
+            intermediate_size,
+            intermediate_weight: fan_in_uniform(&[intermediate_size, hidden_size], hidden_size, dtype.clone()),
+            intermediate_bias: zeros(&[intermediate_size], dtype.clone()),
+            output_weight: fan_in_uniform(&[hidden_size, intermediate_size], intermediate_size, dtype.clone()),
+            output_bias: zeros(&[hidden_size], dtype),
+        }
+    }
+
+    /// Forward. `x`: `(B, L, D)` → `(B, L, D)`.
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let y =
+            x.linear().weight(&self.intermediate_weight).bias(&self.intermediate_bias).call().context(TensorSnafu)?;
+        let y = y.gelu_exact().context(TensorSnafu)?;
+        y.linear().weight(&self.output_weight).bias(&self.output_bias).call().context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for FeedForwardWeights {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "intermediate.dense.weight"), self.intermediate_weight.clone());
+        sd.insert(prefixed(prefix, "intermediate.dense.bias"), self.intermediate_bias.clone());
+        sd.insert(prefixed(prefix, "output.dense.weight"), self.output_weight.clone());
+        sd.insert(prefixed(prefix, "output.dense.bias"), self.output_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.intermediate_weight = get_tensor(sd, &prefixed(prefix, "intermediate.dense.weight"))?;
+        self.intermediate_bias = get_tensor(sd, &prefixed(prefix, "intermediate.dense.bias"))?;
+        self.output_weight = get_tensor(sd, &prefixed(prefix, "output.dense.weight"))?;
+        self.output_bias = get_tensor(sd, &prefixed(prefix, "output.dense.bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/jit.rs
+++ b/model/src/xlm_roberta/jit.rs
@@ -1,0 +1,22 @@
+//! JIT wrapper for [`super::model::XlmRobertaModel`].
+
+extern crate self as svod_model;
+
+use svod_macros::jit_wrapper;
+
+use super::model::XlmRobertaModel;
+
+jit_wrapper! {
+    XlmRobertaJit(XlmRobertaModel) {
+        input_ids: Tensor,
+        attention_mask: Tensor,
+
+        vars {
+            b: (1, model.config.max_batch_size),
+        }
+
+        build(input_ids, attention_mask, b) {
+            model.forward_batch(input_ids, Some(attention_mask), &b)
+        }
+    }
+}

--- a/model/src/xlm_roberta/mod.rs
+++ b/model/src/xlm_roberta/mod.rs
@@ -1,0 +1,35 @@
+//! XLM-RoBERTa — multilingual transformer encoder backbone.
+//!
+//! Pure-Rust port of the XLM-RoBERTa-large architecture: absolute learned
+//! position embeddings (with the fairseq `make_positions` offset), post-norm
+//! encoder layers, separate biased Q/K/V/O projections.
+//!
+//! Consumed by [`crate::bgem3`] (BGE-M3 embedder + reranker). Computes in bf16
+//! on the AMD target; f32 for CPU parity. Tokenization is out-of-band — the
+//! API takes pre-computed `input_ids`.
+
+pub mod attention;
+pub mod config;
+pub mod embeddings;
+pub mod encoder;
+pub mod encoder_layer;
+pub mod error;
+pub mod feed_forward;
+pub mod jit;
+pub mod model;
+pub mod normalization;
+pub mod pooling;
+pub mod position_ids;
+
+pub use attention::XlmRobertaAttention;
+pub use config::{XlmRobertaConfig, xlm_roberta_large};
+pub use embeddings::XlmRobertaEmbeddings;
+pub use encoder::XlmRobertaEncoder;
+pub use encoder_layer::EncoderLayer;
+pub use error::{Error, Result};
+pub use feed_forward::FeedForwardWeights;
+pub use jit::XlmRobertaJit;
+pub use model::XlmRobertaModel;
+pub use normalization::LayerNormWeights;
+pub use pooling::cls;
+pub use position_ids::position_ids_from_input_ids;

--- a/model/src/xlm_roberta/model.rs
+++ b/model/src/xlm_roberta/model.rs
@@ -1,0 +1,122 @@
+//! Root XLM-RoBERTa backbone: embeddings → encoder stack.
+//!
+//! Loads from a HuggingFace `pytorch_model.bin` checkpoint (the published
+//! `BAAI/bge-m3` layout — there is no safetensors variant). Compute dtype is
+//! `config.dtype` (bf16 by default, f32 for CPU parity tests); weights load at
+//! their stored dtype and are cast to `config.dtype` on read.
+
+use std::path::Path;
+
+use snafu::ResultExt;
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict};
+
+use super::config::XlmRobertaConfig;
+use super::embeddings::XlmRobertaEmbeddings;
+use super::encoder::XlmRobertaEncoder;
+use super::error::{HubSnafu, PickleSnafu, Result, StateSnafu, TensorSnafu};
+
+#[derive(Clone)]
+pub struct XlmRobertaModel {
+    pub config: XlmRobertaConfig,
+    pub embeddings: XlmRobertaEmbeddings,
+    pub encoder: XlmRobertaEncoder,
+}
+
+impl XlmRobertaModel {
+    pub fn empty(config: XlmRobertaConfig) -> Self {
+        let eps = config.layer_norm_eps;
+        let dtype = config.dtype.clone();
+        let embeddings = XlmRobertaEmbeddings::empty(
+            config.vocab_size,
+            config.hidden_size,
+            config.max_position_embeddings,
+            config.type_vocab_size,
+            eps,
+            config.pad_token_id,
+            dtype.clone(),
+        );
+        let encoder = XlmRobertaEncoder::empty(&config);
+        Self { config, embeddings, encoder }
+    }
+
+    /// Eager forward: `input_ids` `(B, L)` int + optional `padding_mask`
+    /// `(B, L)` bool → last-hidden-state `(B, L, D)`.
+    pub fn forward(&self, input_ids: &Tensor, padding_mask: Option<&Tensor>) -> Result<Tensor> {
+        let x = self.embeddings.forward(input_ids)?;
+        self.encoder.forward(&x, padding_mask)
+    }
+
+    /// JIT-path variant: `input_ids` / `padding_mask` are sized for the JIT
+    /// plan's `max_batch`; `b` shrinks the leading batch dim to the live value
+    /// at execute time.
+    pub fn forward_batch(
+        &self,
+        input_ids: &Tensor,
+        padding_mask: Option<&Tensor>,
+        b: &BoundVariable,
+    ) -> Result<Tensor> {
+        let bv = b.as_sint();
+        let input_ids = input_ids.try_shrink([Some((SInt::Const(0), bv.clone())), None]).context(TensorSnafu)?;
+        let padding_mask = match padding_mask {
+            Some(m) => Some(m.try_shrink([Some((SInt::Const(0), bv)), None]).context(TensorSnafu)?),
+            None => None,
+        };
+        self.forward(&input_ids, padding_mask.as_ref())
+    }
+
+    /// Download `config.json` + `pytorch_model.bin` from a HuggingFace Hub
+    /// repository and load the backbone.
+    pub fn from_hub(model_id: &str, mut config: XlmRobertaConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", &mut config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: &mut XlmRobertaConfig) -> Result<Self> {
+        let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+        let repo =
+            api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+        let cfg_path = repo.get("config.json").context(HubSnafu)?;
+        let parsed = XlmRobertaConfig::from_json(&cfg_path)?;
+        config.merge_structural_from(&parsed);
+
+        let weights_path = repo.get("pytorch_model.bin").context(HubSnafu)?;
+        Self::from_pytorch_bin(&weights_path, config.clone())
+    }
+
+    /// Load from a `pytorch_model.bin` checkpoint. Weights are cast to
+    /// `config.dtype` as they are read.
+    pub fn from_pytorch_bin(path: &Path, config: XlmRobertaConfig) -> Result<Self> {
+        let sd = crate::wespeaker::pickle::load_flat_pytorch_bin(path, "").context(PickleSnafu)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    /// Build from a preloaded state dict. Each weight is cast to
+    /// `config.dtype`.
+    pub fn from_state_dict(sd: &StateDict, config: XlmRobertaConfig) -> Result<Self> {
+        let dtype = config.dtype.clone();
+        let mut model = Self::empty(config);
+        model.load_state_dict(&state::cast_all(sd, dtype), "").context(StateSnafu)?;
+        Ok(model)
+    }
+}
+
+impl HasStateDict for XlmRobertaModel {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.extend(self.embeddings.state_dict(&prefix_or(prefix, "embeddings")));
+        sd.extend(self.encoder.state_dict(&prefix_or(prefix, "encoder")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.embeddings.load_state_dict(sd, &prefix_or(prefix, "embeddings"))?;
+        self.encoder.load_state_dict(sd, &prefix_or(prefix, "encoder"))?;
+        Ok(())
+    }
+}
+
+fn prefix_or(prefix: &str, suffix: &str) -> String {
+    if prefix.is_empty() { suffix.to_string() } else { format!("{prefix}.{suffix}") }
+}

--- a/model/src/xlm_roberta/normalization.rs
+++ b/model/src/xlm_roberta/normalization.rs
@@ -1,0 +1,59 @@
+//! Affine layer normalization with an optional bias.
+//!
+//! The `Tensor::layernorm` op upcasts to f32 internally before casting back,
+//! so this is numerically exact in bf16.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::ones;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::error::{Result, TensorSnafu};
+
+#[derive(Clone)]
+pub struct LayerNormWeights {
+    pub weight: Tensor,
+    pub bias: Option<Tensor>,
+    pub eps: f64,
+}
+
+impl LayerNormWeights {
+    pub fn empty(size: usize, dtype: DType) -> Self {
+        Self { weight: ones(&[size], dtype), bias: None, eps: 1e-5 }
+    }
+
+    pub fn with_eps(size: usize, eps: f64, dtype: DType) -> Self {
+        Self { weight: ones(&[size], dtype), bias: None, eps }
+    }
+
+    /// Apply LayerNorm over the last axis then affine:
+    /// `(x - μ)/√(σ²+ε) * γ + β?`.
+    pub fn apply(&self, x: &Tensor) -> Result<Tensor> {
+        let normed = x.layernorm(-1, self.eps).context(TensorSnafu)?;
+        let scaled = normed.try_mul(&self.weight).context(TensorSnafu)?;
+        match &self.bias {
+            Some(b) => scaled.try_add(b).context(TensorSnafu),
+            None => Ok(scaled),
+        }
+    }
+}
+
+impl HasStateDict for LayerNormWeights {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        if let Some(b) = &self.bias {
+            sd.insert(prefixed(prefix, "bias"), b.clone());
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        let bias_key = prefixed(prefix, "bias");
+        self.bias = sd.get(&bias_key).cloned();
+        Ok(())
+    }
+}

--- a/model/src/xlm_roberta/pooling.rs
+++ b/model/src/xlm_roberta/pooling.rs
@@ -1,0 +1,12 @@
+//! CLS pooling: take the first token's embedding.
+
+use snafu::ResultExt;
+use svod_tensor::{Tensor, s};
+
+use super::error::{Result, TensorSnafu};
+
+/// CLS pooling: take the first token's embedding. `hidden_states`: `(B, L, D)`
+/// → `(B, D)`.
+pub fn cls(hidden_states: &Tensor) -> Result<Tensor> {
+    hidden_states.getitem(s![.., 0, ..]).context(TensorSnafu)
+}

--- a/model/src/xlm_roberta/position_ids.rs
+++ b/model/src/xlm_roberta/position_ids.rs
@@ -1,0 +1,34 @@
+//! XLM-RoBERTa position-ID computation.
+//!
+//! XLM-RoBERTa (and RoBERTa) compute position IDs from `input_ids` using the
+//! fairseq `make_positions` convention:
+//!
+//! ```text
+//! mask          = (input_ids != padding_idx).int()
+//! incremental   = cumsum(mask, dim=-1) * mask
+//! position_ids  = incremental + padding_idx
+//! ```
+//!
+//! This means real tokens start at position `padding_idx + 1` (= 2 for
+//! `pad_token_id = 1`), and padding tokens map to `padding_idx` (= 1), which
+//! indexes the zeroed row of the position embedding table. Position rows 0 and
+//! 1 are never used for real tokens.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use super::error::{Result, TensorSnafu};
+
+/// Compute XLM-RoBERTa position IDs from `input_ids`.
+///
+/// `input_ids`: `(B, L)` int. Returns `(B, L)` int32 position IDs where real
+/// tokens are numbered starting from `padding_idx + 1` and padding positions
+/// are set to `padding_idx`.
+pub fn position_ids_from_input_ids(input_ids: &Tensor, padding_idx: usize) -> Result<Tensor> {
+    let pad = Tensor::const_(padding_idx as i64, DType::Int32);
+    let mask = input_ids.try_ne(&pad).context(TensorSnafu)?.cast(DType::Int32).context(TensorSnafu)?;
+    let cumsum = mask.cumsum(-1).context(TensorSnafu)?;
+    let incremental = cumsum.try_mul(&mask).context(TensorSnafu)?;
+    incremental.try_add(&pad).context(TensorSnafu)
+}

--- a/schedule/src/gpudims.rs
+++ b/schedule/src/gpudims.rs
@@ -603,9 +603,9 @@ fn get_contraction(original_dims: &[Arc<UOp>], limited_dims: &[Arc<UOp>]) -> Opt
         if is_one(acc) {
             split.push(0);
         } else {
-            match acc_old.iter().position(|o| Arc::ptr_eq(o, acc)) {
-                Some(idx) => split.push(idx + 1),
-                None => return None,
+            {
+                let idx = acc_old.iter().position(|o| Arc::ptr_eq(o, acc))?;
+                split.push(idx + 1)
             }
         }
     }

--- a/schedule/src/rangeify/patterns.rs
+++ b/schedule/src/rangeify/patterns.rs
@@ -469,10 +469,9 @@ fn cleanup_dead_axes_bufferize(
         } else {
             // Live axis: keep range and original dimension
             new_ranges.push(Arc::clone(range));
-            if let Some(dim) = original_shape.get(i) {
+            {
+                let dim = original_shape.get(i)?;
                 reshape_dims.push(dim.clone());
-            } else {
-                return None; // Shape mismatch
             }
         }
     }

--- a/scripts/convert_bgem3.py
+++ b/scripts/convert_bgem3.py
@@ -1,0 +1,128 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "numpy", "safetensors", "transformers", "huggingface_hub"]
+# ///
+"""Generate BGE-M3 parity fixtures for the Rust `svod-model` port.
+
+Downloads `BAAI/bge-m3`, runs the backbone and all three embedding heads
+(dense, sparse, ColBERT) on a fixed input sequence, and dumps a
+`golden.safetensors` storing:
+
+  - `input_ids`          (T,)  int64 — the exact token ids fed to the model
+  - `attention_mask`     (T,)  int64 — 1=real, 0=pad
+  - `input_ids_shape`    (2,)  int64 — (batch, seq_len)
+  - `last_hidden_state`  (B, T, D)    f32 — `model(...).last_hidden_state`
+  - `dense_vecs`         (B, D)       f32 — CLS-pooled L2-normalized dense embedding
+  - `sparse_vecs`        (B, V)       f32 — sparse lexical embedding (full vocab)
+  - `colbert_vecs`       (B, L-1, Dc) f32 — ColBERT multi-vector embeddings
+
+Usage:
+  uv run scripts/convert_bgem3.py
+  uv run scripts/convert_bgem3.py --out path/to/golden.safetensors
+
+Run the Rust parity test with the local fixture:
+  SVOD_BGEM3=$PWD/data/bgem3 \
+      cargo test -p svod-model --lib bgem3::parity -- --ignored
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors.numpy import save_file
+from transformers import AutoModel, AutoTokenizer
+
+HUB = "BAAI/bge-m3"
+DEFAULT_PROMPT = "What is BGE-M3?"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--prompt", default=DEFAULT_PROMPT, help="text to tokenize for the golden forward")
+    p.add_argument("--out", type=Path, default=None, help="output golden.safetensors path")
+    p.add_argument("--max-length", type=int, default=32, help="tokenizer max_length / padding target")
+    args = p.parse_args()
+
+    out = args.out or (Path(__file__).resolve().parent.parent / "data" / "bgem3" / "golden.safetensors")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    tok = AutoTokenizer.from_pretrained(HUB)
+    model = AutoModel.from_pretrained(HUB, torch_dtype=torch.float32)
+    model.eval()
+
+    enc = tok(args.prompt, return_tensors="pt", padding="max_length", max_length=args.max_length, truncation=True)
+    input_ids = enc["input_ids"]  # (1, T)
+    attn = enc["attention_mask"]  # (1, T)
+
+    with torch.no_grad():
+        out_t = model(input_ids=input_ids, attention_mask=attn).last_hidden_state  # (1, T, D)
+
+    # Dense embedding: CLS pooling + L2 normalize.
+    dense_vecs = out_t[:, 0]  # (1, D)
+    dense_vecs = torch.nn.functional.normalize(dense_vecs, dim=-1)
+
+    # ColBERT vectors: skip CLS, project + mask + normalize.
+    # We need to load the colbert_linear weights from the .pt file.
+    import os
+    from huggingface_hub import hf_hub_download
+
+    colbert_path = hf_hub_download(repo_id=HUB, filename="colbert_linear.pt")
+    sparse_path = hf_hub_download(repo_id=HUB, filename="sparse_linear.pt")
+    colbert_sd = torch.load(colbert_path, map_location="cpu", weights_only=True)
+    sparse_sd = torch.load(sparse_path, map_location="cpu", weights_only=True)
+
+    colbert_linear = torch.nn.Linear(model.config.hidden_size, model.config.hidden_size)
+    colbert_linear.load_state_dict(colbert_sd)
+    colbert_linear.eval()
+    sparse_linear = torch.nn.Linear(model.config.hidden_size, 1)
+    sparse_linear.load_state_dict(sparse_sd)
+    sparse_linear.eval()
+
+    with torch.no_grad():
+        # ColBERT: skip CLS, linear, mask, normalize.
+        colbert_vecs = colbert_linear(out_t[:, 1:])  # (1, T-1, Dc)
+        colbert_vecs = colbert_vecs * attn[:, 1:].unsqueeze(-1).float()
+        colbert_vecs = torch.nn.functional.normalize(colbert_vecs, dim=-1)
+
+        # Sparse: relu(linear(hidden)) → scatter to vocab.
+        token_weights = torch.relu(sparse_linear(out_t)).squeeze(-1)  # (1, T)
+        sparse_vecs = torch.zeros(1, model.config.vocab_size, dtype=token_weights.dtype)
+        sparse_vecs = sparse_vecs.scatter_reduce(
+            dim=-1, index=input_ids, src=token_weights, reduce="amax"
+        )
+        unused_tokens = [
+            tok.cls_token_id, tok.eos_token_id, tok.pad_token_id, tok.unk_token_id,
+        ]
+        sparse_vecs[:, unused_tokens] *= 0.0
+
+    ids_np = input_ids.squeeze(0).to(torch.int64).numpy()
+    attn_np = attn.squeeze(0).to(torch.int64).numpy()
+    hidden_np = out_t.squeeze(0).to(torch.float32).numpy()
+    dense_np = dense_vecs.squeeze(0).to(torch.float32).numpy()
+    sparse_np = sparse_vecs.squeeze(0).to(torch.float32).numpy()
+    colbert_np = colbert_vecs.squeeze(0).to(torch.float32).numpy()
+    shape_np = np.array(input_ids.shape, dtype=np.int64)
+
+    save_file(
+        {
+            "input_ids": ids_np,
+            "attention_mask": attn_np,
+            "input_ids_shape": shape_np,
+            "last_hidden_state": hidden_np,
+            "dense_vecs": dense_np,
+            "sparse_vecs": sparse_np,
+            "colbert_vecs": colbert_np,
+        },
+        str(out),
+    )
+    print(f"wrote {out}")
+    print(
+        f"  input_ids {tuple(ids_np.shape)}  hidden {tuple(hidden_np.shape)}  "
+        f"dense {tuple(dense_np.shape)}  sparse {tuple(sparse_np.shape)}  "
+        f"colbert {tuple(colbert_np.shape)}  ({HUB})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_bgem3_reranker.py
+++ b/scripts/convert_bgem3_reranker.py
@@ -1,0 +1,90 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "numpy", "safetensors", "transformers", "huggingface_hub"]
+# ///
+"""Generate BGE-reranker-v2-m3 parity fixtures for the Rust `svod-model` port.
+
+Downloads `BAAI/bge-reranker-v2-m3`, runs the cross-encoder on a fixed
+query-passage pair, and dumps a `golden_reranker.safetensors` storing:
+
+  - `input_ids`          (T,)  int64 — the exact token ids (query+passage pair)
+  - `attention_mask`     (T,)  int64 — 1=real, 0=pad
+  - `input_ids_shape`    (2,)  int64 — (batch, seq_len)
+  - `logits`             (B, 1) f32 — raw cross-encoder logits
+  - `normalized_scores`  (B, 1) f32 — sigmoid(logits)
+
+Usage:
+  uv run scripts/convert_bgem3_reranker.py
+  uv run scripts/convert_bgem3_reranker.py --out path/to/golden_reranker.safetensors
+
+Run the Rust parity test with the local fixture:
+  SVOD_BGEM3=$PWD/data/bgem3 \
+      cargo test -p svod-model --lib bgem3::parity::reranker -- --ignored
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors.numpy import save_file
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+HUB = "BAAI/bge-reranker-v2-m3"
+DEFAULT_QUERY = "What is BGE-M3?"
+DEFAULT_PASSAGE = "BGE-M3 is an embedding model supporting dense retrieval, lexical matching and multi-vector interaction."
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--query", default=DEFAULT_QUERY)
+    p.add_argument("--passage", default=DEFAULT_PASSAGE)
+    p.add_argument("--out", type=Path, default=None)
+    p.add_argument("--max-length", type=int, default=64)
+    args = p.parse_args()
+
+    out = args.out or (Path(__file__).resolve().parent.parent / "data" / "bgem3" / "golden_reranker.safetensors")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    tok = AutoTokenizer.from_pretrained(HUB)
+    model = AutoModelForSequenceClassification.from_pretrained(HUB, torch_dtype=torch.float32)
+    model.eval()
+
+    # Tokenize as a query-passage pair (cross-encoder convention).
+    enc = tok(
+        args.query,
+        args.passage,
+        return_tensors="pt",
+        padding="max_length",
+        max_length=args.max_length,
+        truncation=True,
+    )
+    input_ids = enc["input_ids"]  # (1, T)
+    attn = enc["attention_mask"]  # (1, T)
+
+    with torch.no_grad():
+        logits = model(input_ids=input_ids, attention_mask=attn).logits  # (1, 1)
+        scores = torch.sigmoid(logits)
+
+    ids_np = input_ids.squeeze(0).to(torch.int64).numpy()
+    attn_np = attn.squeeze(0).to(torch.int64).numpy()
+    logits_np = logits.squeeze(0).to(torch.float32).numpy()  # (1,)
+    scores_np = scores.squeeze(0).to(torch.float32).numpy()
+    shape_np = np.array(input_ids.shape, dtype=np.int64)
+
+    save_file(
+        {
+            "input_ids": ids_np,
+            "attention_mask": attn_np,
+            "input_ids_shape": shape_np,
+            "logits": logits_np,
+            "normalized_scores": scores_np,
+        },
+        str(out),
+    )
+    print(f"wrote {out}")
+    print(f"  input_ids {tuple(ids_np.shape)}  logits {tuple(logits_np.shape)}  ({HUB})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_qwen3.py
+++ b/scripts/convert_qwen3.py
@@ -1,0 +1,73 @@
+# /// script
+# dependencies = ["torch", "numpy", "safetensors", "transformers"]
+# requires-python = ">=3.10"
+# ///
+"""Generate golden parity fixtures for Qwen3-Embedding-0.6B."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from safetensors.numpy import save_file
+from transformers import AutoModel, AutoTokenizer
+
+MODEL_ID = "Qwen/Qwen3-Embedding-0.6B"
+PROMPT = "What is Qwen3?"
+MAX_LEN = 32
+
+
+def main():
+    local = Path(__file__).resolve().parent.parent / "submodules" / "Qwen3-Embedding-0.6B"
+    model_path = str(local) if local.exists() else MODEL_ID
+
+    print(f"Loading {model_path} ...")
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    model = AutoModel.from_pretrained(model_path, torch_dtype=torch.float32)
+    model.eval()
+
+    # Left-padding so last token = position L-1.
+    tokenizer.padding_side = "left"
+    enc = tokenizer(
+        PROMPT,
+        padding="max_length",
+        max_length=MAX_LEN,
+        truncation=True,
+        return_tensors="pt",
+    )
+    input_ids = enc["input_ids"]
+    attention_mask = enc["attention_mask"]
+    print(f"input_ids shape: {tuple(input_ids.shape)}")
+    print(f"attention_mask shape: {tuple(attention_mask.shape)}")
+
+    with torch.no_grad():
+        out = model(input_ids=input_ids, attention_mask=attention_mask)
+        last_hidden_state = out.last_hidden_state  # (1, 32, 1024)
+
+        # Last-token pooling (left-padded → last position is the real last token)
+        pooled = last_hidden_state[:, -1, :]  # (1, 1024)
+        embeddings = F.normalize(pooled, p=2, dim=-1)  # (1, 1024)
+
+    print(f"last_hidden_state shape: {tuple(last_hidden_state.shape)}")
+    print(f"embeddings shape: {tuple(embeddings.shape)}")
+
+    out_dir = Path(__file__).resolve().parent.parent / "data" / "qwen3"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "golden.safetensors"
+
+    save_file(
+        {
+            "input_ids": input_ids.numpy().astype(np.int64).flatten(),
+            "attention_mask": attention_mask.numpy().astype(np.int64).flatten(),
+            "input_ids_shape": np.array([1, MAX_LEN], dtype=np.int64),
+            "last_hidden_state": last_hidden_state.numpy().astype(np.float32),
+            "embeddings": embeddings.numpy().astype(np.float32),
+        },
+        str(out_path),
+    )
+    print(f"Saved golden to {out_path}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/convert_qwen3_reranker.py
+++ b/scripts/convert_qwen3_reranker.py
@@ -1,0 +1,83 @@
+# /// script
+# dependencies = ["torch", "numpy", "safetensors", "transformers"]
+# requires-python = ">=3.10"
+# ///
+"""Generate golden parity fixtures for Qwen3-Reranker-0.6B."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors.numpy import save_file
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MODEL_ID = "Qwen/Qwen3-Reranker-0.6B"
+QUERY = "What is Qwen3?"
+PASSAGE = "Qwen3 is a large language model series developed by Qwen team."
+MAX_LEN = 32
+
+
+def last_logit_pool(logits, attention_mask):
+    left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
+    if left_padding:
+        return logits[:, -1, :]
+    else:
+        seq_lens = attention_mask.sum(dim=1) - 1
+        return torch.stack([logits[i, seq_lens[i]] for i in range(logits.shape[0])])
+
+
+def main():
+    emb_local = Path(__file__).resolve().parent.parent / "submodules" / "Qwen3-Embedding-0.6B"
+    tokenizer = AutoTokenizer.from_pretrained(str(emb_local))
+
+    reranker_local = Path(__file__).resolve().parent.parent / "submodules" / "Qwen3-Reranker-0.6B"
+    model_path = str(reranker_local) if reranker_local.exists() else MODEL_ID
+
+    print(f"Loading {model_path} ...")
+    model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.float32)
+    model.eval()
+
+    tokenizer.padding_side = "left"
+    prefix = "<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n<|im_start|>user\n"
+    suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+    prompt = (
+        f"{prefix}<Instruct>: {''}\n<Query>: {QUERY}\n<Document>: {PASSAGE}{suffix}"
+    )
+    enc = tokenizer(prompt, padding="max_length", max_length=MAX_LEN, truncation=True, return_tensors="pt")
+    input_ids = enc["input_ids"]
+    attention_mask = enc["attention_mask"]
+    print(f"input_ids shape: {tuple(input_ids.shape)}")
+
+    yes_loc = tokenizer("Yes", add_special_tokens=False)["input_ids"][0]
+    print(f"yes_loc: {yes_loc}")
+
+    with torch.no_grad():
+        out = model(input_ids=input_ids, attention_mask=attention_mask)
+        logits = out.logits
+        pooled = last_logit_pool(logits, attention_mask)
+        scores = pooled[:, yes_loc]
+        normalized = torch.sigmoid(scores.float())
+
+    print(f"scores shape: {tuple(scores.shape)}")
+    print(f"score: {normalized.item():.6f}")
+
+    out_dir = Path(__file__).resolve().parent.parent / "data" / "qwen3"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "golden_reranker.safetensors"
+
+    save_file(
+        {
+            "input_ids": input_ids.numpy().astype(np.int64).flatten(),
+            "attention_mask": attention_mask.numpy().astype(np.int64).flatten(),
+            "input_ids_shape": np.array([1, MAX_LEN], dtype=np.int64),
+            "scores": normalized.numpy().astype(np.float32),
+        },
+        str(out_path),
+    )
+    print(f"Saved golden to {out_path}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replace modernbert_base() / modernbert_large() factory functions with ModernBertConfig::default(). The factories were redundant — from_hub already parses config.json and merge_structural_from overwrites every structural field, so the hardcoded dims served no purpose. Tests now use ..ModernBertConfig::default() with explicit test-specific fields.