### PR TITLE
model: YOLO v26 — all 9 task variants + symbolic-batch fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -134,13 +134,13 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -198,8 +198,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -218,8 +218,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -245,9 +245,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
@@ -283,7 +283,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -294,9 +294,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -306,9 +306,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -347,14 +347,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -374,9 +374,20 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -417,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -428,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -438,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -450,14 +461,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -510,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -638,6 +649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -693,18 +713,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -761,7 +781,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -774,7 +794,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -785,7 +805,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -796,14 +816,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -814,9 +834,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_arbitrary"
@@ -826,7 +843,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -848,7 +865,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -907,13 +924,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -936,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -981,15 +998,15 @@ checksum = "2e1f6c3800b304a6be0012039e2a45a322a093539c45ab818d9e6895a39c90fe"
 dependencies = [
  "proc-macro2",
  "quote",
- "rand 0.8.6",
+ "rand 0.8.7",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.13"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
 dependencies = [
  "enumset_derive",
 ]
@@ -1003,7 +1020,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1024,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1117,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1132,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1142,15 +1159,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1159,38 +1176,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1242,37 +1259,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1371,11 +1387,11 @@ dependencies = [
  "log",
  "native-tls",
  "num_cpus",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "ureq",
  "windows-sys 0.61.2",
@@ -1398,9 +1414,9 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1408,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1418,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1437,9 +1453,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1596,12 +1612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,15 +1646,13 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1715,23 +1723,22 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1759,22 +1766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libffi"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0498fe5655f857803e156523e644dcdcdc3b3c7edda42ea2afdae2e09b2db87b"
+checksum = "ed185dbb87539a100c1b36c219e16e71572c6d4d4fed3ded898140f755adeaaf"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -1782,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d4f1d4ce15091955144350b75db16a96d4a63728500122706fb4d29a26afbb"
+checksum = "25831b230b6a90bdea9f28339c1d00d59773a1c492e8ca09b1ad80e56394c261"
 dependencies = [
  "cc",
 ]
@@ -1807,9 +1808,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1843,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1864,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -1893,22 +1894,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tblgen",
  "unindent",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1937,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2013,7 +2014,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2054,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2088,11 +2089,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2156,11 +2156,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2176,7 +2176,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2187,9 +2187,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2342,9 +2342,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2362,25 +2362,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -2485,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2529,7 +2528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2543,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2558,9 +2557,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2577,14 +2576,14 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2592,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -2605,28 +2604,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -2667,9 +2666,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2679,7 +2678,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -2687,20 +2686,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2708,23 +2708,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2743,9 +2743,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2754,12 +2754,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2798,6 +2809,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2859,7 +2885,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2881,14 +2907,14 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2898,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2909,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repugnant-pickle"
@@ -2995,7 +3021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "serde",
  "serde_derive",
 ]
@@ -3012,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3045,7 +3071,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3054,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -3069,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3090,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3114,9 +3140,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -3162,7 +3188,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3197,9 +3223,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3217,29 +3243,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3271,12 +3297,12 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3287,7 +3313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3307,10 +3333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "siphasher"
@@ -3342,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -3360,11 +3392,11 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
- "snafu-derive 0.9.0",
+ "snafu-derive 0.9.2",
 ]
 
 [[package]]
@@ -3376,26 +3408,26 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3457,7 +3489,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3469,7 +3501,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3485,7 +3517,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "snafu 0.9.0",
+ "snafu 0.9.2",
  "svod-runtime",
  "test-case",
 ]
@@ -3575,7 +3607,7 @@ dependencies = [
  "convert_case 0.10.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3597,7 +3629,7 @@ dependencies = [
  "safetensors",
  "serde",
  "serde_json",
- "snafu 0.9.0",
+ "snafu 0.9.2",
  "svod-arch",
  "svod-device",
  "svod-dtype",
@@ -3626,7 +3658,7 @@ dependencies = [
  "prost",
  "prost-build",
  "smallvec",
- "snafu 0.9.0",
+ "snafu 0.9.2",
  "svod-dtype",
  "svod-ir",
  "svod-runtime",
@@ -3744,9 +3776,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3770,7 +3813,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3779,7 +3822,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3803,7 +3846,7 @@ dependencies = [
  "bindgen 0.72.1",
  "cc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3813,7 +3856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3837,7 +3880,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3848,7 +3891,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "test-case-core",
 ]
 
@@ -3863,11 +3906,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -3878,37 +3921,36 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3918,15 +3960,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3972,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3987,9 +4029,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4002,13 +4044,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4033,13 +4075,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4106,7 +4149,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -4149,7 +4192,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4228,9 +4271,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -4261,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4415,27 +4458,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4446,9 +4480,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4456,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4466,46 +4500,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4522,22 +4534,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4555,27 +4555,27 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "wide"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -4667,15 +4667,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4707,28 +4698,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4744,12 +4718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,12 +4728,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4780,22 +4742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4810,12 +4760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4826,12 +4770,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4846,12 +4784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4864,12 +4796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4880,97 +4806,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4980,9 +4818,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yaml-rust2"
@@ -4997,9 +4835,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5014,7 +4852,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5042,22 +4880,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5077,15 +4915,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -5117,7 +4955,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5156,15 +4994,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/device/examples/am_sdma.rs
+++ b/device/examples/am_sdma.rs
@@ -65,7 +65,7 @@ fn main() {
     // Sanity: does a CPU BAR0 write even round-trip at this paddr?
     let mut echo = vec![0u8; 16];
     dev.vram_read(src_pa, &mut echo);
-    println!("src BAR0 write→read roundtrip: {:?} (want {:?})", &echo, &pattern[..16]);
+    println!("src BAR0 write→read roundtrip: {:?} (want {:?})", echo, &pattern[..16]);
 
     // Build the command stream: copy src→dst, then fence a sentinel to rptr+64.
     let done_va = rptr.va_addr + 64;

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1780532242,
-        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "lastModified": 1785541369,
+        "narHash": "sha256-6VCYI5xashcnAR1lambqt9FGh0F6kYhg1P2Z0VDlr48=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "rev": "508ff4829aefddee8ea62291e86b144b58365724",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780925806,
-        "narHash": "sha256-VHDhcCRPix1FlJpC/d3SSyb+QNLQLPDe1vcLdzIXqL0=",
+        "lastModified": 1785607648,
+        "narHash": "sha256-Q8nQO2uIdlFSBtFiDyIWL2J6j4/9HjtUkBs/Pc4SK4Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ffe438e12d4a6643dcde460affbe82af0daa69c6",
+        "rev": "66c81c6cc50be21236d2fc902503203499132d7c",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780888890,
-        "narHash": "sha256-MUQPFiskEENaJ2N82TRIqpKlHXGXJJkPfKH6W788oQo=",
+        "lastModified": 1785562362,
+        "narHash": "sha256-J15aBa3d6B1SUUAQydQ06wFjPzrrcVceb6jkdfwfGls=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7d5f8d75fc195a236b46633d7679139698aeb35f",
+        "rev": "5f29c219a7655519f8a9f8c6968064b82c17cc93",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
         "type": "github"
       },
       "original": {

--- a/ir/src/shape.rs
+++ b/ir/src/shape.rs
@@ -228,17 +228,17 @@ pub fn broadcast_shape(lhs: &Shape, rhs: &Shape) -> Result<Shape> {
         if l == r {
             // Same dimension (concrete value or symbolic expression)
             result.push(l.clone());
-        } else if let (Some(lv), Some(rv)) = (l.as_const(), r.as_const()) {
-            // Both concrete - apply broadcast rule
-            if lv == 1 {
-                result.push(r.clone());
-            } else if rv == 1 || lv == rv {
-                result.push(l.clone());
-            } else {
-                return BroadcastShapeMismatchSnafu { lhs: lhs.clone(), rhs: rhs.clone() }.fail();
-            }
+        } else if l.as_const() == Some(1) {
+            // NumPy broadcasting: size-1 dim expands to the other
+            result.push(r.clone());
+        } else if r.as_const() == Some(1) {
+            // NumPy broadcasting: size-1 dim expands to the other
+            result.push(l.clone());
+        } else if l.as_const().is_some() && r.as_const().is_some() {
+            // Both concrete, non-1, and not equal → error
+            return BroadcastShapeMismatchSnafu { lhs: lhs.clone(), rhs: rhs.clone() }.fail();
         } else {
-            // At least one is symbolic - use max (conservatively)
+            // At least one is symbolic (non-1) - use max (conservatively)
             result.push(crate::sint_max(&[l.clone(), r.clone()]));
         }
     }

--- a/ir/src/sint.rs
+++ b/ir/src/sint.rs
@@ -270,6 +270,8 @@ macro_rules! impl_sint_binop {
                         panic!("arithmetic on SInt::Infer — resolve -1 before computing")
                     }
                     (SInt::Const(a), SInt::Const(b)) => SInt::Const(a $concrete_op b),
+                    (_, SInt::Const(0)) => self.clone(),
+                    (SInt::Const(0), _) => rhs.clone(),
                     _ => {
                         let a = self.to_uop(svod_dtype::DType::Index);
                         let b = rhs.to_uop(svod_dtype::DType::Index);

--- a/model/README.md
+++ b/model/README.md
@@ -33,6 +33,7 @@ plans.
 | Qwen3-Reranker-0.6B | Cross-encoder reranking | `qwen3` | [Qwen team](https://huggingface.co/Qwen) (Qwen3 LLM) | [`Qwen/Qwen3-Reranker-0.6B`](https://huggingface.co/Qwen/Qwen3-Reranker-0.6B) |
 | ResNet (18 / 34 / 50 / 101 / 152) | Vision | `resnet` | [He et al. 2015](https://arxiv.org/abs/1512.03385) | [`timm/resnet*.a1_in1k`](https://huggingface.co/timm) |
 | WeSpeaker ResNet34 | Speaker embedding | `wespeaker` | [wenet-e2e/wespeaker](https://github.com/wenet-e2e/wespeaker) | [`pyannote/wespeaker-voxceleb-resnet34-LM`](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM) |
+| YOLO v26 (detect / cls / seg / obb / pose / depth / semseg) | Vision | `yolo` | [Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26) | [`ultralytics/yolo26n`](https://huggingface.co/ultralytics/yolo26n) |
 
 ## Examples
 
@@ -42,4 +43,6 @@ cargo run -p svod-model --release --example vad_bench -- audio.wav            # 
 cargo run -p svod-model --release --example vad_stream -- audio.wav           # streaming VAD events (simulated mic)
 cargo run -p svod-model --release --example resnet_classify -- --hub --image dog.bin --side 224
 cargo run -p svod-model --release --example wespeaker_parity -- --hub --data reference.npz
+cargo run -p svod-model --release --example yolo_detect -- --hub
+cargo run -p svod-model --release --example yolo_detect -- --hub --scale small --image photo.bin --side 640
 ```

--- a/model/examples/yolo_detect.rs
+++ b/model/examples/yolo_detect.rs
@@ -1,0 +1,198 @@
+//! YOLO v26 object detection — load pretrained weights from HuggingFace,
+//! run JIT-compiled inference, and print detected objects.
+//!
+//! ```text
+//! # Download weights from HF and run on a synthetic image:
+//! cargo run -p svod-model --release --example yolo_detect -- --hub
+//!
+//! # Run on a raw NCHW f32 .bin image (1×3×H×W, normalized 0–1):
+//! cargo run -p svod-model --release --example yolo_detect -- --hub --image photo.bin --side 640
+//!
+//! # Use a specific scale:
+//! cargo run -p svod-model --release --example yolo_detect -- --hub --scale small
+//! ```
+
+use std::path::PathBuf;
+
+use bytemuck::cast_slice;
+use clap::{Parser, ValueEnum};
+use svod_dtype::DType;
+use svod_model::jit::InputSpec;
+use svod_model::yolo::{Yolo26Detect, Yolo26DetectJit, YoloConfig, YoloScale, postprocess_raw};
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum ScaleArg {
+    Nano,
+    Small,
+    Medium,
+    Large,
+    Xlarge,
+}
+
+impl From<ScaleArg> for YoloScale {
+    fn from(arg: ScaleArg) -> Self {
+        match arg {
+            ScaleArg::Nano => YoloScale::Nano,
+            ScaleArg::Small => YoloScale::Small,
+            ScaleArg::Medium => YoloScale::Medium,
+            ScaleArg::Large => YoloScale::Large,
+            ScaleArg::Xlarge => YoloScale::XLarge,
+        }
+    }
+}
+
+impl ScaleArg {
+    fn hub_id(self) -> &'static str {
+        match self {
+            ScaleArg::Nano => "ultralytics/yolo26n",
+            ScaleArg::Small => "ultralytics/yolo26s",
+            ScaleArg::Medium => "ultralytics/yolo26m",
+            ScaleArg::Large => "ultralytics/yolo26l",
+            ScaleArg::Xlarge => "ultralytics/yolo26x",
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "YOLO v26 object detection inference", long_about = None)]
+struct Args {
+    /// Load pretrained weights from HuggingFace Hub.
+    #[arg(long)]
+    hub: bool,
+
+    /// Use zero weights (no download — for testing graph construction).
+    #[arg(long)]
+    zero: bool,
+
+    /// HuggingFace model id override (e.g. "ultralytics/yolo26n").
+    #[arg(long)]
+    hf_id: Option<String>,
+
+    /// Model scale.
+    #[arg(long, value_enum, default_value_t = ScaleArg::Nano)]
+    scale: ScaleArg,
+
+    /// Number of object classes.
+    #[arg(long, default_value_t = 80)]
+    classes: usize,
+
+    /// Square image side length in pixels.
+    #[arg(long, default_value_t = 640)]
+    side: usize,
+
+    /// Maximum number of detections to return.
+    #[arg(long, default_value_t = 300)]
+    max_det: usize,
+
+    /// Path to a raw NCHW f32 .bin file (1×3×side×side). If omitted, a
+    /// deterministic pattern is generated so the example runs with no assets.
+    #[arg(long)]
+    image: Option<PathBuf>,
+}
+
+/// Load a raw f32 NCHW .bin image, or synthesize a deterministic gradient.
+fn load_input(args: &Args) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+    let side = args.side;
+    let n = 3 * side * side;
+    if let Some(ref path) = args.image {
+        let bytes = std::fs::read(path)?;
+        let expected = n * std::mem::size_of::<f32>();
+        if bytes.len() != expected {
+            return Err(format!("expected {} bytes ({} floats), got {}", expected, n, bytes.len()).into());
+        }
+        Ok(cast_slice::<u8, f32>(&bytes).to_vec())
+    } else {
+        // Deterministic gradient pattern.
+        let mut img = vec![0.0f32; n];
+        for c in 0..3usize {
+            for h in 0..side {
+                for w in 0..side {
+                    img[c * side * side + h * side + w] = ((h + w + c * 213) as f32) / ((side + side + 3 * 213) as f32);
+                }
+            }
+        }
+        Ok(img)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let scale: YoloScale = args.scale.into();
+    let cfg = YoloConfig::new(scale, args.classes);
+
+    let model = if args.zero {
+        eprintln!("using zero weights (no download)");
+        Yolo26Detect::with_zero_weights(cfg)
+    } else if args.hub || args.hf_id.is_some() {
+        let id = args.hf_id.as_deref().unwrap_or_else(|| args.scale.hub_id());
+        eprintln!("downloading weights from {id} ...");
+        Yolo26Detect::from_hub(id, cfg)?
+    } else {
+        eprintln!("no --hub or --zero given; defaulting to zero weights");
+        Yolo26Detect::with_zero_weights(cfg)
+    };
+
+    let input = load_input(&args)?;
+    let side = args.side;
+
+    // --- JIT: compile once, run many -------------------------------------
+    // `prepare` bakes the image size (H, W) into the execution plan. The
+    // batch dimension is a symbolic variable bound at runtime via
+    // `execute_with_vars`, so the same plan handles any batch ≤ max_batch_size.
+    let mut jit = Yolo26DetectJit::new(model);
+    jit.prepare(InputSpec::new(&[1, 3, side, side], DType::Float32))?;
+
+    // Copy the NCHW image into the JIT-managed input buffer.
+    jit.images_mut()?.copyin(cast_slice(&input))?;
+
+    // Execute with batch = 1.
+    let t0 = std::time::Instant::now();
+    jit.execute_with_vars(&[("b", 1)])?;
+    let elapsed = t0.elapsed();
+
+    // --- Read output -----------------------------------------------------
+    // `output()` returns the JIT plan's output buffer. `as_array` gives a
+    // typed ndarray view in one call; `as_slice` gets the flat f32 data.
+    let out = jit.output()?;
+    let arr = out.as_array::<f32>()?;
+    let buf_shape = arr.shape();
+    let data = arr.as_slice().expect("contiguous output");
+
+    // Output: [1, 4+nc, A] — decoded xyxy boxes + sigmoid'd class scores.
+    // The JIT output buffer may be flattened; derive logical shape if needed.
+    let out_ch = 4 + args.classes;
+    let shape: Vec<usize> =
+        if buf_shape.len() == 3 { buf_shape.to_vec() } else { vec![1, out_ch, data.len() / out_ch] };
+
+    let detections = postprocess_raw(data, &shape, args.classes, args.max_det)?;
+    let dets = &detections[0];
+
+    // --- Print results ---------------------------------------------------
+    println!();
+    println!(" detections: {}", dets.len());
+    if !dets.is_empty() {
+        println!("  {:<5}  {:<8}  {:>10}  {:>10}  {:>10}  {:>10}  conf", "rank", "class", "x1", "y1", "x2", "y2");
+        for (i, d) in dets.iter().enumerate() {
+            let [x1, y1, x2, y2, conf, class] = *d;
+            println!(
+                "  {:<5}  {:<8}  {:>10.1}  {:>10.1}  {:>10.1}  {:>10.1}  {:.4}",
+                i + 1,
+                class as usize,
+                x1,
+                y1,
+                x2,
+                y2,
+                conf
+            );
+        }
+    }
+
+    let anchors = shape[2];
+    println!();
+    println!("  inference: {:.2} ms", elapsed.as_secs_f64() * 1e3);
+    println!("  image:     {}×{}", side, side);
+    println!("  anchors:   {}", anchors);
+
+    Ok(())
+}

--- a/model/src/blocks/conv.rs
+++ b/model/src/blocks/conv.rs
@@ -24,6 +24,22 @@ impl Conv2dWeights {
         Self { weight, stride, padding, groups: 1 }
     }
 
+    /// Like [`empty`](Self::empty) but with grouped convolution. Weight shape
+    /// is `[out_ch, in_ch / groups, kernel, kernel]`.
+    pub fn empty_grouped(
+        out_ch: usize,
+        in_ch: usize,
+        kernel: usize,
+        stride: usize,
+        padding: usize,
+        groups: usize,
+    ) -> Self {
+        let cin_per_g = in_ch / groups;
+        let fan_in = cin_per_g * kernel * kernel;
+        let weight = fan_in_uniform(&[out_ch, cin_per_g, kernel, kernel], fan_in, DType::Float32);
+        Self { weight, stride, padding, groups }
+    }
+
     pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
         let p = self.padding as isize;
         x.conv2d()

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -15,6 +15,7 @@ pub mod state;
 pub mod wavlm;
 pub mod wespeaker;
 pub mod xlm_roberta;
+pub mod yolo;
 
 #[cfg(test)]
 mod test;

--- a/model/src/test/unit/mod.rs
+++ b/model/src/test/unit/mod.rs
@@ -20,3 +20,4 @@ mod transcribe;
 mod wavlm;
 mod wespeaker;
 mod xlm_roberta;
+mod yolo;

--- a/model/src/test/unit/yolo/classify.rs
+++ b/model/src/test/unit/yolo/classify.rs
@@ -1,0 +1,36 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26Classify, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_cls() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 1000);
+    let model = Yolo26Classify::with_zero_weights(cfg.clone());
+
+    let sd = model.state_dict("");
+
+    for key in ["0.conv.weight", "9.cv1.conv.weight", "10.conv.conv.weight", "10.linear.weight", "10.linear.bias"] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+
+    let mut empty = Yolo26Classify::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_cls() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 1000);
+    let model = Yolo26Classify::with_zero_weights(cfg);
+
+    let images = Tensor::zeros(&[1, 3, 224, 224], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> =
+        out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).expect("concrete shape")).collect();
+
+    assert_eq!(shape, vec![1, 1000]);
+}

--- a/model/src/test/unit/yolo/config.rs
+++ b/model/src/test/unit/yolo/config.rs
@@ -1,0 +1,32 @@
+use crate::yolo::{YoloScale, make_depth, make_divisible, scale_channels};
+
+#[test]
+fn make_divisible_rounds_up_to_multiple_of_8() {
+    assert_eq!(make_divisible(16, 8), 16);
+    assert_eq!(make_divisible(17, 8), 24);
+    assert_eq!(make_divisible(64, 8), 64);
+}
+
+#[test]
+fn nano_scale_channels() {
+    let s = YoloScale::Nano;
+    assert_eq!(scale_channels(64, s), 16);
+    assert_eq!(scale_channels(128, s), 32);
+    assert_eq!(scale_channels(256, s), 64);
+    assert_eq!(scale_channels(512, s), 128);
+    assert_eq!(scale_channels(1024, s), 256);
+}
+
+#[test]
+fn depth_halves_repeats_for_nano() {
+    let s = YoloScale::Nano;
+    assert_eq!(make_depth(2, s), 1);
+    assert_eq!(make_depth(1, s), 1);
+}
+
+#[test]
+fn depth_preserved_for_large() {
+    let s = YoloScale::Large;
+    assert_eq!(make_depth(2, s), 2);
+    assert_eq!(make_depth(1, s), 1);
+}

--- a/model/src/test/unit/yolo/depth.rs
+++ b/model/src/test/unit/yolo/depth.rs
@@ -1,0 +1,31 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26Depth, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_depth() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 1);
+    let model = Yolo26Depth::with_zero_weights(cfg.clone());
+    let sd = model.state_dict("");
+    for key in
+        ["0.conv.weight", "23.proj.0.conv.weight", "23.head.0.conv.weight", "23.head.1.weight", "23.head.3.weight"]
+    {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+    let mut empty = Yolo26Depth::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_depth() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 1);
+    let model = Yolo26Depth::with_zero_weights(cfg);
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> = out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    assert_eq!(shape, vec![1, 1, 80, 80]);
+}

--- a/model/src/test/unit/yolo/detect_p2.rs
+++ b/model/src/test/unit/yolo/detect_p2.rs
@@ -1,0 +1,37 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26DetectP2, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_p2() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26DetectP2::with_zero_weights(cfg.clone());
+    let sd = model.state_dict("");
+    for key in [
+        "0.conv.weight",
+        "13.cv1.conv.weight",
+        "19.cv1.conv.weight",
+        "29.one2one_cv2.0.0.conv.weight",
+        "29.one2one_cv3.0.2.weight",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+    let mut empty = Yolo26DetectP2::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_p2() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26DetectP2::with_zero_weights(cfg);
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> = out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    // 4 + 80 = 84 channels
+    // P2: 80×80=6400, P3: 40×40=1600, P4: 20×20=400, P5: 10×10=100 → 8500 anchors
+    assert_eq!(shape, vec![1, 84, 8500]);
+}

--- a/model/src/test/unit/yolo/detect_p6.rs
+++ b/model/src/test/unit/yolo/detect_p6.rs
@@ -1,0 +1,38 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26DetectP6, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_p6() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26DetectP6::with_zero_weights(cfg.clone());
+    let sd = model.state_dict("");
+    for key in [
+        "0.conv.weight",
+        "9.conv.weight",
+        "12.cv1.conv.weight",
+        "15.cv1.conv.weight",
+        "31.one2one_cv2.0.0.conv.weight",
+        "31.one2one_cv3.0.2.weight",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+    let mut empty = Yolo26DetectP6::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_p6() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26DetectP6::with_zero_weights(cfg);
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> = out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    // 4 + 80 = 84 channels
+    // P3: 40×40=1600, P4: 20×20=400, P5: 10×10=100, P6: 5×5=25 → 2125 anchors
+    assert_eq!(shape, vec![1, 84, 2125]);
+}

--- a/model/src/test/unit/yolo/mod.rs
+++ b/model/src/test/unit/yolo/mod.rs
@@ -1,0 +1,10 @@
+mod classify;
+mod depth;
+mod detect_p2;
+mod detect_p6;
+mod model;
+mod obb;
+mod parity;
+mod pose;
+mod segment;
+mod semseg;

--- a/model/src/test/unit/yolo/model.rs
+++ b/model/src/test/unit/yolo/model.rs
@@ -1,0 +1,92 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26Detect, YoloConfig, YoloScale};
+
+/// State-dict round-trip: build a yolo26n, emit its state dict, verify
+/// representative keys exist (matching Ultralytics layout), then reload
+/// into a fresh instance.
+#[test]
+fn state_dict_round_trip_nano() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Detect::with_zero_weights(cfg.clone());
+
+    let sd = model.state_dict("");
+
+    for key in [
+        "0.conv.weight",
+        "0.bn.weight",
+        "2.cv1.conv.weight",
+        "2.cv2.conv.weight",
+        "2.m.0.cv1.conv.weight",
+        "2.m.0.cv2.conv.weight",
+        "9.cv1.conv.weight",
+        "9.cv2.conv.weight",
+        "10.cv1.conv.weight",
+        "10.cv2.conv.weight",
+        "10.m.0.attn.qkv.conv.weight",
+        "10.m.0.attn.proj.conv.weight",
+        "10.m.0.attn.pe.conv.weight",
+        "10.m.0.ffn.0.conv.weight",
+        "10.m.0.ffn.1.conv.weight",
+        "13.cv1.conv.weight",
+        "16.cv1.conv.weight",
+        "19.cv1.conv.weight",
+        "22.cv1.conv.weight",
+        "23.one2one_cv2.0.0.conv.weight",
+        "23.one2one_cv2.0.2.weight",
+        "23.one2one_cv2.0.2.bias",
+        "23.one2one_cv3.0.0.0.conv.weight",
+        "23.one2one_cv3.0.2.weight",
+        "23.one2one_cv3.0.2.bias",
+        "22.m.0.1.attn.qkv.conv.weight",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+
+    let mut empty = Yolo26Detect::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+/// Build the symbolic forward graph and check the output shape.
+/// Verifies symbolic batch `b` propagates through the full FPN+PAN DAG.
+#[test]
+fn forward_shape_nano() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Detect::with_zero_weights(cfg);
+
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> = out
+        .shape()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_const().or_else(|| s.vmax()).expect("concrete or symbolic-max shape"))
+        .collect();
+
+    // 320×320: P3=40×40, P4=20×20, P5=10×10 → A=2100; out=[1, 84, 2100]
+    assert_eq!(shape, vec![1, 84, 2100]);
+}
+
+/// Heavy: realize the full forward through zero weights.
+#[test]
+#[ignore = "heavy: full Yolo26n graph compile through the CPU backend"]
+fn forward_realize_nano() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Detect::with_zero_weights(cfg);
+
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+
+    let mut out = model.forward(&images, &b).unwrap();
+    out.realize().unwrap();
+
+    let shape: Vec<usize> =
+        out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).expect("concrete dim")).collect();
+    assert_eq!(shape, vec![1, 84, 2100]);
+}

--- a/model/src/test/unit/yolo/obb.rs
+++ b/model/src/test/unit/yolo/obb.rs
@@ -1,0 +1,36 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26Obb, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_obb() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Obb::with_zero_weights(cfg.clone());
+    let sd = model.state_dict("");
+    for key in [
+        "0.conv.weight",
+        "23.one2one_cv2.0.0.conv.weight",
+        "23.one2one_cv4.0.0.conv.weight",
+        "23.one2one_cv4.0.2.weight",
+        "23.one2one_cv4.0.2.bias",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+    let mut empty = Yolo26Obb::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_obb() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Obb::with_zero_weights(cfg);
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> = out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    // 4 + 80 + 1 = 85 channels, 2100 anchors
+    assert_eq!(shape, vec![1, 85, 2100]);
+}

--- a/model/src/test/unit/yolo/parity.rs
+++ b/model/src/test/unit/yolo/parity.rs
@@ -1,0 +1,75 @@
+//! Golden parity test — downloads real YOLO26n weights from HuggingFace,
+//! runs forward, and compares against a PyTorch reference output.
+//!
+//! ```text
+//! SVOD_YOLO=$PWD/data/yolo cargo test -p svod-model --lib yolo::parity -- --ignored
+//! ```
+
+use std::path::PathBuf;
+
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::StateDict;
+use crate::state::load_safetensors;
+use crate::yolo::{Yolo26Detect, YoloConfig, YoloScale};
+
+const HUB_REPO: &str = "ultralytics/yolo26n";
+
+fn resolve_file(name: &str) -> PathBuf {
+    if let Ok(dir) = std::env::var("SVOD_YOLO") {
+        let p = PathBuf::from(dir).join(name);
+        if p.exists() {
+            return p;
+        }
+    }
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../data/yolo").join(name);
+    if p.exists() {
+        return p;
+    }
+    let api = hf_hub::api::sync::Api::new().expect("HF Hub API");
+    let repo = hf_hub::Repo::with_revision(HUB_REPO.into(), hf_hub::RepoType::Model, "main".into());
+    api.repo(repo).get(name).unwrap_or_else(|_| panic!("download {name} from {HUB_REPO}"))
+}
+
+fn load_golden_vec<T: Clone + Default + svod_dtype::ext::HasDType>(sd: &StateDict, key: &str) -> Vec<T> {
+    let mut t = sd.get(key).unwrap_or_else(|| panic!("missing golden key: {key}")).clone();
+    t.realize().unwrap();
+    t.as_vec::<T>().unwrap()
+}
+
+fn load_golden_i64(sd: &StateDict, key: &str) -> Vec<i64> {
+    load_golden_vec(sd, key)
+}
+
+fn max_abs_delta(got: &[f32], want: &[f32]) -> f32 {
+    got.iter().zip(want).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max)
+}
+
+#[test]
+#[ignore = "heavy: real YOLO26n weights + PyTorch golden (local or HF Hub download)"]
+fn detect_output_matches_pytorch() {
+    let weights = resolve_file("model.safetensors");
+    let golden_path = resolve_file("golden.safetensors");
+
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Detect::from_safetensors(&weights, cfg).expect("load model");
+
+    let golden = load_safetensors(&golden_path).expect("load golden");
+
+    let image_shape = load_golden_i64(&golden, "images_shape");
+    let images_vec = load_golden_vec::<f32>(&golden, "images");
+    let images = Tensor::from_slice(&images_vec)
+        .try_reshape(image_shape.iter().map(|&d| d as isize).collect::<Vec<_>>())
+        .unwrap();
+
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let mut out = model.forward(&images, &b).expect("forward");
+    out.realize().unwrap();
+
+    let got = out.as_vec::<f32>().unwrap();
+    let want = load_golden_vec::<f32>(&golden, "output");
+    assert_eq!(got.len(), want.len(), "output length mismatch");
+    let delta = max_abs_delta(&got, &want);
+    assert!(delta < 1e-3, "max |delta| = {delta:.6} exceeds 1e-3");
+}

--- a/model/src/test/unit/yolo/pose.rs
+++ b/model/src/test/unit/yolo/pose.rs
@@ -1,0 +1,35 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26Pose, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_pose() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 1);
+    let model = Yolo26Pose::with_zero_weights(cfg.clone());
+    let sd = model.state_dict("");
+    for key in [
+        "0.conv.weight",
+        "23.one2one_cv4.0.0.conv.weight",
+        "23.one2one_cv4_kpts.0.weight",
+        "23.one2one_cv4_kpts.0.bias",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+    let mut empty = Yolo26Pose::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_pose() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 1);
+    let model = Yolo26Pose::with_zero_weights(cfg);
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> = out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    // 4 + 1 + 51 = 56 (boxes + cls + 17*3 keypoints), 2100 anchors
+    assert_eq!(shape, vec![1, 56, 2100]);
+}

--- a/model/src/test/unit/yolo/segment.rs
+++ b/model/src/test/unit/yolo/segment.rs
@@ -1,0 +1,39 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26Segment, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_segment() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Segment::with_zero_weights(cfg.clone());
+    let sd = model.state_dict("");
+    for key in [
+        "0.conv.weight",
+        "23.one2one_cv4.0.0.conv.weight",
+        "23.proto.cv1.conv.weight",
+        "23.proto.upsample.weight",
+        "23.proto.cv3.conv.weight",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+    let mut empty = Yolo26Segment::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_segment() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 80);
+    let model = Yolo26Segment::with_zero_weights(cfg);
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+    let (preds, protos) = model.forward(&images, &b).unwrap();
+    let ps: Vec<usize> = preds.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    // 4 + 80 + 32 = 116 channels, 2100 anchors
+    assert_eq!(ps, vec![1, 116, 2100]);
+    let prs: Vec<usize> = protos.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).unwrap()).collect();
+    // nm=32 protos at H/4=80, W/4=80
+    assert_eq!(prs, vec![1, 32, 80, 80]);
+}

--- a/model/src/test/unit/yolo/semseg.rs
+++ b/model/src/test/unit/yolo/semseg.rs
@@ -1,0 +1,45 @@
+use svod_dtype::DType;
+use svod_tensor::{Tensor, Variable};
+
+use crate::state::HasStateDict;
+use crate::yolo::{Yolo26SemSeg, YoloConfig, YoloScale};
+
+#[test]
+fn state_dict_round_trip_semseg() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 19);
+    let model = Yolo26SemSeg::with_zero_weights(cfg.clone());
+
+    let sd = model.state_dict("");
+
+    for key in [
+        "0.conv.weight",
+        "10.cv1.conv.weight",
+        "13.cv1.conv.weight",
+        "16.cv1.conv.weight",
+        "17.classifier.0.conv.weight",
+        "17.classifier.2.weight",
+        "17.classifier.2.bias",
+    ] {
+        assert!(sd.contains_key(key), "missing key: {key}");
+    }
+
+    let mut empty = Yolo26SemSeg::with_zero_weights(cfg);
+    empty.load_state_dict(&sd, "").expect("load round-trip");
+}
+
+#[test]
+fn forward_shape_semseg() {
+    let cfg = YoloConfig::new(YoloScale::Nano, 19);
+    let model = Yolo26SemSeg::with_zero_weights(cfg);
+
+    let images = Tensor::zeros(&[1, 3, 320, 320], DType::Float32).unwrap();
+    let var = Variable::new("b", 1, 1);
+    let b = var.bind(1).unwrap();
+
+    let out = model.forward(&images, &b).unwrap();
+    let shape: Vec<usize> =
+        out.shape().unwrap().iter().map(|s| s.as_const().or_else(|| s.vmax()).expect("concrete shape")).collect();
+
+    // 320×320 → P3 at stride 8 → 40×40, nc=19
+    assert_eq!(shape, vec![1, 19, 40, 40]);
+}

--- a/model/src/yolo/backbone/mod.rs
+++ b/model/src/yolo/backbone/mod.rs
@@ -1,0 +1,10 @@
+//! YOLO v26 backbone variants.
+//!
+//! - [`YoloBackbone`] / [`YoloBackboneCls`] — standard P3-P5 (layers 0-10)
+//! - [`YoloBackboneP6`] — deeper P3-P6 (layers 0-12)
+
+pub(crate) mod p6;
+pub(crate) mod standard;
+
+pub use p6::{YoloBackboneP6, p6_scaled_channels};
+pub use standard::{YoloBackbone, YoloBackboneCls, scaled_channels, upsample_nearest_2x};

--- a/model/src/yolo/backbone/p6.rs
+++ b/model/src/yolo/backbone/p6.rs
@@ -1,0 +1,121 @@
+//! [`YoloBackboneP6`] — YOLO v26-P6 backbone (layers 0–12).
+//!
+//! Deeper than the standard backbone: adds a P6/64 stage (Conv→C3k2) after
+//! P5/32, and P5 is narrowed to 768 channels. SPPF uses `shortcut=false`.
+
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use crate::yolo::blocks::attention::C2PSA;
+use crate::yolo::blocks::conv::YoloConv;
+use crate::yolo::blocks::csp::C3k2;
+use crate::yolo::blocks::sppf::Sppf;
+use crate::yolo::config::{YoloScale, make_depth, scale_channels};
+use crate::yolo::error::Result;
+
+/// P6 backbone channels after scaling: `[c0, c1, c2, c3, c5, c6]`.
+/// `c5 = scale_channels(768)` (P5), `c6 = scale_channels(1024)` (P6).
+pub fn p6_scaled_channels(scale: YoloScale) -> [usize; 6] {
+    let sc = |yaml_c| scale_channels(yaml_c, scale);
+    [sc(64), sc(128), sc(256), sc(512), sc(768), sc(1024)]
+}
+
+/// Full YOLO v26-P6 backbone (layers 0–12).
+///
+/// Forward returns four skip-connection outputs: `(l4, l6, l8, l12)`
+/// at strides 8, 16, 32, 64.
+#[derive(Clone)]
+pub struct YoloBackboneP6 {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+    pub c3k2_2: C3k2,
+    pub conv3: YoloConv,
+    pub c3k2_4: C3k2,
+    pub conv5: YoloConv,
+    pub c3k2_6: C3k2,
+    pub conv7: YoloConv,
+    pub c3k2_8: C3k2,
+    pub conv9: YoloConv,
+    pub c3k2_10: C3k2,
+    pub sppf11: Sppf,
+    pub c2psa12: C2PSA,
+}
+
+impl YoloBackboneP6 {
+    pub fn empty(scale: YoloScale) -> Self {
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let [c0, c1, c2, c3, c5, c6] = p6_scaled_channels(scale);
+        Self {
+            conv0: YoloConv::empty(3, c0, 3, 2, true),
+            conv1: YoloConv::empty(c0, c1, 3, 2, true),
+            c3k2_2: C3k2::empty(c1, c2, d(2), true, 0.25, false, false),
+            conv3: YoloConv::empty(c2, c2, 3, 2, true),
+            c3k2_4: C3k2::empty(c2, c3, d(2), true, 0.25, false, false),
+            conv5: YoloConv::empty(c3, c3, 3, 2, true),
+            c3k2_6: C3k2::empty(c3, c3, d(2), true, 0.5, true, false),
+            conv7: YoloConv::empty(c3, c5, 3, 2, true),
+            c3k2_8: C3k2::empty(c5, c5, d(2), true, 0.5, true, false),
+            conv9: YoloConv::empty(c5, c6, 3, 2, true),
+            c3k2_10: C3k2::empty(c6, c6, d(2), true, 0.5, true, false),
+            sppf11: Sppf::empty(c6, c6, 5, 3, false),
+            c2psa12: C2PSA::empty(c6, c6, d(2), 0.5),
+        }
+    }
+
+    /// Run backbone layers 0–12, returning `(l4, l6, l8, l12)`.
+    pub fn forward(&self, x: &Tensor) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        let x = self.c3k2_2.forward(&x)?;
+        let x = self.conv3.forward(&x)?;
+        let l4 = self.c3k2_4.forward(&x)?;
+        let x = self.conv5.forward(&l4)?;
+        let l6 = self.c3k2_6.forward(&x)?;
+        let x = self.conv7.forward(&l6)?;
+        let l8 = self.c3k2_8.forward(&x)?;
+        let x = self.conv9.forward(&l8)?;
+        let x = self.c3k2_10.forward(&x)?;
+        let x = self.sppf11.forward(&x)?;
+        let l12 = self.c2psa12.forward(&x)?;
+        Ok((l4, l6, l8, l12))
+    }
+}
+
+impl HasStateDict for YoloBackboneP6 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        let mut sd = self.conv0.state_dict(&p(0));
+        sd.extend(self.conv1.state_dict(&p(1)));
+        sd.extend(self.c3k2_2.state_dict(&p(2)));
+        sd.extend(self.conv3.state_dict(&p(3)));
+        sd.extend(self.c3k2_4.state_dict(&p(4)));
+        sd.extend(self.conv5.state_dict(&p(5)));
+        sd.extend(self.c3k2_6.state_dict(&p(6)));
+        sd.extend(self.conv7.state_dict(&p(7)));
+        sd.extend(self.c3k2_8.state_dict(&p(8)));
+        sd.extend(self.conv9.state_dict(&p(9)));
+        sd.extend(self.c3k2_10.state_dict(&p(10)));
+        sd.extend(self.sppf11.state_dict(&p(11)));
+        sd.extend(self.c2psa12.state_dict(&p(12)));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        self.conv0.load_state_dict(sd, &p(0))?;
+        self.conv1.load_state_dict(sd, &p(1))?;
+        self.c3k2_2.load_state_dict(sd, &p(2))?;
+        self.conv3.load_state_dict(sd, &p(3))?;
+        self.c3k2_4.load_state_dict(sd, &p(4))?;
+        self.conv5.load_state_dict(sd, &p(5))?;
+        self.c3k2_6.load_state_dict(sd, &p(6))?;
+        self.conv7.load_state_dict(sd, &p(7))?;
+        self.c3k2_8.load_state_dict(sd, &p(8))?;
+        self.conv9.load_state_dict(sd, &p(9))?;
+        self.c3k2_10.load_state_dict(sd, &p(10))?;
+        self.sppf11.load_state_dict(sd, &p(11))?;
+        self.c2psa12.load_state_dict(sd, &p(12))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/backbone/standard.rs
+++ b/model/src/yolo/backbone/standard.rs
@@ -1,0 +1,241 @@
+//! Shared YOLO v26 backbone (layers 0–10) and classification backbone
+//! (layers 0–9, no SPPF).
+//!
+//! The backbone produces three skip-connection feature maps (P3/8, P4/16,
+//! P5/32) consumed by detection-family and depth neck/head. The classify
+//! variant stops at the C2PSA layer (layer 9) and omits SPPF.
+
+use snafu::{OptionExt, ResultExt};
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use crate::yolo::blocks::attention::C2PSA;
+use crate::yolo::blocks::conv::YoloConv;
+use crate::yolo::blocks::csp::C3k2;
+use crate::yolo::blocks::sppf::Sppf;
+use crate::yolo::config::{YoloScale, make_depth, scale_channels};
+use crate::yolo::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// Backbone channels after scaling (used to construct neck/head).
+pub fn scaled_channels(scale: YoloScale) -> [usize; 5] {
+    let sc = |yaml_c| scale_channels(yaml_c, scale);
+    [sc(64), sc(128), sc(256), sc(512), sc(1024)]
+}
+
+/// Full YOLO v26 backbone (layers 0–10): Conv→Conv→C3k2→Conv→C3k2→Conv→
+/// C3k2→Conv→C3k2→SPPF→C2PSA.
+///
+/// Forward returns the three skip-connection outputs: `(l4, l6, l10)`.
+#[derive(Clone)]
+pub struct YoloBackbone {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+    pub c3k2_2: C3k2,
+    pub conv3: YoloConv,
+    pub c3k2_4: C3k2,
+    pub conv5: YoloConv,
+    pub c3k2_6: C3k2,
+    pub conv7: YoloConv,
+    pub c3k2_8: C3k2,
+    pub sppf9: Sppf,
+    pub c2psa10: C2PSA,
+}
+
+impl YoloBackbone {
+    pub fn empty(scale: YoloScale) -> Self {
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let [c0, c1, c2, c3, c4] = scaled_channels(scale);
+        Self {
+            conv0: YoloConv::empty(3, c0, 3, 2, true),
+            conv1: YoloConv::empty(c0, c1, 3, 2, true),
+            c3k2_2: C3k2::empty(c1, c2, d(2), true, 0.25, false, false),
+            conv3: YoloConv::empty(c2, c2, 3, 2, true),
+            c3k2_4: C3k2::empty(c2, c3, d(2), true, 0.25, false, false),
+            conv5: YoloConv::empty(c3, c3, 3, 2, true),
+            c3k2_6: C3k2::empty(c3, c3, d(2), true, 0.5, true, false),
+            conv7: YoloConv::empty(c3, c4, 3, 2, true),
+            c3k2_8: C3k2::empty(c4, c4, d(2), true, 0.5, true, false),
+            sppf9: Sppf::empty(c4, c4, 5, 3, true),
+            c2psa10: C2PSA::empty(c4, c4, d(2), 0.5),
+        }
+    }
+
+    /// Run backbone layers 0–10, returning skip features `(l4, l6, l10)`.
+    pub fn forward(&self, x: &Tensor) -> Result<(Tensor, Tensor, Tensor)> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        let x = self.c3k2_2.forward(&x)?;
+        let x = self.conv3.forward(&x)?;
+        let l4 = self.c3k2_4.forward(&x)?;
+        let x = self.conv5.forward(&l4)?;
+        let l6 = self.c3k2_6.forward(&x)?;
+        let x = self.conv7.forward(&l6)?;
+        let x = self.c3k2_8.forward(&x)?;
+        let x = self.sppf9.forward(&x)?;
+        let l10 = self.c2psa10.forward(&x)?;
+        Ok((l4, l6, l10))
+    }
+
+    /// Run backbone layers 0–10, returning four skip features `(l2, l4, l6, l10)`.
+    /// Used by the P2 variant neck which taps the P2/4 feature at layer 2.
+    pub fn forward_with_p2(&self, x: &Tensor) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        let l2 = self.c3k2_2.forward(&x)?;
+        let x = self.conv3.forward(&l2)?;
+        let l4 = self.c3k2_4.forward(&x)?;
+        let x = self.conv5.forward(&l4)?;
+        let l6 = self.c3k2_6.forward(&x)?;
+        let x = self.conv7.forward(&l6)?;
+        let x = self.c3k2_8.forward(&x)?;
+        let x = self.sppf9.forward(&x)?;
+        let l10 = self.c2psa10.forward(&x)?;
+        Ok((l2, l4, l6, l10))
+    }
+}
+
+impl HasStateDict for YoloBackbone {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        let mut sd = self.conv0.state_dict(&p(0));
+        sd.extend(self.conv1.state_dict(&p(1)));
+        sd.extend(self.c3k2_2.state_dict(&p(2)));
+        sd.extend(self.conv3.state_dict(&p(3)));
+        sd.extend(self.c3k2_4.state_dict(&p(4)));
+        sd.extend(self.conv5.state_dict(&p(5)));
+        sd.extend(self.c3k2_6.state_dict(&p(6)));
+        sd.extend(self.conv7.state_dict(&p(7)));
+        sd.extend(self.c3k2_8.state_dict(&p(8)));
+        sd.extend(self.sppf9.state_dict(&p(9)));
+        sd.extend(self.c2psa10.state_dict(&p(10)));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        self.conv0.load_state_dict(sd, &p(0))?;
+        self.conv1.load_state_dict(sd, &p(1))?;
+        self.c3k2_2.load_state_dict(sd, &p(2))?;
+        self.conv3.load_state_dict(sd, &p(3))?;
+        self.c3k2_4.load_state_dict(sd, &p(4))?;
+        self.conv5.load_state_dict(sd, &p(5))?;
+        self.c3k2_6.load_state_dict(sd, &p(6))?;
+        self.conv7.load_state_dict(sd, &p(7))?;
+        self.c3k2_8.load_state_dict(sd, &p(8))?;
+        self.sppf9.load_state_dict(sd, &p(9))?;
+        self.c2psa10.load_state_dict(sd, &p(10))?;
+        Ok(())
+    }
+}
+
+/// Classification backbone (layers 0–9): same as [`YoloBackbone`] but without
+/// SPPF (layer 9 is C2PSA, not SPPF). The classify YAML puts C2PSA at index 9.
+#[derive(Clone)]
+pub struct YoloBackboneCls {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+    pub c3k2_2: C3k2,
+    pub conv3: YoloConv,
+    pub c3k2_4: C3k2,
+    pub conv5: YoloConv,
+    pub c3k2_6: C3k2,
+    pub conv7: YoloConv,
+    pub c3k2_8: C3k2,
+    pub c2psa9: C2PSA,
+}
+
+impl YoloBackboneCls {
+    pub fn empty(scale: YoloScale) -> Self {
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let [c0, c1, c2, c3, c4] = scaled_channels(scale);
+        Self {
+            conv0: YoloConv::empty(3, c0, 3, 2, true),
+            conv1: YoloConv::empty(c0, c1, 3, 2, true),
+            c3k2_2: C3k2::empty(c1, c2, d(2), true, 0.25, false, false),
+            conv3: YoloConv::empty(c2, c2, 3, 2, true),
+            c3k2_4: C3k2::empty(c2, c3, d(2), true, 0.25, false, false),
+            conv5: YoloConv::empty(c3, c3, 3, 2, true),
+            c3k2_6: C3k2::empty(c3, c3, d(2), true, 0.5, true, false),
+            conv7: YoloConv::empty(c3, c4, 3, 2, true),
+            c3k2_8: C3k2::empty(c4, c4, d(2), true, 0.5, true, false),
+            c2psa9: C2PSA::empty(c4, c4, d(2), 0.5),
+        }
+    }
+
+    /// Run layers 0–9, returning the final feature map.
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        let x = self.c3k2_2.forward(&x)?;
+        let x = self.conv3.forward(&x)?;
+        let x = self.c3k2_4.forward(&x)?;
+        let x = self.conv5.forward(&x)?;
+        let x = self.c3k2_6.forward(&x)?;
+        let x = self.conv7.forward(&x)?;
+        let x = self.c3k2_8.forward(&x)?;
+        self.c2psa9.forward(&x)
+    }
+}
+
+impl HasStateDict for YoloBackboneCls {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        let mut sd = self.conv0.state_dict(&p(0));
+        sd.extend(self.conv1.state_dict(&p(1)));
+        sd.extend(self.c3k2_2.state_dict(&p(2)));
+        sd.extend(self.conv3.state_dict(&p(3)));
+        sd.extend(self.c3k2_4.state_dict(&p(4)));
+        sd.extend(self.conv5.state_dict(&p(5)));
+        sd.extend(self.c3k2_6.state_dict(&p(6)));
+        sd.extend(self.conv7.state_dict(&p(7)));
+        sd.extend(self.c3k2_8.state_dict(&p(8)));
+        sd.extend(self.c2psa9.state_dict(&p(9)));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        self.conv0.load_state_dict(sd, &p(0))?;
+        self.conv1.load_state_dict(sd, &p(1))?;
+        self.c3k2_2.load_state_dict(sd, &p(2))?;
+        self.conv3.load_state_dict(sd, &p(3))?;
+        self.c3k2_4.load_state_dict(sd, &p(4))?;
+        self.conv5.load_state_dict(sd, &p(5))?;
+        self.c3k2_6.load_state_dict(sd, &p(6))?;
+        self.conv7.load_state_dict(sd, &p(7))?;
+        self.c3k2_8.load_state_dict(sd, &p(8))?;
+        self.c2psa9.load_state_dict(sd, &p(9))?;
+        Ok(())
+    }
+}
+
+/// Nearest-neighbour 2× upsample via gather (tinygrad interpolate approach).
+pub fn upsample_nearest_2x(x: &Tensor) -> Result<Tensor> {
+    use svod_ir::SInt;
+    let shape = x.shape().context(TensorSnafu)?;
+    let b = shape[0].clone();
+    let c = shape[1].clone();
+    let h: usize = shape[2].as_const().context(SymbolicShapeSnafu { what: "upsample H" })?;
+    let w: usize = shape[3].as_const().context(SymbolicShapeSnafu { what: "upsample W" })?;
+
+    let h_idx: Vec<i64> = (0..h as i64).flat_map(|v| [v, v]).collect();
+    let w_idx: Vec<i64> = (0..w as i64).flat_map(|v| [v, v]).collect();
+
+    let h_index = Tensor::from_slice(&h_idx)
+        .try_reshape([SInt::from(1usize), SInt::from(1usize), SInt::from(h * 2), SInt::from(1usize)])
+        .context(TensorSnafu)?
+        .try_expand([b.clone(), c.clone(), SInt::from(h * 2), SInt::from(w)])
+        .context(TensorSnafu)?;
+    let x = x.gather(2, &h_index).context(TensorSnafu)?;
+
+    let shape = x.shape().context(TensorSnafu)?;
+    let b = shape[0].clone();
+    let c = shape[1].clone();
+    let w_index = Tensor::from_slice(&w_idx)
+        .try_reshape([SInt::from(1usize), SInt::from(1usize), SInt::from(1usize), SInt::from(w * 2)])
+        .context(TensorSnafu)?
+        .try_expand([b, c, SInt::from(h * 2), SInt::from(w * 2)])
+        .context(TensorSnafu)?;
+    x.gather(3, &w_index).context(TensorSnafu)
+}

--- a/model/src/yolo/blocks/attention.rs
+++ b/model/src/yolo/blocks/attention.rs
@@ -1,0 +1,226 @@
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::conv::YoloConv;
+use crate::yolo::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// Multi-head attention with a depthwise-conv positional encoding.
+///
+/// Computes full N×N attention but with a reduced key dimension
+/// (`key_dim = head_dim * attn_ratio`) to cut QK^T cost.
+/// All projections are 1×1 convs (no activation).
+///
+/// State-dict keys: `qkv.{conv,bn}.*`, `proj.{conv,bn}.*`, `pe.{conv,bn}.*`.
+#[derive(Clone)]
+pub struct Attention {
+    pub qkv: YoloConv,
+    pub proj: YoloConv,
+    pub pe: YoloConv,
+    pub num_heads: usize,
+    pub key_dim: usize,
+    pub head_dim: usize,
+    pub scale: f32,
+}
+
+impl Attention {
+    pub fn empty(dim: usize, num_heads: usize, attn_ratio: f64) -> Self {
+        let head_dim = dim / num_heads;
+        let key_dim = (head_dim as f64 * attn_ratio) as usize;
+        let scale = (key_dim as f64).powf(-0.5) as f32;
+        let nh_kd = key_dim * num_heads;
+        let qkv_out = dim + nh_kd * 2;
+
+        Self {
+            qkv: YoloConv::empty(dim, qkv_out, 1, 1, false),
+            proj: YoloConv::empty(dim, dim, 1, 1, false),
+            pe: YoloConv::empty_dw(dim, dim, 3, 1, false),
+            num_heads,
+            key_dim,
+            head_dim,
+            scale,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let shape = x.shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+        let nh = self.num_heads;
+        let kd = self.key_dim;
+        let hd = self.head_dim;
+        let kkd = kd * 2 + hd;
+
+        let h: usize = shape[2].as_const().context(SymbolicShapeSnafu { what: "yolo attention H" })?;
+        let w: usize = shape[3].as_const().context(SymbolicShapeSnafu { what: "yolo attention W" })?;
+        let hw = h * w;
+
+        // QKV 1×1 conv: [B, C, H, W] → [B, nh*kkd, H, W]
+        let qkv = self.qkv.forward(x)?;
+
+        // Flatten spatial then separate heads:
+        // [B, nh*kkd, H, W] → [B, nh*kkd, H*W] → [B, nh, kkd, N]
+        let qkv = qkv
+            .try_reshape([b.clone(), SInt::from(nh * kkd), SInt::from(hw)])
+            .context(TensorSnafu)?
+            .try_reshape([b.clone(), SInt::from(nh), SInt::from(kkd), SInt::from(hw)])
+            .context(TensorSnafu)?;
+
+        // Split into q [B,nh,kd,N], k [B,nh,kd,N], v [B,nh,hd,N]
+        let parts = qkv.split(&[kd, kd, hd], 2).context(TensorSnafu)?;
+        let q = &parts[0];
+        let k = &parts[1];
+        let v = &parts[2];
+
+        // Scale q
+        let scale_t = Tensor::from_slice([self.scale]);
+        let q = q.try_mul(&scale_t).context(TensorSnafu)?;
+
+        // attn = q^T @ k : [B, nh, N, kd] @ [B, nh, kd, N] = [B, nh, N, N]
+        let q_t = q.try_transpose(-2, -1).context(TensorSnafu)?;
+        let attn = q_t.matmul(k).context(TensorSnafu)?;
+        let attn = attn.softmax(-1).context(TensorSnafu)?;
+
+        // out = v @ attn^T : [B, nh, hd, N] @ [B, nh, N, N] = [B, nh, hd, N]
+        let attn_t = attn.try_transpose(-2, -1).context(TensorSnafu)?;
+        let out = v.matmul(&attn_t).context(TensorSnafu)?;
+
+        // Reshape back to spatial: [B, nh, hd, N] → [B, C, H, W]
+        let c = nh * hd;
+        let out = out
+            .try_reshape([b.clone(), SInt::from(c), SInt::from(hw)])
+            .context(TensorSnafu)?
+            .try_reshape([b.clone(), SInt::from(c), SInt::from(h), SInt::from(w)])
+            .context(TensorSnafu)?;
+
+        // Positional encoding: depthwise conv on v reshaped to spatial
+        let v_spatial = v
+            .try_reshape([b.clone(), SInt::from(c), SInt::from(hw)])
+            .context(TensorSnafu)?
+            .try_reshape([b.clone(), SInt::from(c), SInt::from(h), SInt::from(w)])
+            .context(TensorSnafu)?;
+        let pe = self.pe.forward(&v_spatial)?;
+
+        let out = out.try_add(&pe).context(TensorSnafu)?;
+
+        self.proj.forward(&out)
+    }
+}
+
+impl HasStateDict for Attention {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.qkv.state_dict(&prefixed(prefix, "qkv"));
+        sd.extend(self.proj.state_dict(&prefixed(prefix, "proj")));
+        sd.extend(self.pe.state_dict(&prefixed(prefix, "pe")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.qkv.load_state_dict(sd, &prefixed(prefix, "qkv"))?;
+        self.proj.load_state_dict(sd, &prefixed(prefix, "proj"))?;
+        self.pe.load_state_dict(sd, &prefixed(prefix, "pe"))?;
+        Ok(())
+    }
+}
+
+/// Position-Sensitive Attention block: attention + FFN, both with residual.
+///
+/// State-dict keys: `attn.*`, `ffn.0.{conv,bn}.*`, `ffn.1.{conv,bn}.*`.
+#[derive(Clone)]
+pub struct PSABlock {
+    pub attn: Attention,
+    pub ffn0: YoloConv,
+    pub ffn1: YoloConv,
+}
+
+impl PSABlock {
+    pub fn empty(c: usize, num_heads: usize) -> Self {
+        Self {
+            attn: Attention::empty(c, num_heads, 0.5),
+            ffn0: YoloConv::empty(c, c * 2, 1, 1, true),
+            ffn1: YoloConv::empty(c * 2, c, 1, 1, false),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let attn_out = self.attn.forward(x)?;
+        let x = x.try_add(&attn_out).context(TensorSnafu)?;
+        let ffn_out = self.ffn1.forward(&self.ffn0.forward(&x)?)?;
+        x.try_add(&ffn_out).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for PSABlock {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.attn.state_dict(&prefixed(prefix, "attn"));
+        sd.extend(self.ffn0.state_dict(&prefixed(prefix, "ffn.0")));
+        sd.extend(self.ffn1.state_dict(&prefixed(prefix, "ffn.1")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.attn.load_state_dict(sd, &prefixed(prefix, "attn"))?;
+        self.ffn0.load_state_dict(sd, &prefixed(prefix, "ffn.0"))?;
+        self.ffn1.load_state_dict(sd, &prefixed(prefix, "ffn.1"))?;
+        Ok(())
+    }
+}
+
+/// CSP with partial self-attention: split channels, run PSABlocks on half,
+/// concat, project back.
+///
+/// State-dict keys: `cv1.{conv,bn}.*`, `cv2.{conv,bn}.*`, `m.{i}.*`.
+#[derive(Clone)]
+pub struct C2PSA {
+    pub cv1: YoloConv,
+    pub cv2: YoloConv,
+    pub m: Vec<PSABlock>,
+    pub c_hidden: usize,
+}
+
+impl C2PSA {
+    pub fn empty(in_ch: usize, out_ch: usize, n: usize, e: f64) -> Self {
+        assert_eq!(in_ch, out_ch, "C2PSA requires c1 == c2");
+        let c_hidden = (out_ch as f64 * e) as usize;
+        let num_heads = (c_hidden / 64).max(1);
+        Self {
+            cv1: YoloConv::empty(in_ch, 2 * c_hidden, 1, 1, true),
+            cv2: YoloConv::empty(2 * c_hidden, out_ch, 1, 1, true),
+            m: (0..n).map(|_| PSABlock::empty(c_hidden, num_heads)).collect(),
+            c_hidden,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let y = self.cv1.forward(x)?;
+        let parts = y.split(&[self.c_hidden, self.c_hidden], 1).context(TensorSnafu)?;
+        let a = &parts[0];
+        let mut b = parts[1].clone();
+        for blk in &self.m {
+            b = blk.forward(&b)?;
+        }
+        let cat = Tensor::cat(&[a, &b], 1).context(TensorSnafu)?;
+        self.cv2.forward(&cat)
+    }
+}
+
+impl HasStateDict for C2PSA {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.cv1.state_dict(&prefixed(prefix, "cv1"));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        for (i, blk) in self.m.iter().enumerate() {
+            sd.extend(blk.state_dict(&prefixed(prefix, &format!("m.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        for (i, blk) in self.m.iter_mut().enumerate() {
+            blk.load_state_dict(sd, &prefixed(prefix, &format!("m.{i}")))?;
+        }
+        Ok(())
+    }
+}

--- a/model/src/yolo/blocks/bottleneck.rs
+++ b/model/src/yolo/blocks/bottleneck.rs
@@ -1,0 +1,50 @@
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::conv::YoloConv;
+use crate::yolo::error::{Result, TensorSnafu};
+
+/// Standard YOLO bottleneck: two Conv+BN+SiLU layers with optional residual.
+///
+/// State-dict keys: `cv1.{conv,bn}.*`, `cv2.{conv,bn}.*`.
+#[derive(Clone)]
+pub struct YoloBottleneck {
+    pub cv1: YoloConv,
+    pub cv2: YoloConv,
+    pub add: bool,
+}
+
+impl YoloBottleneck {
+    /// Default: `k=(3,3)`, `e=0.5`.
+    pub fn empty(in_ch: usize, out_ch: usize, shortcut: bool) -> Self {
+        Self::empty_full(in_ch, out_ch, shortcut, 3, 3, 0.5)
+    }
+
+    /// Full control: separate kernel sizes for cv1/cv2 and expansion ratio.
+    pub fn empty_full(in_ch: usize, out_ch: usize, shortcut: bool, k1: usize, k2: usize, e: f64) -> Self {
+        let c_ = (out_ch as f64 * e) as usize;
+        let add = shortcut && in_ch == out_ch;
+        Self { cv1: YoloConv::empty(in_ch, c_, k1, 1, true), cv2: YoloConv::empty(c_, out_ch, k2, 1, true), add }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let out = self.cv2.forward(&self.cv1.forward(x)?)?;
+        if self.add { out.try_add(x).context(TensorSnafu) } else { Ok(out) }
+    }
+}
+
+impl HasStateDict for YoloBottleneck {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.cv1.state_dict(&prefixed(prefix, "cv1"));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/blocks/conv.rs
+++ b/model/src/yolo/blocks/conv.rs
@@ -1,0 +1,160 @@
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use crate::yolo::error::{Result, TensorSnafu};
+
+fn gcd(a: usize, b: usize) -> usize {
+    if b == 0 { a } else { gcd(b, a % b) }
+}
+
+/// Conv2d(bias=False) + BatchNorm2d + SiLU — the universal YOLO building block.
+/// When `act` is `false` the activation is skipped (used by SPPF.cv1,
+/// Attention projections, and PSABlock FFN output conv).
+///
+/// State-dict keys: `conv.weight`, `bn.{weight,bias,running_mean,invstd}`.
+#[derive(Clone)]
+pub struct YoloConv {
+    pub conv: crate::blocks::Conv2dWeights,
+    pub bn: crate::blocks::BatchNormWeights,
+    pub act: bool,
+}
+
+impl YoloConv {
+    pub fn empty(in_ch: usize, out_ch: usize, kernel: usize, stride: usize, act: bool) -> Self {
+        let padding = kernel / 2;
+        Self {
+            conv: crate::blocks::Conv2dWeights::empty(out_ch, in_ch, kernel, stride, padding),
+            bn: crate::blocks::BatchNormWeights::empty(out_ch),
+            act,
+        }
+    }
+
+    /// Depthwise variant: `groups = gcd(in_ch, out_ch)`.
+    pub fn empty_dw(in_ch: usize, out_ch: usize, kernel: usize, stride: usize, act: bool) -> Self {
+        let groups = gcd(in_ch, out_ch);
+        let padding = kernel / 2;
+        Self {
+            conv: crate::blocks::Conv2dWeights::empty_grouped(out_ch, in_ch, kernel, stride, padding, groups),
+            bn: crate::blocks::BatchNormWeights::empty(out_ch),
+            act,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv.forward(x)?;
+        let x = self.bn.forward(&x)?;
+        if self.act { x.silu().context(TensorSnafu) } else { Ok(x) }
+    }
+}
+
+impl HasStateDict for YoloConv {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv.state_dict(&prefixed(prefix, "conv"));
+        sd.extend(self.bn.state_dict(&prefixed(prefix, "bn")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv.load_state_dict(sd, &prefixed(prefix, "conv"))?;
+        self.bn.load_state_dict(sd, &prefixed(prefix, "bn"))?;
+        Ok(())
+    }
+}
+
+/// Raw Conv2d with bias (no BN, no activation). Used by the Detect head's
+/// final 1×1 classification and box-regression layers.
+///
+/// State-dict keys: `weight`, `bias`.
+#[derive(Clone)]
+pub struct Conv2dBias {
+    pub weight: Tensor,
+    pub bias: Tensor,
+    pub stride: usize,
+    pub padding: usize,
+}
+
+impl Conv2dBias {
+    pub fn empty(in_ch: usize, out_ch: usize, kernel: usize, stride: usize) -> Self {
+        let padding = kernel / 2;
+        let fan_in = in_ch * kernel * kernel;
+        Self {
+            weight: fan_in_uniform(&[out_ch, in_ch, kernel, kernel], fan_in, DType::Float32),
+            bias: fan_in_uniform(&[out_ch], fan_in, DType::Float32),
+            stride,
+            padding,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let p = self.padding as isize;
+        x.conv2d()
+            .weight(&self.weight)
+            .bias(&self.bias)
+            .stride(&[self.stride, self.stride])
+            .padding(&[(p, p), (p, p)])
+            .call()
+            .context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Conv2dBias {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd.insert(prefixed(prefix, "bias"), self.bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        self.bias = get_tensor(sd, &prefixed(prefix, "bias"))?;
+        Ok(())
+    }
+}
+
+/// ConvTranspose2d with bias (no BN). Doubles spatial resolution.
+///
+/// State-dict keys: `weight`, `bias`.
+#[derive(Clone)]
+pub struct ConvTranspose2dBias {
+    pub weight: Tensor,
+    pub bias: Tensor,
+}
+
+impl ConvTranspose2dBias {
+    pub fn empty(in_ch: usize, out_ch: usize, kernel: usize) -> Self {
+        let fan_in = in_ch * kernel * kernel;
+        Self {
+            weight: fan_in_uniform(&[in_ch, out_ch, kernel, kernel], fan_in, DType::Float32),
+            bias: fan_in_uniform(&[out_ch], fan_in, DType::Float32),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        x.conv_transpose2d()
+            .weight(&self.weight)
+            .maybe_bias(Some(&self.bias))
+            .stride(&[2, 2])
+            .call()
+            .context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for ConvTranspose2dBias {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        sd.insert(prefixed(prefix, "weight"), self.weight.clone());
+        sd.insert(prefixed(prefix, "bias"), self.bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.weight = get_tensor(sd, &prefixed(prefix, "weight"))?;
+        self.bias = get_tensor(sd, &prefixed(prefix, "bias"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/blocks/csp.rs
+++ b/model/src/yolo/blocks/csp.rs
@@ -1,0 +1,268 @@
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::attention::PSABlock;
+use super::bottleneck::YoloBottleneck;
+use super::conv::YoloConv;
+use crate::yolo::error::{Result, TensorSnafu};
+
+// ---------------------------------------------------------------------------
+// C2f — the C2f/C3k2 parent: 1×1 conv → chunk(2) → chain → cat → 1×1 conv
+// ---------------------------------------------------------------------------
+
+/// Faster CSP Bottleneck: 1×1 conv splits into two halves; the second half
+/// passes through a chain of bottlenecks; all outputs are concatenated and
+/// merged by a final 1×1 conv.
+///
+/// State-dict keys: `cv1.*`, `cv2.*`, `m.{i}.*`.
+#[derive(Clone)]
+pub struct C2f {
+    pub cv1: YoloConv,
+    pub cv2: YoloConv,
+    pub m: Vec<YoloBottleneck>,
+    pub c_hidden: usize,
+}
+
+impl C2f {
+    pub fn empty(in_ch: usize, out_ch: usize, n: usize, shortcut: bool, e: f64) -> Self {
+        let c_hidden = (out_ch as f64 * e) as usize;
+        Self {
+            cv1: YoloConv::empty(in_ch, 2 * c_hidden, 1, 1, true),
+            cv2: YoloConv::empty((2 + n) * c_hidden, out_ch, 1, 1, true),
+            m: (0..n).map(|_| YoloBottleneck::empty(c_hidden, c_hidden, shortcut)).collect(),
+            c_hidden,
+        }
+    }
+
+    /// C2f forward shared with C3k2: `cv1 → chunk(2) → chain(m) → cat → cv2`.
+    pub fn forward_chain(&self, x: &Tensor) -> Result<Tensor> {
+        let y = self.cv1.forward(x)?;
+        let chunks = y.chunk(2, 1).context(TensorSnafu)?;
+        let mut parts = vec![chunks[0].clone(), chunks[1].clone()];
+        let mut current = chunks[1].clone();
+        for blk in &self.m {
+            current = blk.forward(&current)?;
+            parts.push(current.clone());
+        }
+        let refs: Vec<&Tensor> = parts.iter().collect();
+        let cat = Tensor::cat(&refs, 1).context(TensorSnafu)?;
+        self.cv2.forward(&cat)
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        self.forward_chain(x)
+    }
+}
+
+impl HasStateDict for C2f {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.cv1.state_dict(&prefixed(prefix, "cv1"));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        for (i, blk) in self.m.iter().enumerate() {
+            sd.extend(blk.state_dict(&prefixed(prefix, &format!("m.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        for (i, blk) in self.m.iter_mut().enumerate() {
+            blk.load_state_dict(sd, &prefixed(prefix, &format!("m.{i}")))?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C3k — CSP Bottleneck with 3 convs and configurable kernel size
+// ---------------------------------------------------------------------------
+
+/// CSP with three 1×1 convs and n inner bottlenecks with kernel `k`.
+///
+/// State-dict keys: `cv1.*`, `cv2.*`, `cv3.*`, `m.{i}.*`.
+#[derive(Clone)]
+pub struct C3k {
+    pub cv1: YoloConv,
+    pub cv2: YoloConv,
+    pub cv3: YoloConv,
+    pub m: Vec<YoloBottleneck>,
+}
+
+impl C3k {
+    pub fn empty(in_ch: usize, out_ch: usize, n: usize, shortcut: bool, e: f64, k: usize) -> Self {
+        let c_ = (out_ch as f64 * e) as usize;
+        Self {
+            cv1: YoloConv::empty(in_ch, c_, 1, 1, true),
+            cv2: YoloConv::empty(in_ch, c_, 1, 1, true),
+            cv3: YoloConv::empty(2 * c_, out_ch, 1, 1, true),
+            m: (0..n).map(|_| YoloBottleneck::empty_full(c_, c_, shortcut, k, k, 1.0)).collect(),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let left = self.cv1.forward(x)?;
+        let mut current = left;
+        for blk in &self.m {
+            current = blk.forward(&current)?;
+        }
+        let right = self.cv2.forward(x)?;
+        let cat = Tensor::cat(&[&current, &right], 1).context(TensorSnafu)?;
+        self.cv3.forward(&cat)
+    }
+}
+
+impl HasStateDict for C3k {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.cv1.state_dict(&prefixed(prefix, "cv1"));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        sd.extend(self.cv3.state_dict(&prefixed(prefix, "cv3")));
+        for (i, blk) in self.m.iter().enumerate() {
+            sd.extend(blk.state_dict(&prefixed(prefix, &format!("m.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        self.cv3.load_state_dict(sd, &prefixed(prefix, "cv3"))?;
+        for (i, blk) in self.m.iter_mut().enumerate() {
+            blk.load_state_dict(sd, &prefixed(prefix, &format!("m.{i}")))?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C3k2 — C2f parent with pluggable inner blocks
+// ---------------------------------------------------------------------------
+
+/// Inner block for C3k2: plain Bottleneck, C3k, or Bottleneck+PSABlock.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
+pub enum C3k2Inner {
+    Bottleneck(YoloBottleneck),
+    C3k(C3k),
+    Attn(AttnBottleneck),
+}
+
+/// `Sequential(Bottleneck, PSABlock)` — used when `attn=True`.
+#[derive(Clone)]
+pub struct AttnBottleneck {
+    pub bottleneck: YoloBottleneck,
+    pub psa: PSABlock,
+}
+
+impl C3k2Inner {
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        match self {
+            C3k2Inner::Bottleneck(b) => b.forward(x),
+            C3k2Inner::C3k(c) => c.forward(x),
+            C3k2Inner::Attn(a) => {
+                let b = a.bottleneck.forward(x)?;
+                a.psa.forward(&b)
+            }
+        }
+    }
+}
+
+impl HasStateDict for C3k2Inner {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        match self {
+            C3k2Inner::Bottleneck(b) => b.state_dict(prefix),
+            C3k2Inner::C3k(c) => c.state_dict(prefix),
+            C3k2Inner::Attn(a) => {
+                let mut sd = a.bottleneck.state_dict(&prefixed(prefix, "0"));
+                sd.extend(a.psa.state_dict(&prefixed(prefix, "1")));
+                sd
+            }
+        }
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        match self {
+            C3k2Inner::Bottleneck(b) => b.load_state_dict(sd, prefix),
+            C3k2Inner::C3k(c) => c.load_state_dict(sd, prefix),
+            C3k2Inner::Attn(a) => {
+                a.bottleneck.load_state_dict(sd, &prefixed(prefix, "0"))?;
+                a.psa.load_state_dict(sd, &prefixed(prefix, "1"))?;
+                Ok(())
+            }
+        }
+    }
+}
+
+/// C3k2: C2f with pluggable inner blocks (Bottleneck, C3k, or attn).
+///
+/// State-dict keys: `cv1.*`, `cv2.*`, `m.{i}.*`.
+#[derive(Clone)]
+pub struct C3k2 {
+    pub cv1: YoloConv,
+    pub cv2: YoloConv,
+    pub m: Vec<C3k2Inner>,
+    pub c_hidden: usize,
+}
+
+impl C3k2 {
+    pub fn empty(in_ch: usize, out_ch: usize, n: usize, shortcut: bool, e: f64, c3k: bool, attn: bool) -> Self {
+        let c_hidden = (out_ch as f64 * e) as usize;
+        let num_heads = (c_hidden / 64).max(1);
+        let m: Vec<C3k2Inner> = (0..n)
+            .map(|_| {
+                if attn {
+                    C3k2Inner::Attn(AttnBottleneck {
+                        bottleneck: YoloBottleneck::empty(c_hidden, c_hidden, shortcut),
+                        psa: PSABlock::empty(c_hidden, num_heads),
+                    })
+                } else if c3k {
+                    C3k2Inner::C3k(C3k::empty(c_hidden, c_hidden, 2, shortcut, 0.5, 3))
+                } else {
+                    C3k2Inner::Bottleneck(YoloBottleneck::empty(c_hidden, c_hidden, shortcut))
+                }
+            })
+            .collect();
+        Self {
+            cv1: YoloConv::empty(in_ch, 2 * c_hidden, 1, 1, true),
+            cv2: YoloConv::empty((2 + n) * c_hidden, out_ch, 1, 1, true),
+            m,
+            c_hidden,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let y = self.cv1.forward(x)?;
+        let chunks = y.chunk(2, 1).context(TensorSnafu)?;
+        let mut parts = vec![chunks[0].clone(), chunks[1].clone()];
+        let mut current = chunks[1].clone();
+        for blk in &self.m {
+            current = blk.forward(&current)?;
+            parts.push(current.clone());
+        }
+        let refs: Vec<&Tensor> = parts.iter().collect();
+        let cat = Tensor::cat(&refs, 1).context(TensorSnafu)?;
+        self.cv2.forward(&cat)
+    }
+}
+
+impl HasStateDict for C3k2 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.cv1.state_dict(&prefixed(prefix, "cv1"));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        for (i, blk) in self.m.iter().enumerate() {
+            sd.extend(blk.state_dict(&prefixed(prefix, &format!("m.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        for (i, blk) in self.m.iter_mut().enumerate() {
+            blk.load_state_dict(sd, &prefixed(prefix, &format!("m.{i}")))?;
+        }
+        Ok(())
+    }
+}

--- a/model/src/yolo/blocks/mod.rs
+++ b/model/src/yolo/blocks/mod.rs
@@ -1,0 +1,13 @@
+//! YOLO v26 neural-network building blocks.
+
+pub(crate) mod attention;
+pub(crate) mod bottleneck;
+pub(crate) mod conv;
+pub(crate) mod csp;
+pub(crate) mod sppf;
+
+pub use attention::{Attention, C2PSA, PSABlock};
+pub use bottleneck::YoloBottleneck;
+pub use conv::{Conv2dBias, ConvTranspose2dBias, YoloConv};
+pub use csp::{C2f, C3k, C3k2, C3k2Inner};
+pub use sppf::Sppf;

--- a/model/src/yolo/blocks/sppf.rs
+++ b/model/src/yolo/blocks/sppf.rs
@@ -1,0 +1,71 @@
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::conv::YoloConv;
+use crate::yolo::error::{Result, TensorSnafu};
+
+/// Spatial Pyramid Pooling - Fast: 1×1 conv → 3× MaxPool(k=5) → cat → 1×1 conv.
+/// When `shortcut` is true and `in_ch == out_ch`, a residual connection is added.
+///
+/// State-dict keys: `cv1.{conv,bn}.*`, `cv2.{conv,bn}.*`.
+#[derive(Clone)]
+pub struct Sppf {
+    pub cv1: YoloConv,
+    pub cv2: YoloConv,
+    pub add: bool,
+}
+
+impl Sppf {
+    pub fn empty(in_ch: usize, out_ch: usize, _kernel: usize, n: usize, shortcut: bool) -> Self {
+        let c_hidden = in_ch / 2;
+        Self {
+            cv1: YoloConv::empty(in_ch, c_hidden, 1, 1, false),
+            cv2: YoloConv::empty(c_hidden * (n + 1), out_ch, 1, 1, true),
+            add: shortcut && in_ch == out_ch,
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let y0 = self.cv1.forward(x)?;
+        let y1 = y0
+            .max_pool2d()
+            .kernel_size(&[5, 5])
+            .stride(&[1, 1])
+            .padding(&[(2, 2), (2, 2)])
+            .call()
+            .context(TensorSnafu)?;
+        let y2 = y1
+            .max_pool2d()
+            .kernel_size(&[5, 5])
+            .stride(&[1, 1])
+            .padding(&[(2, 2), (2, 2)])
+            .call()
+            .context(TensorSnafu)?;
+        let y3 = y2
+            .max_pool2d()
+            .kernel_size(&[5, 5])
+            .stride(&[1, 1])
+            .padding(&[(2, 2), (2, 2)])
+            .call()
+            .context(TensorSnafu)?;
+        let cat = Tensor::cat(&[&y0, &y1, &y2, &y3], 1).context(TensorSnafu)?;
+        let out = self.cv2.forward(&cat)?;
+        if self.add { out.try_add(x).context(TensorSnafu) } else { Ok(out) }
+    }
+}
+
+impl HasStateDict for Sppf {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.cv1.state_dict(&prefixed(prefix, "cv1"));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/classify.rs
+++ b/model/src/yolo/classify.rs
@@ -1,0 +1,131 @@
+//! [`Yolo26Classify`] — YOLO v26 image classification.
+//!
+//! Backbone (no SPPF, layers 0–9) → Conv(1×1→1280) → GAP → Linear → softmax.
+//! Forward returns `[B, nc]` class probabilities.
+
+use snafu::ResultExt;
+use svod_dtype::DType;
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::init::fan_in_uniform;
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::backbone::YoloBackboneCls;
+use super::blocks::conv::YoloConv;
+use super::config::YoloConfig;
+use super::error::{Result, StateSnafu, TensorSnafu};
+use super::loader;
+
+const HIDDEN: usize = 1280;
+
+/// Classification head: Conv(c4→1280, k1) → GAP → Linear(1280→nc).
+///
+/// State-dict keys: `conv.{conv,bn}.*`, `linear.weight`, `linear.bias`.
+#[derive(Clone)]
+pub struct ClassifyHead {
+    pub conv: YoloConv,
+    pub linear_weight: Tensor,
+    pub linear_bias: Tensor,
+}
+
+impl ClassifyHead {
+    pub fn empty(in_ch: usize, nc: usize) -> Self {
+        Self {
+            conv: YoloConv::empty(in_ch, HIDDEN, 1, 1, true),
+            linear_weight: fan_in_uniform(&[nc, HIDDEN], HIDDEN, DType::Float32),
+            linear_bias: fan_in_uniform(&[nc], HIDDEN, DType::Float32),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let b = x.shape().context(TensorSnafu)?[0].clone();
+        let x = self.conv.forward(x)?;
+        // GAP: mean over H,W (axes 2,3)
+        let x = x.mean_with().axes(vec![2isize, 3]).keepdim(true).call().context(TensorSnafu)?;
+        // Flatten: [B, 1280, 1, 1] → [B, 1280]
+        let x = x.try_reshape([b, SInt::from(HIDDEN)]).context(TensorSnafu)?;
+        // Linear → softmax
+        let logits = x.linear().weight(&self.linear_weight).bias(&self.linear_bias).call().context(TensorSnafu)?;
+        logits.softmax(-1).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for ClassifyHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv.state_dict(&prefixed(prefix, "conv"));
+        sd.insert(prefixed(prefix, "linear.weight"), self.linear_weight.clone());
+        sd.insert(prefixed(prefix, "linear.bias"), self.linear_bias.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv.load_state_dict(sd, &prefixed(prefix, "conv"))?;
+        self.linear_weight = get_tensor(sd, &prefixed(prefix, "linear.weight"))?;
+        self.linear_bias = get_tensor(sd, &prefixed(prefix, "linear.bias"))?;
+        Ok(())
+    }
+}
+
+/// YOLO v26 classification model.
+///
+/// Forward returns `[B, nc]` softmax probabilities.
+#[derive(Clone)]
+pub struct Yolo26Classify {
+    pub config: YoloConfig,
+    pub backbone: YoloBackboneCls,
+    pub head: ClassifyHead,
+}
+
+impl Yolo26Classify {
+    pub fn with_zero_weights(config: YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, _, _, c4] = super::backbone::scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackboneCls::empty(scale),
+            head: ClassifyHead::empty(c4, config.nc),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    /// Run the full network. Returns `[B, nc]` softmax probabilities.
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let feat = self.backbone.forward(&x)?;
+        self.head.forward(&feat)
+    }
+}
+
+impl HasStateDict for Yolo26Classify {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.head.state_dict(&prefixed(prefix, "10")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "10"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/config.rs
+++ b/model/src/yolo/config.rs
@@ -1,0 +1,84 @@
+/// YOLO model scale variants. Each maps to Ultralytics'
+/// `[depth_multiple, width_multiple, max_channels]` scaling table.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum YoloScale {
+    Nano,
+    Small,
+    Medium,
+    Large,
+    XLarge,
+}
+
+impl YoloScale {
+    /// Returns `(depth, width, max_channels)` from the yolo26 scaling table.
+    pub fn scaling(self) -> (f64, f64, usize) {
+        match self {
+            YoloScale::Nano => (0.50, 0.25, 1024),
+            YoloScale::Small => (0.50, 0.50, 1024),
+            YoloScale::Medium => (0.50, 1.00, 512),
+            YoloScale::Large => (1.00, 1.00, 512),
+            YoloScale::XLarge => (1.00, 1.50, 512),
+        }
+    }
+
+    pub fn depth(self) -> f64 {
+        self.scaling().0
+    }
+
+    pub fn width(self) -> f64 {
+        self.scaling().1
+    }
+
+    pub fn max_channels(self) -> usize {
+        self.scaling().2
+    }
+}
+
+/// `ceil(value / divisor) * divisor` — Ultralytics `make_divisible`.
+pub fn make_divisible(value: usize, divisor: usize) -> usize {
+    ((value as f64 / divisor as f64).ceil() as usize) * divisor
+}
+
+/// Scale a YAML channel spec through the width/max_channels table entry.
+pub fn scale_channels(c: usize, scale: YoloScale) -> usize {
+    let scaled = (std::cmp::min(c, scale.max_channels()) as f64 * scale.width()) as usize;
+    make_divisible(scaled, 8)
+}
+
+/// `max(round(n * depth), 1)` — Ultralytics depth gain.
+pub fn make_depth(n: usize, scale: YoloScale) -> usize {
+    let scaled = (n as f64 * scale.depth()).round() as usize;
+    scaled.max(1)
+}
+
+#[derive(Clone, Debug)]
+pub struct YoloConfig {
+    pub scale: YoloScale,
+    pub nc: usize,
+    pub reg_max: usize,
+    pub max_batch_size: usize,
+}
+
+impl YoloConfig {
+    pub fn new(scale: YoloScale, nc: usize) -> Self {
+        Self { scale, nc, reg_max: 1, max_batch_size: 1 }
+    }
+
+    pub fn with_max_batch_size(mut self, max_batch_size: usize) -> Self {
+        self.max_batch_size = max_batch_size;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detect head strides
+// ---------------------------------------------------------------------------
+
+/// Strides for the three detection levels (P3/8, P4/16, P5/32).
+pub const DETECT_STRIDES: [usize; 3] = [8, 16, 32];
+
+/// Strides for P2 variant (P2/4, P3/8, P4/16, P5/32).
+pub const P2_STRIDES: [usize; 4] = [4, 8, 16, 32];
+
+/// Strides for P6 variant (P3/8, P4/16, P5/32, P6/64).
+pub const P6_STRIDES: [usize; 4] = [8, 16, 32, 64];

--- a/model/src/yolo/depth.rs
+++ b/model/src/yolo/depth.rs
@@ -1,0 +1,197 @@
+//! [`Yolo26Depth`] — YOLO v26 monocular depth estimation.
+//!
+//! Full backbone+neck + multi-scale fusion decoder. Projects each pyramid
+//! level to `c_mid` channels, progressively upsamples+fuses from P5→P3,
+//! then runs Conv→ConvTranspose2d→Conv→Conv2d to produce `[B, 1, H/4, W/4]`.
+
+use snafu::ResultExt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
+
+use super::backbone::YoloBackbone;
+use super::blocks::conv::{Conv2dBias, ConvTranspose2dBias, YoloConv};
+use super::config::YoloConfig;
+use super::error::{Result, StateSnafu, TensorSnafu};
+use super::loader;
+use super::neck::YoloNeck;
+
+/// Bilinear 2× upsample with align_corners=True.
+fn resize_bilinear_2x(x: &Tensor) -> Result<Tensor> {
+    use svod_tensor::nn::{CoordinateTransformMode, ResizeMode};
+    x.resize()
+        .scales(&[1.0, 1.0, 2.0, 2.0])
+        .mode(ResizeMode::Linear)
+        .coordinate_transformation_mode(CoordinateTransformMode::AlignCorners)
+        .call()
+        .context(TensorSnafu)
+}
+
+/// Depth fusion decoder head.
+///
+/// State-dict keys:
+/// - `proj.{i}.*` — 1×1 conv per level
+/// - `refine.{i}.0.*`, `refine.{i}.1.*` — refinement blocks
+/// - `head.0.*`, `head.1.*`, `head.2.*`, `head.3.*`
+/// - `cal_a`, `cal_b` — log-affine calibration buffers
+#[derive(Clone)]
+pub struct DepthHead {
+    pub proj: Vec<YoloConv>,
+    pub refine: Vec<(YoloConv, YoloConv)>,
+    pub head_conv0: YoloConv,
+    pub head_deconv: ConvTranspose2dBias,
+    pub head_conv1: YoloConv,
+    pub head_conv2: Conv2dBias,
+    pub cal_a: Tensor,
+    pub cal_b: Tensor,
+}
+
+impl DepthHead {
+    pub fn empty(ch: &[usize], c_mid: usize) -> Self {
+        let proj: Vec<YoloConv> = ch.iter().map(|&c| YoloConv::empty(c, c_mid, 1, 1, true)).collect();
+        let nl = ch.len();
+        let refine: Vec<(YoloConv, YoloConv)> = (0..nl - 1)
+            .map(|_| (YoloConv::empty(c_mid, c_mid, 3, 1, true), YoloConv::empty(c_mid, c_mid, 3, 1, true)))
+            .collect();
+        Self {
+            proj,
+            refine,
+            head_conv0: YoloConv::empty(c_mid, c_mid / 2, 3, 1, true),
+            head_deconv: ConvTranspose2dBias::empty(c_mid / 2, c_mid / 2, 2),
+            head_conv1: YoloConv::empty(c_mid / 2, c_mid / 4, 3, 1, true),
+            head_conv2: Conv2dBias::empty(c_mid / 4, 1, 1, 1),
+            cal_a: Tensor::from_slice([1.0f32]),
+            cal_b: Tensor::from_slice([0.0f32]),
+        }
+    }
+
+    pub fn forward(&self, feats: &[Tensor]) -> Result<Tensor> {
+        let nl = feats.len();
+        let projected: Vec<Tensor> = (0..nl).map(|i| self.proj[i].forward(&feats[i])).collect::<Result<_>>()?;
+
+        let mut out = projected[nl - 1].clone();
+        for i in (0..nl - 1).rev() {
+            out = resize_bilinear_2x(&out)?;
+            out = out.try_add(&projected[i]).context(TensorSnafu)?;
+            out = self.refine[i].0.forward(&out)?;
+            out = self.refine[i].1.forward(&out)?;
+        }
+
+        let out = self.head_conv0.forward(&out)?;
+        let out = self.head_deconv.forward(&out)?;
+        let out = self.head_conv1.forward(&out)?;
+        let out = self.head_conv2.forward(&out)?;
+
+        // exp(clamp(out, -4, 5))
+        let neg4 = Tensor::from_slice([-4.0f32]);
+        let pos5 = Tensor::from_slice([5.0f32]);
+        let clamped = out.clamp().min(&neg4).max(&pos5).call().context(TensorSnafu)?;
+        let depth = clamped.try_exp().context(TensorSnafu)?;
+        // Log-affine calibration: depth = depth^cal_a * exp(cal_b)
+        let depth = depth.try_pow(&self.cal_a).context(TensorSnafu)?;
+        let cal_b_exp = self.cal_b.try_exp().context(TensorSnafu)?;
+        depth.try_mul(&cal_b_exp).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for DepthHead {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, p) in self.proj.iter().enumerate() {
+            sd.extend(p.state_dict(&prefixed(prefix, &format!("proj.{i}"))));
+        }
+        for (i, (a, b)) in self.refine.iter().enumerate() {
+            sd.extend(a.state_dict(&prefixed(prefix, &format!("refine.{i}.0"))));
+            sd.extend(b.state_dict(&prefixed(prefix, &format!("refine.{i}.1"))));
+        }
+        sd.extend(self.head_conv0.state_dict(&prefixed(prefix, "head.0")));
+        sd.extend(self.head_deconv.state_dict(&prefixed(prefix, "head.1")));
+        sd.extend(self.head_conv1.state_dict(&prefixed(prefix, "head.2")));
+        sd.extend(self.head_conv2.state_dict(&prefixed(prefix, "head.3")));
+        sd.insert(prefixed(prefix, "cal_a"), self.cal_a.clone());
+        sd.insert(prefixed(prefix, "cal_b"), self.cal_b.clone());
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, p) in self.proj.iter_mut().enumerate() {
+            p.load_state_dict(sd, &prefixed(prefix, &format!("proj.{i}")))?;
+        }
+        for (i, (a, b)) in self.refine.iter_mut().enumerate() {
+            a.load_state_dict(sd, &prefixed(prefix, &format!("refine.{i}.0")))?;
+            b.load_state_dict(sd, &prefixed(prefix, &format!("refine.{i}.1")))?;
+        }
+        self.head_conv0.load_state_dict(sd, &prefixed(prefix, "head.0"))?;
+        self.head_deconv.load_state_dict(sd, &prefixed(prefix, "head.1"))?;
+        self.head_conv1.load_state_dict(sd, &prefixed(prefix, "head.2"))?;
+        self.head_conv2.load_state_dict(sd, &prefixed(prefix, "head.3"))?;
+        self.cal_a = get_tensor(sd, &prefixed(prefix, "cal_a")).unwrap_or_else(|_| Tensor::from_slice([1.0f32]));
+        self.cal_b = get_tensor(sd, &prefixed(prefix, "cal_b")).unwrap_or_else(|_| Tensor::from_slice([0.0f32]));
+        Ok(())
+    }
+}
+
+/// YOLO v26 depth model. Forward returns `[B, 1, H/4, W/4]` depth map.
+#[derive(Clone)]
+pub struct Yolo26Depth {
+    pub config: YoloConfig,
+    pub backbone: YoloBackbone,
+    pub neck: YoloNeck,
+    pub head: DepthHead,
+}
+
+impl Yolo26Depth {
+    pub fn with_zero_weights(config: YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, c2, c3, c4] = super::backbone::scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            neck: YoloNeck::empty(scale),
+            head: DepthHead::empty(&[c2, c3, c4], 256),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l10) = self.backbone.forward(&x)?;
+        let (p3, p4, p5) = self.neck.forward(&l4, &l6, &l10)?;
+        self.head.forward(&[p3, p4, p5])
+    }
+}
+
+impl HasStateDict for Yolo26Depth {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "23")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "23"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/detect.rs
+++ b/model/src/yolo/detect.rs
@@ -1,0 +1,334 @@
+//! [`Yolo26Detect`], [`Yolo26DetectP2`], [`Yolo26DetectP6`] — YOLO v26
+//! object detection models (standard, P2, P6 topologies).
+//!
+//! All three share the same [`Detect`] head (differing only in the number of
+//! detection scales) and differ in backbone/neck depth.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::backbone::{YoloBackbone, scaled_channels};
+use super::config::{P2_STRIDES, P6_STRIDES, YoloConfig};
+use super::error::{Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::head::{BoxBranch, ClsBranch, dist2bbox, make_anchors};
+use super::loader;
+
+// ---------------------------------------------------------------------------
+// Detect head
+// ---------------------------------------------------------------------------
+
+/// YOLO v26 detection head (end2end, reg_max=1). Loads only the one2one
+/// branch weights (the one2many branch is training-only).
+///
+/// Forward returns a single tensor `[B, 4+nc, A]` — decoded boxes (xyxy in
+/// pixel space) concatenated with sigmoid'd class scores.
+#[derive(Clone)]
+pub struct Detect {
+    pub cv2: Vec<BoxBranch>,
+    pub cv3: Vec<ClsBranch>,
+    pub nc: usize,
+    pub reg_max: usize,
+    pub strides: Vec<usize>,
+}
+
+impl Detect {
+    pub fn empty(ch: &[usize], nc: usize, reg_max: usize) -> Self {
+        Self::empty_with_strides(ch, nc, reg_max, &super::config::DETECT_STRIDES)
+    }
+
+    pub fn empty_with_strides(ch: &[usize], nc: usize, reg_max: usize, strides: &[usize]) -> Self {
+        let hidden_box = (16usize).max(ch[0] / 4).max(reg_max * 4);
+        let hidden_cls = ch[0].max(nc.min(100));
+        Self {
+            cv2: ch.iter().map(|&c| BoxBranch::empty(c, hidden_box, reg_max)).collect(),
+            cv3: ch.iter().map(|&c| ClsBranch::empty(c, hidden_cls, nc)).collect(),
+            nc,
+            reg_max,
+            strides: strides.to_vec(),
+        }
+    }
+
+    /// Run box + cls heads on each feature map, decode boxes via dist2bbox,
+    /// sigmoid scores, and cat into `[B, 4+nc, A]`.
+    pub fn forward(&self, feats: &[Tensor]) -> Result<Tensor> {
+        let shape = feats[0].shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+
+        let mut boxes_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut scores_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut feat_sizes: Vec<(usize, usize)> = Vec::with_capacity(feats.len());
+
+        for (i, feat) in feats.iter().enumerate() {
+            let fshape = feat.shape().context(TensorSnafu)?;
+            let h: usize = fshape[2].as_const().context(SymbolicShapeSnafu { what: "yolo detect H" })?;
+            let w: usize = fshape[3].as_const().context(SymbolicShapeSnafu { what: "yolo detect W" })?;
+            let hw = h * w;
+            feat_sizes.push((h, w));
+
+            let box_out = self.cv2[i].forward(feat)?;
+            let box_out =
+                box_out.try_reshape([b.clone(), SInt::from(4 * self.reg_max), SInt::from(hw)]).context(TensorSnafu)?;
+            boxes_list.push(box_out);
+
+            let cls_out = self.cv3[i].forward(feat)?;
+            let cls_out = cls_out.try_reshape([b.clone(), SInt::from(self.nc), SInt::from(hw)]).context(TensorSnafu)?;
+            scores_list.push(cls_out);
+        }
+
+        let boxes_refs: Vec<&Tensor> = boxes_list.iter().collect();
+        let scores_refs: Vec<&Tensor> = scores_list.iter().collect();
+
+        let boxes = Tensor::cat(&boxes_refs, 2).context(TensorSnafu)?;
+        let scores = Tensor::cat(&scores_refs, 2).context(TensorSnafu)?;
+
+        let num_anchors: usize = feat_sizes.iter().map(|&(h, w)| h * w).sum();
+        let (anchors, strides) = make_anchors(&feat_sizes, &self.strides);
+
+        let dbox = dist2bbox(&boxes, &anchors, &strides, num_anchors)?;
+        let scores = scores.sigmoid().context(TensorSnafu)?;
+
+        Tensor::cat(&[&dbox, &scores], 1).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Detect {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, br) in self.cv2.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv2.{i}"))));
+        }
+        for (i, br) in self.cv3.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv3.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, br) in self.cv2.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv2.{i}")))?;
+        }
+        for (i, br) in self.cv3.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv3.{i}")))?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Yolo26Detect — standard P3/P4/P5
+// ---------------------------------------------------------------------------
+
+/// YOLO v26 object detection model (P3/8–P5/32).
+///
+/// Forward returns `[B, 4+nc, A]` (decoded boxes + scores).
+#[derive(Clone)]
+pub struct Yolo26Detect {
+    pub config: YoloConfig,
+    pub backbone: YoloBackbone,
+    pub neck: super::neck::YoloNeck,
+    pub head: Detect,
+}
+
+impl Yolo26Detect {
+    pub fn with_zero_weights(config: YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, c2, c3, c4] = scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            neck: super::neck::YoloNeck::empty(scale),
+            head: Detect::empty(&[c2, c3, c4], config.nc, config.reg_max),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l10) = self.backbone.forward(&x)?;
+        let (p3, p4, p5) = self.neck.forward(&l4, &l6, &l10)?;
+        self.head.forward(&[p3, p4, p5])
+    }
+}
+
+impl HasStateDict for Yolo26Detect {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "23")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "23"))?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Yolo26DetectP2 — P2/P3/P4/P5
+// ---------------------------------------------------------------------------
+
+/// YOLO v26-P2 object detection model (P2/4–P5/32).
+///
+/// Uses the standard backbone (tapping P2/4) with an extended P2 neck,
+/// producing four detection feature maps at strides 4, 8, 16, 32.
+#[derive(Clone)]
+pub struct Yolo26DetectP2 {
+    pub config: YoloConfig,
+    pub backbone: YoloBackbone,
+    pub neck: super::neck::YoloNeckP2,
+    pub head: Detect,
+}
+
+impl Yolo26DetectP2 {
+    pub fn with_zero_weights(config: YoloConfig) -> Self {
+        let scale = config.scale;
+        let sc = |yaml_c| crate::yolo::config::scale_channels(yaml_c, scale);
+        let ch = [sc(128), sc(256), sc(512), sc(1024)];
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            neck: super::neck::YoloNeckP2::empty(scale),
+            head: Detect::empty_with_strides(&ch, config.nc, config.reg_max, &P2_STRIDES),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l2, l4, l6, l10) = self.backbone.forward_with_p2(&x)?;
+        let (p2, p3, p4, p5) = self.neck.forward(&l2, &l4, &l6, &l10)?;
+        self.head.forward(&[p2, p3, p4, p5])
+    }
+}
+
+impl HasStateDict for Yolo26DetectP2 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "29")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "29"))?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Yolo26DetectP6 — P3/P4/P5/P6
+// ---------------------------------------------------------------------------
+
+/// YOLO v26-P6 object detection model (P3/8–P6/64).
+///
+/// Uses the P6 backbone (deeper, P5=768ch, P6=1024ch) with a P6 neck,
+/// producing four detection feature maps at strides 8, 16, 32, 64.
+#[derive(Clone)]
+pub struct Yolo26DetectP6 {
+    pub config: YoloConfig,
+    pub backbone: super::backbone::YoloBackboneP6,
+    pub neck: super::neck::YoloNeckP6,
+    pub head: Detect,
+}
+
+impl Yolo26DetectP6 {
+    pub fn with_zero_weights(config: YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, c2, c3, c5, c6] = super::backbone::p6_scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: super::backbone::YoloBackboneP6::empty(scale),
+            neck: super::neck::YoloNeckP6::empty(scale),
+            head: Detect::empty_with_strides(&[c2, c3, c5, c6], config.nc, config.reg_max, &P6_STRIDES),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l8, l12) = self.backbone.forward(&x)?;
+        let (p3, p4, p5, p6) = self.neck.forward(&l4, &l6, &l8, &l12)?;
+        self.head.forward(&[p3, p4, p5, p6])
+    }
+}
+
+impl HasStateDict for Yolo26DetectP6 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "31")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "31"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/error.rs
+++ b/model/src/yolo/error.rs
@@ -1,0 +1,38 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("{source}"))]
+    Tensor {
+        #[snafu(source(from(svod_tensor::error::Error, Box::new)))]
+        source: Box<svod_tensor::error::Error>,
+    },
+    #[snafu(display("{source}"))]
+    State {
+        #[snafu(source(from(crate::state::Error, Box::new)))]
+        source: Box<crate::state::Error>,
+    },
+    #[snafu(display("hub error: {source}"))]
+    Hub { source: hf_hub::api::sync::ApiError },
+    #[snafu(display("invalid yolo config: {message}"))]
+    Config { message: String },
+    #[snafu(display("{what} requires a concrete shape, got a symbolic dim"))]
+    SymbolicShape { what: &'static str },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<crate::blocks::Error> for Error {
+    fn from(e: crate::blocks::Error) -> Self {
+        match e {
+            crate::blocks::Error::Tensor { source } => Error::Tensor { source },
+        }
+    }
+}
+
+impl From<svod_tensor::error::Error> for Error {
+    fn from(e: svod_tensor::error::Error) -> Self {
+        Error::Tensor { source: Box::new(e) }
+    }
+}

--- a/model/src/yolo/head.rs
+++ b/model/src/yolo/head.rs
@@ -1,0 +1,234 @@
+//! Shared detection-head infrastructure: branches, anchor generation, box
+//! decoding, and postprocessing.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::blocks::conv::{Conv2dBias, YoloConv};
+use super::error::{Result, SymbolicShapeSnafu, TensorSnafu};
+
+/// Generate anchor points and stride tensor from feature map sizes.
+///
+/// Returns `(anchors [2, A], strides [1, A])` as constant f32 tensors.
+/// Anchor point `(x, y)` = `(col + 0.5, row + 0.5)` in grid coordinates.
+pub(crate) fn make_anchors(feat_sizes: &[(usize, usize)], strides: &[usize]) -> (Tensor, Tensor) {
+    let mut anchor_vec = Vec::new();
+    let mut stride_vec = Vec::new();
+    for (&(h, w), &s) in feat_sizes.iter().zip(strides.iter()) {
+        for y in 0..h {
+            for x in 0..w {
+                anchor_vec.push((x as f32) + 0.5);
+                anchor_vec.push((y as f32) + 0.5);
+                stride_vec.push(s as f32);
+            }
+        }
+    }
+    let a = anchor_vec.len() / 2;
+    let anchors = Tensor::from_slice(&anchor_vec).try_reshape([2, a]).expect("anchor reshape");
+    let strides = Tensor::from_slice(&stride_vec).try_reshape([1, a]).expect("stride reshape");
+    (anchors, strides)
+}
+
+/// Convert distance (lt, rb) predictions to xyxy boxes, then scale by strides.
+///
+/// `boxes [B, 4, A]`, `anchors [2, A]`, `strides [1, A]` → `[B, 4, A]`.
+pub(crate) fn dist2bbox(boxes: &Tensor, anchors: &Tensor, strides: &Tensor, num_anchors: usize) -> Result<Tensor> {
+    let parts = boxes.split(&[2, 2], 1).context(TensorSnafu)?;
+    let lt = &parts[0];
+    let rb = &parts[1];
+
+    let anchors_3d = anchors
+        .try_reshape([SInt::from(1isize), SInt::from(2isize), SInt::from(num_anchors as isize)])
+        .context(TensorSnafu)?;
+
+    let x1y1 = anchors_3d.try_sub(lt).context(TensorSnafu)?;
+    let x2y2 = anchors_3d.try_add(rb).context(TensorSnafu)?;
+    let bbox = Tensor::cat(&[&x1y1, &x2y2], 1).context(TensorSnafu)?;
+
+    let strides_3d = strides
+        .try_reshape([SInt::from(1isize), SInt::from(1isize), SInt::from(num_anchors as isize)])
+        .context(TensorSnafu)?;
+    bbox.try_mul(&strides_3d).context(TensorSnafu)
+}
+
+/// Box-regression branch: `Conv(k3) → Conv(k3) → Conv2d(k1, bias)`.
+/// Outputs `4 * reg_max` channels.
+///
+/// State-dict keys: `0.{conv,bn}.*`, `1.{conv,bn}.*`, `2.weight`, `2.bias`.
+#[derive(Clone)]
+pub struct BoxBranch {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+    pub conv2: Conv2dBias,
+}
+
+impl BoxBranch {
+    pub fn empty(in_ch: usize, hidden: usize, reg_max: usize) -> Self {
+        Self {
+            conv0: YoloConv::empty(in_ch, hidden, 3, 1, true),
+            conv1: YoloConv::empty(hidden, hidden, 3, 1, true),
+            conv2: Conv2dBias::empty(hidden, 4 * reg_max, 1, 1),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        self.conv2.forward(&x)
+    }
+}
+
+impl HasStateDict for BoxBranch {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv0.state_dict(&prefixed(prefix, "0"));
+        sd.extend(self.conv1.state_dict(&prefixed(prefix, "1")));
+        sd.extend(self.conv2.state_dict(&prefixed(prefix, "2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv0.load_state_dict(sd, &prefixed(prefix, "0"))?;
+        self.conv1.load_state_dict(sd, &prefixed(prefix, "1"))?;
+        self.conv2.load_state_dict(sd, &prefixed(prefix, "2"))?;
+        Ok(())
+    }
+}
+
+/// Classification branch (non-legacy): `(DWConv→Conv) × 2 → Conv2d(bias)`.
+///
+/// State-dict keys: `0.0.*`, `0.1.*`, `1.0.*`, `1.1.*`, `2.weight`, `2.bias`.
+#[derive(Clone)]
+pub struct ClsBranch {
+    pub dw0: YoloConv,
+    pub conv0: YoloConv,
+    pub dw1: YoloConv,
+    pub conv1: YoloConv,
+    pub conv2: Conv2dBias,
+}
+
+impl ClsBranch {
+    pub fn empty(in_ch: usize, hidden: usize, nc: usize) -> Self {
+        Self {
+            dw0: YoloConv::empty_dw(in_ch, in_ch, 3, 1, true),
+            conv0: YoloConv::empty(in_ch, hidden, 1, 1, true),
+            dw1: YoloConv::empty_dw(hidden, hidden, 3, 1, true),
+            conv1: YoloConv::empty(hidden, hidden, 1, 1, true),
+            conv2: Conv2dBias::empty(hidden, nc, 1, 1),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.dw0.forward(x)?;
+        let x = self.conv0.forward(&x)?;
+        let x = self.dw1.forward(&x)?;
+        let x = self.conv1.forward(&x)?;
+        self.conv2.forward(&x)
+    }
+}
+
+impl HasStateDict for ClsBranch {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.dw0.state_dict(&prefixed(prefix, "0.0"));
+        sd.extend(self.conv0.state_dict(&prefixed(prefix, "0.1")));
+        sd.extend(self.dw1.state_dict(&prefixed(prefix, "1.0")));
+        sd.extend(self.conv1.state_dict(&prefixed(prefix, "1.1")));
+        sd.extend(self.conv2.state_dict(&prefixed(prefix, "2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.dw0.load_state_dict(sd, &prefixed(prefix, "0.0"))?;
+        self.conv0.load_state_dict(sd, &prefixed(prefix, "0.1"))?;
+        self.dw1.load_state_dict(sd, &prefixed(prefix, "1.0"))?;
+        self.conv1.load_state_dict(sd, &prefixed(prefix, "1.1"))?;
+        self.conv2.load_state_dict(sd, &prefixed(prefix, "2"))?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Postprocess — top-k selection (outside JIT graph)
+// ---------------------------------------------------------------------------
+
+/// A single detection: `(x1, y1, x2, y2, confidence, class_id)`.
+pub type Detection = [f32; 6];
+
+/// Top-k postprocess on raw `[B, 4+nc, A]` f32 data.
+///
+/// Implements the two-stage selection from Ultralytics:
+/// 1. Pre-filter anchors by max class score (top-k).
+/// 2. Global top-k across all `(anchor, class)` pairs within those anchors.
+pub fn postprocess_raw(data: &[f32], shape: &[usize], nc: usize, max_det: usize) -> Result<Vec<Vec<Detection>>> {
+    let batch = shape[0];
+    let out_ch = shape[1];
+    let anchors = shape[2];
+
+    let stride_b = out_ch * anchors;
+    let stride_c = anchors;
+
+    let k = max_det.min(anchors);
+    let mut results = Vec::with_capacity(batch);
+
+    for b in 0..batch {
+        // Stage 1: top-k anchors by max class score.
+        let mut max_scores: Vec<(f32, usize)> = (0..anchors)
+            .map(|a| {
+                let mut best = 0.0f32;
+                for c in 0..nc {
+                    let s = data[b * stride_b + (4 + c) * stride_c + a];
+                    if s > best {
+                        best = s;
+                    }
+                }
+                (best, a)
+            })
+            .collect();
+        max_scores.sort_by(|a, b2| b2.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        max_scores.truncate(k);
+
+        // Stage 2: top-k (anchor, class) within the pre-filtered anchors.
+        let mut candidates: Vec<(f32, usize, usize)> = Vec::with_capacity(k * nc);
+        for &(_score, a) in &max_scores {
+            for c in 0..nc {
+                let s = data[b * stride_b + (4 + c) * stride_c + a];
+                candidates.push((s, a, c));
+            }
+        }
+        candidates.sort_by(|a, b2| b2.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.truncate(k);
+
+        let dets: Vec<Detection> = candidates
+            .iter()
+            .map(|&(score, a, c)| {
+                let base = b * stride_b;
+                [
+                    data[base + a],
+                    data[base + stride_c + a],
+                    data[base + 2 * stride_c + a],
+                    data[base + 3 * stride_c + a],
+                    score,
+                    c as f32,
+                ]
+            })
+            .collect();
+        results.push(dets);
+    }
+
+    Ok(results)
+}
+
+/// Top-k postprocess on a realized `[B, 4+nc, A]` tensor. Returns one
+/// `Vec<Detection>` per image, sorted by confidence descending.
+pub fn postprocess(preds: &mut Tensor, nc: usize, max_det: usize) -> Result<Vec<Vec<Detection>>> {
+    preds.realize().context(TensorSnafu)?;
+    let shape = preds.shape().context(TensorSnafu)?;
+    let batch: usize = shape[0].as_const().context(SymbolicShapeSnafu { what: "postprocess batch" })?;
+    let out_ch: usize = shape[1].as_const().context(SymbolicShapeSnafu { what: "postprocess channels" })?;
+    let anchors: usize = shape[2].as_const().context(SymbolicShapeSnafu { what: "postprocess anchors" })?;
+
+    let data = preds.as_vec::<f32>().context(TensorSnafu)?;
+    postprocess_raw(&data, &[batch, out_ch, anchors], nc, max_det)
+}

--- a/model/src/yolo/jit.rs
+++ b/model/src/yolo/jit.rs
@@ -1,0 +1,21 @@
+//! JIT wrappers for YOLO v26 models.
+
+extern crate self as svod_model;
+
+use svod_macros::jit_wrapper;
+
+use super::detect::Yolo26Detect;
+
+jit_wrapper! {
+    Yolo26DetectJit(Yolo26Detect) {
+        images: Tensor,
+
+        vars {
+            b: (1, model.config.max_batch_size),
+        }
+
+        build(images, b) {
+            model.forward(images, &b)
+        }
+    }
+}

--- a/model/src/yolo/loader.rs
+++ b/model/src/yolo/loader.rs
@@ -1,0 +1,51 @@
+//! Shared loader helpers for YOLO models.
+
+use std::path::Path;
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, StateDict};
+
+use super::error::{HubSnafu, Result, StateSnafu, TensorSnafu};
+
+/// Download `model.safetensors` from HuggingFace Hub.
+pub fn download_safetensors(model_id: &str, revision: &str) -> Result<std::path::PathBuf> {
+    let api = hf_hub::api::sync::Api::new().context(HubSnafu)?;
+    let repo =
+        api.repo(hf_hub::Repo::with_revision(model_id.to_string(), hf_hub::RepoType::Model, revision.to_string()));
+    repo.get("model.safetensors").context(HubSnafu)
+}
+
+/// Load + fold BN + strip `model.` prefix, returning a clean state dict.
+pub fn prepare_state_dict(path: &Path) -> Result<StateDict> {
+    let sd = state::load_safetensors(path).context(StateSnafu)?;
+    prepare_state_dict_from_sd(&sd)
+}
+
+/// Same as [`prepare_state_dict`] but from a pre-loaded state dict.
+pub fn prepare_state_dict_from_sd(sd: &StateDict) -> Result<StateDict> {
+    let sd = crate::blocks::remap::fold_batchnorm(sd.clone()).map_err(super::error::Error::from)?;
+    Ok(strip_model_prefix(&sd))
+}
+
+/// Strip the `model.` prefix from all keys if present (Ultralytics wraps
+/// everything in `self.model`).
+pub fn strip_model_prefix(sd: &StateDict) -> StateDict {
+    if sd.keys().any(|k| k.starts_with("model.")) {
+        sd.iter()
+            .map(|(k, v)| {
+                let k2 = k.strip_prefix("model.").unwrap_or(k);
+                (k2.to_string(), v.clone())
+            })
+            .collect()
+    } else {
+        sd.clone()
+    }
+}
+
+/// Shrink the batch dimension of a 4D NCHW tensor to a bound variable.
+pub fn shrink_batch(images: &Tensor, batch: &svod_tensor::BoundVariable) -> Result<Tensor> {
+    use svod_ir::SInt;
+    images.try_shrink([Some((SInt::Const(0), batch.as_sint())), None, None, None]).context(TensorSnafu)
+}

--- a/model/src/yolo/mod.rs
+++ b/model/src/yolo/mod.rs
@@ -1,0 +1,65 @@
+//! YOLO v26 — multi-task vision models.
+//!
+//! Each task is a separate type sharing common backbone/neck infrastructure:
+//!
+//! - [`Yolo26Detect`] — object detection (end2end, reg_max=1, NMS-free)
+//! - [`Yolo26DetectP2`] — detection with extra P2/4 scale
+//! - [`Yolo26DetectP6`] — detection with extra P6/64 scale
+//! - [`Yolo26Classify`] — image classification
+//! - [`Yolo26Segment`] — instance segmentation
+//! - [`Yolo26Obb`] — oriented bounding box detection
+//! - [`Yolo26Pose`] — pose estimation
+//! - [`Yolo26Depth`] — monocular depth estimation
+//! - [`Yolo26SemSeg`] — semantic segmentation
+//!
+//! ## Recipe
+//!
+//! ```no_run
+//! use svod_model::yolo::{Yolo26Detect, YoloConfig, YoloScale, Yolo26DetectJit, postprocess};
+//! use svod_model::jit::InputSpec;
+//!
+//! let model = Yolo26Detect::from_hub("ultralytics/yolo26n",
+//!     YoloConfig::new(YoloScale::Nano, 80))?;
+//!
+//! let mut jit = Yolo26DetectJit::new(model);
+//! jit.prepare(InputSpec::f32(&[1, 3, 640, 640]))?;
+//! // copy NCHW image into jit.images_mut()?, then:
+//! jit.execute()?;
+//! let preds = jit.output()?;
+//! let detections = postprocess(&preds, 80, 300)?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+mod backbone;
+mod blocks;
+mod classify;
+mod config;
+mod depth;
+mod detect;
+mod error;
+mod head;
+mod jit;
+mod loader;
+mod neck;
+mod obb;
+mod pose;
+mod segment;
+mod semseg;
+
+pub use backbone::{YoloBackbone, YoloBackboneCls, YoloBackboneP6, scaled_channels, upsample_nearest_2x};
+pub use blocks::{
+    Attention, C2PSA, C2f, C3k, C3k2, C3k2Inner, Conv2dBias, ConvTranspose2dBias, PSABlock, Sppf, YoloBottleneck,
+    YoloConv,
+};
+pub use classify::{ClassifyHead, Yolo26Classify};
+pub use config::{YoloConfig, YoloScale, make_depth, make_divisible, scale_channels};
+pub use depth::{DepthHead, Yolo26Depth};
+pub use detect::{Detect, Yolo26Detect, Yolo26DetectP2, Yolo26DetectP6};
+pub use error::{Error, Result};
+pub use head::{BoxBranch, ClsBranch, Detection, postprocess, postprocess_raw};
+pub use jit::Yolo26DetectJit;
+pub use neck::{YoloNeck, YoloNeckP2, YoloNeckP6};
+pub use obb::{AngleBranch, OBB26, Yolo26Obb};
+pub use pose::{Pose26, PoseFeatBranch, Yolo26Pose};
+pub use segment::{MaskBranch, Proto26, Segment26, Yolo26Segment};
+pub use semseg::{SemSegClassifier, Yolo26SemSeg};

--- a/model/src/yolo/neck/mod.rs
+++ b/model/src/yolo/neck/mod.rs
@@ -1,0 +1,13 @@
+//! YOLO v26 FPN+PAN neck variants.
+//!
+//! - [`YoloNeck`] — standard P3-P5 (layers 11-22)
+//! - [`YoloNeckP2`] — extended P2-P5 (layers 11-28)
+//! - [`YoloNeckP6`] — extended P3-P6 (layers 13-30)
+
+pub(crate) mod p2;
+pub(crate) mod p6;
+pub(crate) mod standard;
+
+pub use p2::YoloNeckP2;
+pub use p6::YoloNeckP6;
+pub use standard::YoloNeck;

--- a/model/src/yolo/neck/p2.rs
+++ b/model/src/yolo/neck/p2.rs
@@ -1,0 +1,129 @@
+//! [`YoloNeckP2`] — YOLO v26-P2 FPN+PAN neck (layers 11–28).
+//!
+//! Extends the standard neck with one extra FPN top-down stage (reaching
+//! P2/4) and one extra PAN bottom-up stage. Outputs four detection feature
+//! maps at strides 4, 8, 16, 32.
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use crate::yolo::backbone::upsample_nearest_2x;
+use crate::yolo::blocks::conv::YoloConv;
+use crate::yolo::blocks::csp::C3k2;
+use crate::yolo::config::{YoloScale, make_depth, scale_channels};
+use crate::yolo::error::{Result, TensorSnafu};
+
+/// P2 neck (layers 11–28). Takes four backbone features `(l2, l4, l6, l10)`
+/// and produces `(P2, P3, P4, P5)` at strides 4, 8, 16, 32.
+#[derive(Clone)]
+pub struct YoloNeckP2 {
+    pub c3k2_13: C3k2,
+    pub c3k2_16: C3k2,
+    pub c3k2_19: C3k2,
+    pub conv20: YoloConv,
+    pub c3k2_22: C3k2,
+    pub conv23: YoloConv,
+    pub c3k2_25: C3k2,
+    pub conv26: YoloConv,
+    pub c3k2_28: C3k2,
+}
+
+impl YoloNeckP2 {
+    pub fn empty(scale: YoloScale) -> Self {
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let sc = |yaml_c| scale_channels(yaml_c, scale);
+        let c1 = sc(128);
+        let c2 = sc(256);
+        let c3 = sc(512);
+        let c4 = sc(1024);
+        Self {
+            // Layer 13: C3k2 [512, True] — input cat(upsample(c4), c3) = c4+c3
+            c3k2_13: C3k2::empty(c4 + c3, c3, d(2), true, 0.5, true, false),
+            // Layer 16: C3k2 [256, True] — input cat(upsample(l13_out=c3), l4=c3) = c3+c3
+            c3k2_16: C3k2::empty(c3 + c3, c2, d(2), true, 0.5, true, false),
+            // Layer 19: C3k2 [128, True] — input cat(upsample(l16_out=c2), l2=c2) = c2+c2
+            c3k2_19: C3k2::empty(c2 + c2, c1, d(2), true, 0.5, true, false),
+            // Layer 20: Conv [128, 3, 2]
+            conv20: YoloConv::empty(c1, c1, 3, 2, true),
+            // Layer 22: C3k2 [256, True] — input cat(conv20_out, c3k2_16_out)
+            c3k2_22: C3k2::empty(c1 + c2, c2, d(2), true, 0.5, true, false),
+            // Layer 23: Conv [256, 3, 2]
+            conv23: YoloConv::empty(c2, c2, 3, 2, true),
+            // Layer 25: C3k2 [512, True] — input cat(conv23_out, c3k2_13_out)
+            c3k2_25: C3k2::empty(c2 + c3, c3, d(2), true, 0.5, true, false),
+            // Layer 26: Conv [512, 3, 2]
+            conv26: YoloConv::empty(c3, c3, 3, 2, true),
+            // Layer 28: C3k2 [1024, True, 0.5, True] — attn=True
+            c3k2_28: C3k2::empty(c3 + c4, c4, d(1), true, 0.5, true, true),
+        }
+    }
+
+    /// Run the P2 FPN+PAN. Returns `(P2, P3, P4, P5)` detection features.
+    pub fn forward(
+        &self,
+        l2: &Tensor,
+        l4: &Tensor,
+        l6: &Tensor,
+        l10: &Tensor,
+    ) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+        // FPN top-down: l10 → up → cat(l6) → c3k2_13 → up → cat(l4) → c3k2_16 → up → cat(l2) → c3k2_19
+        let up = upsample_nearest_2x(l10)?;
+        let cat = Tensor::cat(&[&up, l6], 1).context(TensorSnafu)?;
+        let l13 = self.c3k2_13.forward(&cat)?;
+
+        let up = upsample_nearest_2x(&l13)?;
+        let cat = Tensor::cat(&[&up, l4], 1).context(TensorSnafu)?;
+        let l16 = self.c3k2_16.forward(&cat)?;
+
+        let up = upsample_nearest_2x(&l16)?;
+        let cat = Tensor::cat(&[&up, l2], 1).context(TensorSnafu)?;
+        let l19 = self.c3k2_19.forward(&cat)?;
+
+        // PAN bottom-up: l19 → conv20 → cat(l16) → c3k2_22 → conv23 → cat(l13) → c3k2_25 → conv26 → cat(l10) → c3k2_28
+        let l20 = self.conv20.forward(&l19)?;
+        let cat = Tensor::cat(&[&l20, &l16], 1).context(TensorSnafu)?;
+        let l22 = self.c3k2_22.forward(&cat)?;
+
+        let l23 = self.conv23.forward(&l22)?;
+        let cat = Tensor::cat(&[&l23, &l13], 1).context(TensorSnafu)?;
+        let l25 = self.c3k2_25.forward(&cat)?;
+
+        let l26 = self.conv26.forward(&l25)?;
+        let cat = Tensor::cat(&[&l26, l10], 1).context(TensorSnafu)?;
+        let l28 = self.c3k2_28.forward(&cat)?;
+
+        Ok((l19, l22, l25, l28))
+    }
+}
+
+impl HasStateDict for YoloNeckP2 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        let mut sd = self.c3k2_13.state_dict(&p(13));
+        sd.extend(self.c3k2_16.state_dict(&p(16)));
+        sd.extend(self.c3k2_19.state_dict(&p(19)));
+        sd.extend(self.conv20.state_dict(&p(20)));
+        sd.extend(self.c3k2_22.state_dict(&p(22)));
+        sd.extend(self.conv23.state_dict(&p(23)));
+        sd.extend(self.c3k2_25.state_dict(&p(25)));
+        sd.extend(self.conv26.state_dict(&p(26)));
+        sd.extend(self.c3k2_28.state_dict(&p(28)));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        self.c3k2_13.load_state_dict(sd, &p(13))?;
+        self.c3k2_16.load_state_dict(sd, &p(16))?;
+        self.c3k2_19.load_state_dict(sd, &p(19))?;
+        self.conv20.load_state_dict(sd, &p(20))?;
+        self.c3k2_22.load_state_dict(sd, &p(22))?;
+        self.conv23.load_state_dict(sd, &p(23))?;
+        self.c3k2_25.load_state_dict(sd, &p(25))?;
+        self.conv26.load_state_dict(sd, &p(26))?;
+        self.c3k2_28.load_state_dict(sd, &p(28))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/neck/p6.rs
+++ b/model/src/yolo/neck/p6.rs
@@ -1,0 +1,125 @@
+//! [`YoloNeckP6`] — YOLO v26-P6 FPN+PAN neck (layers 13–30).
+//!
+//! Takes four P6 backbone features `(l4, l6, l8, l12)` at strides 8, 16, 32,
+//! 64 and produces four detection feature maps `(P3, P4, P5, P6)`.
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use crate::yolo::backbone::p6::p6_scaled_channels;
+use crate::yolo::backbone::upsample_nearest_2x;
+use crate::yolo::blocks::conv::YoloConv;
+use crate::yolo::blocks::csp::C3k2;
+use crate::yolo::config::{YoloScale, make_depth};
+use crate::yolo::error::{Result, TensorSnafu};
+
+/// P6 neck (layers 13–30). Takes four backbone features `(l4, l6, l8, l12)`
+/// and produces `(P3, P4, P5, P6)` at strides 8, 16, 32, 64.
+#[derive(Clone)]
+pub struct YoloNeckP6 {
+    pub c3k2_15: C3k2,
+    pub c3k2_18: C3k2,
+    pub c3k2_21: C3k2,
+    pub conv22: YoloConv,
+    pub c3k2_24: C3k2,
+    pub conv25: YoloConv,
+    pub c3k2_27: C3k2,
+    pub conv28: YoloConv,
+    pub c3k2_30: C3k2,
+}
+
+impl YoloNeckP6 {
+    pub fn empty(scale: YoloScale) -> Self {
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let [_, _, c2, c3, c5, c6] = p6_scaled_channels(scale);
+        Self {
+            // Layer 15: C3k2 [768, True] — input cat(upsample(c6), c5) = c6+c5
+            c3k2_15: C3k2::empty(c6 + c5, c5, d(2), true, 0.5, true, false),
+            // Layer 18: C3k2 [512, True] — input cat(upsample(c5), c3) = c5+c3
+            c3k2_18: C3k2::empty(c5 + c3, c3, d(2), true, 0.5, true, false),
+            // Layer 21: C3k2 [256, True] — input cat(upsample(l18_out=c3), l4=c3) = c3+c3
+            c3k2_21: C3k2::empty(c3 + c3, c2, d(2), true, 0.5, true, false),
+            // Layer 22: Conv [256, 3, 2]
+            conv22: YoloConv::empty(c2, c2, 3, 2, true),
+            // Layer 24: C3k2 [512, True] — input cat(conv22_out, c3k2_18_out)
+            c3k2_24: C3k2::empty(c2 + c3, c3, d(2), true, 0.5, true, false),
+            // Layer 25: Conv [512, 3, 2]
+            conv25: YoloConv::empty(c3, c3, 3, 2, true),
+            // Layer 27: C3k2 [768, True] — input cat(conv25_out, c3k2_15_out)
+            c3k2_27: C3k2::empty(c3 + c5, c5, d(2), true, 0.5, true, false),
+            // Layer 28: Conv [768, 3, 2]
+            conv28: YoloConv::empty(c5, c5, 3, 2, true),
+            // Layer 30: C3k2 [1024, True, 0.5, True] — attn=True
+            c3k2_30: C3k2::empty(c5 + c6, c6, d(1), true, 0.5, true, true),
+        }
+    }
+
+    /// Run the P6 FPN+PAN. Returns `(P3, P4, P5, P6)` detection features.
+    pub fn forward(
+        &self,
+        l4: &Tensor,
+        l6: &Tensor,
+        l8: &Tensor,
+        l12: &Tensor,
+    ) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+        // FPN top-down: l12 → up → cat(l8) → c3k2_15 → up → cat(l6) → c3k2_18 → up → cat(l4) → c3k2_21
+        let up = upsample_nearest_2x(l12)?;
+        let cat = Tensor::cat(&[&up, l8], 1).context(TensorSnafu)?;
+        let l15 = self.c3k2_15.forward(&cat)?;
+
+        let up = upsample_nearest_2x(&l15)?;
+        let cat = Tensor::cat(&[&up, l6], 1).context(TensorSnafu)?;
+        let l18 = self.c3k2_18.forward(&cat)?;
+
+        let up = upsample_nearest_2x(&l18)?;
+        let cat = Tensor::cat(&[&up, l4], 1).context(TensorSnafu)?;
+        let l21 = self.c3k2_21.forward(&cat)?;
+
+        // PAN bottom-up: l21 → conv22 → cat(l18) → c3k2_24 → conv25 → cat(l15) → c3k2_27 → conv28 → cat(l12) → c3k2_30
+        let l22 = self.conv22.forward(&l21)?;
+        let cat = Tensor::cat(&[&l22, &l18], 1).context(TensorSnafu)?;
+        let l24 = self.c3k2_24.forward(&cat)?;
+
+        let l25 = self.conv25.forward(&l24)?;
+        let cat = Tensor::cat(&[&l25, &l15], 1).context(TensorSnafu)?;
+        let l27 = self.c3k2_27.forward(&cat)?;
+
+        let l28 = self.conv28.forward(&l27)?;
+        let cat = Tensor::cat(&[&l28, l12], 1).context(TensorSnafu)?;
+        let l30 = self.c3k2_30.forward(&cat)?;
+
+        Ok((l21, l24, l27, l30))
+    }
+}
+
+impl HasStateDict for YoloNeckP6 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        let mut sd = self.c3k2_15.state_dict(&p(15));
+        sd.extend(self.c3k2_18.state_dict(&p(18)));
+        sd.extend(self.c3k2_21.state_dict(&p(21)));
+        sd.extend(self.conv22.state_dict(&p(22)));
+        sd.extend(self.c3k2_24.state_dict(&p(24)));
+        sd.extend(self.conv25.state_dict(&p(25)));
+        sd.extend(self.c3k2_27.state_dict(&p(27)));
+        sd.extend(self.conv28.state_dict(&p(28)));
+        sd.extend(self.c3k2_30.state_dict(&p(30)));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        self.c3k2_15.load_state_dict(sd, &p(15))?;
+        self.c3k2_18.load_state_dict(sd, &p(18))?;
+        self.c3k2_21.load_state_dict(sd, &p(21))?;
+        self.conv22.load_state_dict(sd, &p(22))?;
+        self.c3k2_24.load_state_dict(sd, &p(24))?;
+        self.conv25.load_state_dict(sd, &p(25))?;
+        self.c3k2_27.load_state_dict(sd, &p(27))?;
+        self.conv28.load_state_dict(sd, &p(28))?;
+        self.c3k2_30.load_state_dict(sd, &p(30))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/neck/standard.rs
+++ b/model/src/yolo/neck/standard.rs
@@ -1,0 +1,95 @@
+//! YOLO v26 FPN+PAN neck (layers 11–22).
+//!
+//! Takes backbone skip features `(l4, l6, l10)` and produces three detection
+//! feature maps `(P3, P4, P5)` at strides 8, 16, 32.
+
+use snafu::ResultExt;
+use svod_tensor::Tensor;
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use crate::yolo::backbone::{scaled_channels, upsample_nearest_2x};
+use crate::yolo::blocks::conv::YoloConv;
+use crate::yolo::blocks::csp::C3k2;
+use crate::yolo::config::{YoloScale, make_depth};
+use crate::yolo::error::{Result, TensorSnafu};
+
+/// Full FPN+PAN neck (layers 11–22). Shared by detect, segment, obb, pose,
+/// and depth models.
+#[derive(Clone)]
+pub struct YoloNeck {
+    pub c3k2_13: C3k2,
+    pub c3k2_16: C3k2,
+    pub conv17: YoloConv,
+    pub c3k2_19: C3k2,
+    pub conv20: YoloConv,
+    pub c3k2_22: C3k2,
+}
+
+impl YoloNeck {
+    pub fn empty(scale: YoloScale) -> Self {
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let [_, _, c2, c3, c4] = scaled_channels(scale);
+        Self {
+            // Layer 13: C3k2 [512, True] — input is cat(upsample(c4), c3) = c4+c3
+            c3k2_13: C3k2::empty(c4 + c3, c3, d(2), true, 0.5, true, false),
+            // Layer 16: C3k2 [256, True] — input is cat(upsample(c3), c3) = c3+c3
+            c3k2_16: C3k2::empty(c3 + c3, c2, d(2), true, 0.5, true, false),
+            // Layer 17: Conv [256, 3, 2]
+            conv17: YoloConv::empty(c2, c2, 3, 2, true),
+            // Layer 19: C3k2 [512, True] — input is cat(conv17_out, c3k2_13_out)
+            c3k2_19: C3k2::empty(c2 + c3, c3, d(2), true, 0.5, true, false),
+            // Layer 20: Conv [512, 3, 2]
+            conv20: YoloConv::empty(c3, c3, 3, 2, true),
+            // Layer 22: C3k2 [1024, True, 0.5, True] — attn=True
+            c3k2_22: C3k2::empty(c3 + c4, c4, d(1), true, 0.5, true, true),
+        }
+    }
+
+    /// Run the full FPN+PAN. Returns `(P3, P4, P5)` detection features.
+    pub fn forward(&self, l4: &Tensor, l6: &Tensor, l10: &Tensor) -> Result<(Tensor, Tensor, Tensor)> {
+        // FPN top-down
+        let up = upsample_nearest_2x(l10)?;
+        let cat = Tensor::cat(&[&up, l6], 1).context(TensorSnafu)?;
+        let l13 = self.c3k2_13.forward(&cat)?;
+
+        let up = upsample_nearest_2x(&l13)?;
+        let cat = Tensor::cat(&[&up, l4], 1).context(TensorSnafu)?;
+        let l16 = self.c3k2_16.forward(&cat)?;
+
+        // PAN bottom-up
+        let l17 = self.conv17.forward(&l16)?;
+        let cat = Tensor::cat(&[&l17, &l13], 1).context(TensorSnafu)?;
+        let l19 = self.c3k2_19.forward(&cat)?;
+
+        let l20 = self.conv20.forward(&l19)?;
+        let cat = Tensor::cat(&[&l20, l10], 1).context(TensorSnafu)?;
+        let l22 = self.c3k2_22.forward(&cat)?;
+
+        Ok((l16, l19, l22))
+    }
+}
+
+impl HasStateDict for YoloNeck {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        let mut sd = self.c3k2_13.state_dict(&p(13));
+        sd.extend(self.c3k2_16.state_dict(&p(16)));
+        sd.extend(self.conv17.state_dict(&p(17)));
+        sd.extend(self.c3k2_19.state_dict(&p(19)));
+        sd.extend(self.conv20.state_dict(&p(20)));
+        sd.extend(self.c3k2_22.state_dict(&p(22)));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        let p = |i: usize| prefixed(prefix, &i.to_string());
+        self.c3k2_13.load_state_dict(sd, &p(13))?;
+        self.c3k2_16.load_state_dict(sd, &p(16))?;
+        self.conv17.load_state_dict(sd, &p(17))?;
+        self.c3k2_19.load_state_dict(sd, &p(19))?;
+        self.conv20.load_state_dict(sd, &p(20))?;
+        self.c3k2_22.load_state_dict(sd, &p(22))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/obb.rs
+++ b/model/src/yolo/obb.rs
@@ -1,0 +1,281 @@
+//! [`Yolo26Obb`] — YOLO v26 oriented bounding box detection.
+//!
+//! Detection head + angle prediction branch per scale. Boxes decoded as
+//! rotated boxes via `dist2rbox`. Returns `[B, 4+nc+1, A]`.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::backbone::YoloBackbone;
+use super::blocks::conv::{Conv2dBias, YoloConv};
+use super::config::DETECT_STRIDES;
+use super::error::{Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::head::{BoxBranch, ClsBranch, make_anchors};
+use super::loader;
+use super::neck::YoloNeck;
+
+/// Angle branch: Conv(k3) → Conv(k3) → Conv2d(k1, bias). Outputs 1 channel.
+///
+/// State-dict keys: `0.*`, `1.*`, `2.weight`, `2.bias`.
+#[derive(Clone)]
+pub struct AngleBranch {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+    pub conv2: Conv2dBias,
+}
+
+impl AngleBranch {
+    pub fn empty(in_ch: usize, ne: usize) -> Self {
+        let hidden = (in_ch / 4).max(ne);
+        Self {
+            conv0: YoloConv::empty(in_ch, hidden, 3, 1, true),
+            conv1: YoloConv::empty(hidden, hidden, 3, 1, true),
+            conv2: Conv2dBias::empty(hidden, ne, 1, 1),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        self.conv2.forward(&x)
+    }
+}
+
+impl HasStateDict for AngleBranch {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv0.state_dict(&prefixed(prefix, "0"));
+        sd.extend(self.conv1.state_dict(&prefixed(prefix, "1")));
+        sd.extend(self.conv2.state_dict(&prefixed(prefix, "2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv0.load_state_dict(sd, &prefixed(prefix, "0"))?;
+        self.conv1.load_state_dict(sd, &prefixed(prefix, "1"))?;
+        self.conv2.load_state_dict(sd, &prefixed(prefix, "2"))?;
+        Ok(())
+    }
+}
+
+/// YOLO v26 OBB detection head (end2end, reg_max=1).
+///
+/// Reuses Detect's box+cls branches and adds an angle branch.
+/// Forward returns `[B, 4+nc+ne, A]` — rotated boxes + scores + angles.
+#[derive(Clone)]
+pub struct OBB26 {
+    pub cv2: Vec<BoxBranch>,
+    pub cv3: Vec<ClsBranch>,
+    pub cv4: Vec<AngleBranch>,
+    pub nc: usize,
+    pub reg_max: usize,
+    pub ne: usize,
+}
+
+impl OBB26 {
+    pub fn empty(ch: &[usize], nc: usize, reg_max: usize, ne: usize) -> Self {
+        let hidden_box = (16usize).max(ch[0] / 4).max(reg_max * 4);
+        let hidden_cls = ch[0].max(nc.min(100));
+        Self {
+            cv2: ch.iter().map(|&c| BoxBranch::empty(c, hidden_box, reg_max)).collect(),
+            cv3: ch.iter().map(|&c| ClsBranch::empty(c, hidden_cls, nc)).collect(),
+            cv4: ch.iter().map(|&c| AngleBranch::empty(c, ne)).collect(),
+            nc,
+            reg_max,
+            ne,
+        }
+    }
+
+    pub fn forward(&self, feats: &[Tensor]) -> Result<Tensor> {
+        let shape = feats[0].shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+
+        let mut boxes_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut scores_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut angle_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut feat_sizes: Vec<(usize, usize)> = Vec::with_capacity(feats.len());
+
+        for (i, feat) in feats.iter().enumerate() {
+            let fshape = feat.shape().context(TensorSnafu)?;
+            let h: usize = fshape[2].as_const().context(SymbolicShapeSnafu { what: "obb H" })?;
+            let w: usize = fshape[3].as_const().context(SymbolicShapeSnafu { what: "obb W" })?;
+            feat_sizes.push((h, w));
+            let hw = h * w;
+
+            let box_out = self.cv2[i].forward(feat)?;
+            boxes_list.push(
+                box_out.try_reshape([b.clone(), SInt::from(4 * self.reg_max), SInt::from(hw)]).context(TensorSnafu)?,
+            );
+
+            let cls_out = self.cv3[i].forward(feat)?;
+            scores_list
+                .push(cls_out.try_reshape([b.clone(), SInt::from(self.nc), SInt::from(hw)]).context(TensorSnafu)?);
+
+            let angle_out = self.cv4[i].forward(feat)?;
+            angle_list
+                .push(angle_out.try_reshape([b.clone(), SInt::from(self.ne), SInt::from(hw)]).context(TensorSnafu)?);
+        }
+
+        let boxes_refs: Vec<&Tensor> = boxes_list.iter().collect();
+        let scores_refs: Vec<&Tensor> = scores_list.iter().collect();
+        let angle_refs: Vec<&Tensor> = angle_list.iter().collect();
+
+        let boxes = Tensor::cat(&boxes_refs, 2).context(TensorSnafu)?;
+        let scores = Tensor::cat(&scores_refs, 2).context(TensorSnafu)?;
+        let angles = Tensor::cat(&angle_refs, 2).context(TensorSnafu)?;
+
+        let num_anchors: usize = feat_sizes.iter().map(|&(h, w)| h * w).sum();
+        let (anchors, strides) = make_anchors(&feat_sizes, &DETECT_STRIDES);
+
+        // dist2rbox decode (consumes angles for box rotation)
+        let dbox = dist2rbox(&boxes, &angles, &anchors, &strides, num_anchors)?;
+        let scores = scores.sigmoid().context(TensorSnafu)?;
+
+        // Cat: [B, 4+nc+ne, A] = dbox + scores + raw_angles
+        Tensor::cat(&[&dbox, &scores, &angles], 1).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for OBB26 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, br) in self.cv2.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv2.{i}"))));
+        }
+        for (i, br) in self.cv3.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv3.{i}"))));
+        }
+        for (i, br) in self.cv4.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv4.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, br) in self.cv2.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv2.{i}")))?;
+        }
+        for (i, br) in self.cv3.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv3.{i}")))?;
+        }
+        for (i, br) in self.cv4.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv4.{i}")))?;
+        }
+        Ok(())
+    }
+}
+
+/// Decode rotated boxes from distance + angle predictions.
+/// `boxes [B,4,A]`, `angles [B,1,A]`, `anchors [2,A]`, `strides [1,A]` → `[B,4,A]` (xywh).
+fn dist2rbox(
+    boxes: &Tensor,
+    angles: &Tensor,
+    anchors: &Tensor,
+    strides: &Tensor,
+    num_anchors: usize,
+) -> Result<Tensor> {
+    let parts = boxes.split(&[2, 2], 1).context(TensorSnafu)?;
+    let lt = &parts[0];
+    let rb = &parts[1];
+
+    let cos = angles.cos().context(TensorSnafu)?;
+    let sin = angles.sin().context(TensorSnafu)?;
+
+    // xf, yf = (rb - lt) / 2
+    let diff = rb.try_sub(lt).context(TensorSnafu)?;
+    let diff_halves = diff.split(&[1, 1], 1).context(TensorSnafu)?;
+    let xf = &diff_halves[0];
+    let yf = &diff_halves[1];
+    let half = Tensor::from_slice([0.5f32]);
+    let xf = xf.try_mul(&half).context(TensorSnafu)?;
+    let yf = yf.try_mul(&half).context(TensorSnafu)?;
+
+    // x = xf*cos - yf*sin, y = xf*sin + yf*cos
+    let x = xf.try_mul(&cos)?.try_sub(&yf.try_mul(&sin)?).context(TensorSnafu)?;
+    let y = xf.try_mul(&sin)?.try_add(&yf.try_mul(&cos)?).context(TensorSnafu)?;
+    let xy = Tensor::cat(&[&x, &y], 1).context(TensorSnafu)?;
+
+    // xy += anchors (broadcast [2,A] → [1,2,A])
+    let anchors_3d = anchors
+        .try_reshape([SInt::from(1isize), SInt::from(2isize), SInt::from(num_anchors as isize)])
+        .context(TensorSnafu)?;
+    let xy = xy.try_add(&anchors_3d).context(TensorSnafu)?;
+
+    // wh = lt + rb
+    let wh = lt.try_add(rb).context(TensorSnafu)?;
+    let bbox = Tensor::cat(&[&xy, &wh], 1).context(TensorSnafu)?;
+
+    let strides_3d = strides
+        .try_reshape([SInt::from(1isize), SInt::from(1isize), SInt::from(num_anchors as isize)])
+        .context(TensorSnafu)?;
+    bbox.try_mul(&strides_3d).context(TensorSnafu)
+}
+
+/// YOLO v26 OBB model.
+///
+/// Forward returns `[B, 4+nc+1, A]` — rotated boxes + scores + angle.
+#[derive(Clone)]
+pub struct Yolo26Obb {
+    pub config: super::config::YoloConfig,
+    pub backbone: YoloBackbone,
+    pub neck: YoloNeck,
+    pub head: OBB26,
+}
+
+impl Yolo26Obb {
+    pub fn with_zero_weights(config: super::config::YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, c2, c3, c4] = super::backbone::scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            neck: YoloNeck::empty(scale),
+            head: OBB26::empty(&[c2, c3, c4], config.nc, config.reg_max, 1),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: super::config::YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: super::config::YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: super::config::YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: super::config::YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l10) = self.backbone.forward(&x)?;
+        let (p3, p4, p5) = self.neck.forward(&l4, &l6, &l10)?;
+        self.head.forward(&[p3, p4, p5])
+    }
+}
+
+impl HasStateDict for Yolo26Obb {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "23")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "23"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/pose.rs
+++ b/model/src/yolo/pose.rs
@@ -1,0 +1,293 @@
+//! [`Yolo26Pose`] — YOLO v26 pose estimation.
+//!
+//! Detection head + keypoint prediction branches. Pose26 uses a shared
+//! feature extractor (Conv→Conv) then separate keypoint Conv2d head.
+//! At inference, sigma heads and RealNVP flow are not used.
+//!
+//! Forward returns `[B, 4+nc+nk, A]` — boxes + scores + decoded keypoints.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::backbone::YoloBackbone;
+use super::blocks::conv::{Conv2dBias, YoloConv};
+use super::config::DETECT_STRIDES;
+use super::error::{Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::head::{BoxBranch, ClsBranch, dist2bbox, make_anchors};
+use super::loader;
+use super::neck::YoloNeck;
+
+/// Pose shared feature extractor: Conv(k3) → Conv(k3).
+/// State-dict keys: `0.*`, `1.*`.
+#[derive(Clone)]
+pub struct PoseFeatBranch {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+}
+
+impl PoseFeatBranch {
+    pub fn empty(in_ch: usize, hidden: usize) -> Self {
+        Self { conv0: YoloConv::empty(in_ch, hidden, 3, 1, true), conv1: YoloConv::empty(hidden, hidden, 3, 1, true) }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv0.forward(x)?;
+        self.conv1.forward(&x)
+    }
+}
+
+impl HasStateDict for PoseFeatBranch {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv0.state_dict(&prefixed(prefix, "0"));
+        sd.extend(self.conv1.state_dict(&prefixed(prefix, "1")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv0.load_state_dict(sd, &prefixed(prefix, "0"))?;
+        self.conv1.load_state_dict(sd, &prefixed(prefix, "1"))?;
+        Ok(())
+    }
+}
+
+/// Pose26 head: Detect box+cls + shared pose features + keypoint prediction.
+///
+/// Forward returns `[B, 4+nc+nk, A]` — boxes + scores + decoded keypoints.
+#[derive(Clone)]
+pub struct Pose26 {
+    pub cv2: Vec<BoxBranch>,
+    pub cv3: Vec<ClsBranch>,
+    pub cv4: Vec<PoseFeatBranch>,
+    pub cv4_kpts: Vec<Conv2dBias>,
+    pub nc: usize,
+    pub reg_max: usize,
+    pub kpt_shape: (usize, usize),
+    pub nk: usize,
+}
+
+impl Pose26 {
+    pub fn empty(ch: &[usize], nc: usize, kpt_shape: (usize, usize), reg_max: usize) -> Self {
+        let nk = kpt_shape.0 * kpt_shape.1;
+        let hidden_box = (16usize).max(ch[0] / 4).max(reg_max * 4);
+        let hidden_cls = ch[0].max(nc.min(100));
+        // Pose26: c4 = max(ch[0]//4, num_kpts*(ndim+2))
+        let c4 = (ch[0] / 4).max(kpt_shape.0 * (kpt_shape.1 + 2));
+        Self {
+            cv2: ch.iter().map(|&c| BoxBranch::empty(c, hidden_box, reg_max)).collect(),
+            cv3: ch.iter().map(|&c| ClsBranch::empty(c, hidden_cls, nc)).collect(),
+            cv4: ch.iter().map(|&c| PoseFeatBranch::empty(c, c4)).collect(),
+            cv4_kpts: ch.iter().map(|_| Conv2dBias::empty(c4, nk, 1, 1)).collect(),
+            nc,
+            reg_max,
+            kpt_shape,
+            nk,
+        }
+    }
+
+    pub fn forward(&self, feats: &[Tensor]) -> Result<Tensor> {
+        let shape = feats[0].shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+
+        let mut boxes_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut scores_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut kpts_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut feat_sizes: Vec<(usize, usize)> = Vec::with_capacity(feats.len());
+
+        for (i, feat) in feats.iter().enumerate() {
+            let fshape = feat.shape().context(TensorSnafu)?;
+            let h: usize = fshape[2].as_const().context(SymbolicShapeSnafu { what: "pose H" })?;
+            let w: usize = fshape[3].as_const().context(SymbolicShapeSnafu { what: "pose W" })?;
+            feat_sizes.push((h, w));
+            let hw = h * w;
+
+            let box_out = self.cv2[i].forward(feat)?;
+            boxes_list.push(
+                box_out.try_reshape([b.clone(), SInt::from(4 * self.reg_max), SInt::from(hw)]).context(TensorSnafu)?,
+            );
+
+            let cls_out = self.cv3[i].forward(feat)?;
+            scores_list
+                .push(cls_out.try_reshape([b.clone(), SInt::from(self.nc), SInt::from(hw)]).context(TensorSnafu)?);
+
+            let features = self.cv4[i].forward(feat)?;
+            let kpts = self.cv4_kpts[i].forward(&features)?;
+            kpts_list.push(kpts.try_reshape([b.clone(), SInt::from(self.nk), SInt::from(hw)]).context(TensorSnafu)?);
+        }
+
+        let boxes_refs: Vec<&Tensor> = boxes_list.iter().collect();
+        let scores_refs: Vec<&Tensor> = scores_list.iter().collect();
+        let kpts_refs: Vec<&Tensor> = kpts_list.iter().collect();
+
+        let boxes = Tensor::cat(&boxes_refs, 2).context(TensorSnafu)?;
+        let scores = Tensor::cat(&scores_refs, 2).context(TensorSnafu)?;
+        let kpts = Tensor::cat(&kpts_refs, 2).context(TensorSnafu)?;
+
+        let num_anchors: usize = feat_sizes.iter().map(|&(h, w)| h * w).sum();
+        let (anchors, strides) = make_anchors(&feat_sizes, &DETECT_STRIDES);
+
+        let dbox = dist2bbox(&boxes, &anchors, &strides, num_anchors)?;
+        let scores = scores.sigmoid().context(TensorSnafu)?;
+
+        // kpts_decode (Pose26 export path): y = kpts.view(bs, num_kpts, ndim, -1)
+        // a = (y[:,:,:2] + anchors) * strides; vis = sigmoid(y[:,:,2:3])
+        let decoded_kpts = kpts_decode(&kpts, &anchors, &strides, self.kpt_shape.0, self.kpt_shape.1, num_anchors)?;
+
+        Tensor::cat(&[&dbox, &scores, &decoded_kpts], 1).context(TensorSnafu)
+    }
+}
+
+/// Pose26 keypoint decode (export path):
+/// `y = kpts.view(bs, num_kpts, ndim, A)`
+/// `a = (y[:,:,:2] + anchors) * strides`
+/// if ndim==3: `a = cat(a, y[:,:,2:3].sigmoid(), 2)`
+/// `return a.view(bs, nk, A)`
+fn kpts_decode(
+    kpts: &Tensor,
+    anchors: &Tensor,
+    strides: &Tensor,
+    num_kpts: usize,
+    ndim: usize,
+    num_anchors: usize,
+) -> Result<Tensor> {
+    let b = kpts.shape().context(TensorSnafu)?[0].clone();
+
+    // [B, nk, A] → [B, num_kpts, ndim, A]
+    let y = kpts
+        .try_reshape([b.clone(), SInt::from(num_kpts), SInt::from(ndim), SInt::from(num_anchors)])
+        .context(TensorSnafu)?;
+
+    // xy: [B, num_kpts, 2, A] = y[:,:,:2,:]
+    let xy =
+        y.slice_with().starts(&[0, 0, 0, 0]).ends(&[i64::MAX, i64::MAX, 2, i64::MAX]).call().context(TensorSnafu)?;
+
+    // anchors [2,A] → [1,1,2,A], strides [1,A] → [1,1,1,A]
+    let anchors_4d = anchors
+        .try_reshape([SInt::from(1isize), SInt::from(1isize), SInt::from(2isize), SInt::from(num_anchors)])
+        .context(TensorSnafu)?;
+    let strides_4d = strides
+        .try_reshape([SInt::from(1isize), SInt::from(1isize), SInt::from(1isize), SInt::from(num_anchors)])
+        .context(TensorSnafu)?;
+
+    let xy = xy.try_add(&anchors_4d).context(TensorSnafu)?;
+    let xy = xy.try_mul(&strides_4d).context(TensorSnafu)?;
+
+    if ndim == 3 {
+        // vis: [B, num_kpts, 1, A] = y[:,:,2:3,:]
+        let vis = y
+            .slice_with()
+            .starts(&[0, 0, 2, 0])
+            .ends(&[i64::MAX, i64::MAX, 3, i64::MAX])
+            .call()
+            .context(TensorSnafu)?;
+        let vis = vis.sigmoid().context(TensorSnafu)?;
+        let cat = Tensor::cat(&[&xy, &vis], 2).context(TensorSnafu)?;
+        cat.try_reshape([b, SInt::from(num_kpts * ndim), SInt::from(num_anchors)]).context(TensorSnafu)
+    } else {
+        xy.try_reshape([b, SInt::from(num_kpts * ndim), SInt::from(num_anchors)]).context(TensorSnafu)
+    }
+}
+
+impl HasStateDict for Pose26 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, br) in self.cv2.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv2.{i}"))));
+        }
+        for (i, br) in self.cv3.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv3.{i}"))));
+        }
+        for (i, br) in self.cv4.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv4.{i}"))));
+        }
+        for (i, kpt) in self.cv4_kpts.iter().enumerate() {
+            sd.extend(kpt.state_dict(&prefixed(prefix, &format!("one2one_cv4_kpts.{i}"))));
+        }
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, br) in self.cv2.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv2.{i}")))?;
+        }
+        for (i, br) in self.cv3.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv3.{i}")))?;
+        }
+        for (i, br) in self.cv4.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv4.{i}")))?;
+        }
+        for (i, kpt) in self.cv4_kpts.iter_mut().enumerate() {
+            kpt.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv4_kpts.{i}")))?;
+        }
+        Ok(())
+    }
+}
+
+/// YOLO v26 pose estimation model.
+///
+/// Forward returns `[B, 4+nc+nk, A]` — boxes + scores + decoded keypoints.
+#[derive(Clone)]
+pub struct Yolo26Pose {
+    pub config: super::config::YoloConfig,
+    pub backbone: YoloBackbone,
+    pub neck: YoloNeck,
+    pub head: Pose26,
+}
+
+impl Yolo26Pose {
+    pub fn with_zero_weights(config: super::config::YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, c2, c3, c4] = super::backbone::scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            neck: YoloNeck::empty(scale),
+            head: Pose26::empty(&[c2, c3, c4], config.nc, (17, 3), config.reg_max),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: super::config::YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: super::config::YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: super::config::YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: super::config::YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l10) = self.backbone.forward(&x)?;
+        let (p3, p4, p5) = self.neck.forward(&l4, &l6, &l10)?;
+        self.head.forward(&[p3, p4, p5])
+    }
+}
+
+impl HasStateDict for Yolo26Pose {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "23")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "23"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/segment.rs
+++ b/model/src/yolo/segment.rs
@@ -1,0 +1,320 @@
+//! [`Yolo26Segment`] — YOLO v26 instance segmentation.
+//!
+//! Detection head + mask coefficient branch + Proto26 prototype generator.
+//! Forward returns `(predictions [B, 4+nc+nm, A], protos [B, nm, H/4, W/4])`.
+
+use snafu::{OptionExt, ResultExt};
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::backbone::{YoloBackbone, upsample_nearest_2x};
+use super::blocks::conv::ConvTranspose2dBias;
+use super::blocks::conv::{Conv2dBias, YoloConv};
+use super::config::DETECT_STRIDES;
+use super::error::{Result, StateSnafu, SymbolicShapeSnafu, TensorSnafu};
+use super::head::{BoxBranch, ClsBranch, dist2bbox, make_anchors};
+use super::loader;
+use super::neck::YoloNeck;
+
+/// Mask coefficient branch: Conv(k3) → Conv(k3) → Conv2d(k1, bias).
+/// Outputs `nm` channels.
+///
+/// State-dict keys: `0.*`, `1.*`, `2.weight`, `2.bias`.
+#[derive(Clone)]
+pub struct MaskBranch {
+    pub conv0: YoloConv,
+    pub conv1: YoloConv,
+    pub conv2: Conv2dBias,
+}
+
+impl MaskBranch {
+    pub fn empty(in_ch: usize, nm: usize) -> Self {
+        let hidden = (16usize).max(in_ch / 4).max(nm);
+        Self {
+            conv0: YoloConv::empty(in_ch, hidden, 3, 1, true),
+            conv1: YoloConv::empty(hidden, hidden, 3, 1, true),
+            conv2: Conv2dBias::empty(hidden, nm, 1, 1),
+        }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv0.forward(x)?;
+        let x = self.conv1.forward(&x)?;
+        self.conv2.forward(&x)
+    }
+}
+
+impl HasStateDict for MaskBranch {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv0.state_dict(&prefixed(prefix, "0"));
+        sd.extend(self.conv1.state_dict(&prefixed(prefix, "1")));
+        sd.extend(self.conv2.state_dict(&prefixed(prefix, "2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv0.load_state_dict(sd, &prefixed(prefix, "0"))?;
+        self.conv1.load_state_dict(sd, &prefixed(prefix, "1"))?;
+        self.conv2.load_state_dict(sd, &prefixed(prefix, "2"))?;
+        Ok(())
+    }
+}
+
+/// Proto26: multi-scale feature fusion → ConvTranspose2d → prototype masks.
+///
+/// State-dict keys (under `proto.`):
+/// - `feat_refine.{i}.*` — 1×1 convs projecting P4/P5 → P3 channels
+/// - `feat_fuse.*` — Conv(k3)
+/// - `cv1.*` — Proto parent cv1 (3×3 conv)
+/// - `upsample.weight`, `upsample.bias` — ConvTranspose2d
+/// - `cv2.*` — Proto parent cv2 (3×3 conv)
+/// - `cv3.*` — Proto parent cv3 (1×1 conv)
+#[derive(Clone)]
+pub struct Proto26 {
+    pub feat_refine: Vec<YoloConv>,
+    pub feat_fuse: YoloConv,
+    pub cv1: YoloConv,
+    pub upsample: ConvTranspose2dBias,
+    pub cv2: YoloConv,
+    pub cv3: YoloConv,
+}
+
+impl Proto26 {
+    pub fn empty(ch: &[usize], c_: usize, nm: usize) -> Self {
+        let p3_ch = ch[0];
+        Self {
+            feat_refine: ch[1..].iter().map(|&c| YoloConv::empty(c, p3_ch, 1, 1, true)).collect(),
+            feat_fuse: YoloConv::empty(p3_ch, c_, 3, 1, true),
+            cv1: YoloConv::empty(c_, c_, 3, 1, true),
+            upsample: ConvTranspose2dBias::empty(c_, c_, 2),
+            cv2: YoloConv::empty(c_, c_, 3, 1, true),
+            cv3: YoloConv::empty(c_, nm, 1, 1, true),
+        }
+    }
+
+    pub fn forward(&self, feats: &[Tensor]) -> Result<Tensor> {
+        let mut feat = feats[0].clone();
+        for (i, f) in self.feat_refine.iter().enumerate() {
+            let refined = f.forward(&feats[i + 1])?;
+            let mut upsampled = refined;
+            // Nearest upsample by 2^(i+1) via repeated 2× calls
+            for _ in 0..(i + 1) {
+                upsampled = upsample_nearest_2x(&upsampled)?;
+            }
+            feat = feat.try_add(&upsampled).context(TensorSnafu)?;
+        }
+        let feat = self.feat_fuse.forward(&feat)?;
+        // Proto parent: cv1 → ConvTranspose2d → cv2 → cv3
+        let p = self.cv1.forward(&feat)?;
+        let p = self.upsample.forward(&p)?;
+        let p = self.cv2.forward(&p)?;
+        self.cv3.forward(&p)
+    }
+}
+
+impl HasStateDict for Proto26 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, f) in self.feat_refine.iter().enumerate() {
+            sd.extend(f.state_dict(&prefixed(prefix, &format!("feat_refine.{i}"))));
+        }
+        sd.extend(self.feat_fuse.state_dict(&prefixed(prefix, "feat_fuse")));
+        sd.extend(self.cv1.state_dict(&prefixed(prefix, "cv1")));
+        sd.extend(self.upsample.state_dict(&prefixed(prefix, "upsample")));
+        sd.extend(self.cv2.state_dict(&prefixed(prefix, "cv2")));
+        sd.extend(self.cv3.state_dict(&prefixed(prefix, "cv3")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, f) in self.feat_refine.iter_mut().enumerate() {
+            f.load_state_dict(sd, &prefixed(prefix, &format!("feat_refine.{i}")))?;
+        }
+        self.feat_fuse.load_state_dict(sd, &prefixed(prefix, "feat_fuse"))?;
+        self.cv1.load_state_dict(sd, &prefixed(prefix, "cv1"))?;
+        self.upsample.load_state_dict(sd, &prefixed(prefix, "upsample"))?;
+        self.cv2.load_state_dict(sd, &prefixed(prefix, "cv2"))?;
+        self.cv3.load_state_dict(sd, &prefixed(prefix, "cv3"))?;
+        Ok(())
+    }
+}
+
+/// Segment26 head: Detect box+cls + mask coefficients + Proto26.
+///
+/// Forward returns `(predictions [B, 4+nc+nm, A], protos [B, nm, H/4, W/4])`.
+#[derive(Clone)]
+pub struct Segment26 {
+    pub cv2: Vec<BoxBranch>,
+    pub cv3: Vec<ClsBranch>,
+    pub cv4: Vec<MaskBranch>,
+    pub proto: Proto26,
+    pub nc: usize,
+    pub nm: usize,
+    pub reg_max: usize,
+}
+
+impl Segment26 {
+    pub fn empty(ch: &[usize], nc: usize, nm: usize, npr: usize, reg_max: usize) -> Self {
+        let hidden_box = (16usize).max(ch[0] / 4).max(reg_max * 4);
+        let hidden_cls = ch[0].max(nc.min(100));
+        Self {
+            cv2: ch.iter().map(|&c| BoxBranch::empty(c, hidden_box, reg_max)).collect(),
+            cv3: ch.iter().map(|&c| ClsBranch::empty(c, hidden_cls, nc)).collect(),
+            cv4: ch.iter().map(|&c| MaskBranch::empty(c, nm)).collect(),
+            proto: Proto26::empty(ch, npr, nm),
+            nc,
+            nm,
+            reg_max,
+        }
+    }
+
+    pub fn forward(&self, feats: &[Tensor]) -> Result<(Tensor, Tensor)> {
+        let proto = self.proto.forward(feats)?;
+
+        let shape = feats[0].shape().context(TensorSnafu)?;
+        let b = shape[0].clone();
+
+        let mut boxes_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut scores_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut mask_list: Vec<Tensor> = Vec::with_capacity(feats.len());
+        let mut feat_sizes: Vec<(usize, usize)> = Vec::with_capacity(feats.len());
+
+        for (i, feat) in feats.iter().enumerate() {
+            let fshape = feat.shape().context(TensorSnafu)?;
+            let h: usize = fshape[2].as_const().context(SymbolicShapeSnafu { what: "seg H" })?;
+            let w: usize = fshape[3].as_const().context(SymbolicShapeSnafu { what: "seg W" })?;
+            feat_sizes.push((h, w));
+            let hw = h * w;
+
+            let box_out = self.cv2[i].forward(feat)?;
+            boxes_list.push(
+                box_out.try_reshape([b.clone(), SInt::from(4 * self.reg_max), SInt::from(hw)]).context(TensorSnafu)?,
+            );
+
+            let cls_out = self.cv3[i].forward(feat)?;
+            scores_list
+                .push(cls_out.try_reshape([b.clone(), SInt::from(self.nc), SInt::from(hw)]).context(TensorSnafu)?);
+
+            let mask_out = self.cv4[i].forward(feat)?;
+            mask_list
+                .push(mask_out.try_reshape([b.clone(), SInt::from(self.nm), SInt::from(hw)]).context(TensorSnafu)?);
+        }
+
+        let boxes_refs: Vec<&Tensor> = boxes_list.iter().collect();
+        let scores_refs: Vec<&Tensor> = scores_list.iter().collect();
+        let mask_refs: Vec<&Tensor> = mask_list.iter().collect();
+
+        let boxes = Tensor::cat(&boxes_refs, 2).context(TensorSnafu)?;
+        let scores = Tensor::cat(&scores_refs, 2).context(TensorSnafu)?;
+        let masks = Tensor::cat(&mask_refs, 2).context(TensorSnafu)?;
+
+        let num_anchors: usize = feat_sizes.iter().map(|&(h, w)| h * w).sum();
+        let (anchors, strides) = make_anchors(&feat_sizes, &DETECT_STRIDES);
+
+        let dbox = dist2bbox(&boxes, &anchors, &strides, num_anchors)?;
+        let scores = scores.sigmoid().context(TensorSnafu)?;
+        let preds = Tensor::cat(&[&dbox, &scores, &masks], 1).context(TensorSnafu)?;
+
+        Ok((preds, proto))
+    }
+}
+
+impl HasStateDict for Segment26 {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = StateDict::new();
+        for (i, br) in self.cv2.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv2.{i}"))));
+        }
+        for (i, br) in self.cv3.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv3.{i}"))));
+        }
+        for (i, br) in self.cv4.iter().enumerate() {
+            sd.extend(br.state_dict(&prefixed(prefix, &format!("one2one_cv4.{i}"))));
+        }
+        sd.extend(self.proto.state_dict(&prefixed(prefix, "proto")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        for (i, br) in self.cv2.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv2.{i}")))?;
+        }
+        for (i, br) in self.cv3.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv3.{i}")))?;
+        }
+        for (i, br) in self.cv4.iter_mut().enumerate() {
+            br.load_state_dict(sd, &prefixed(prefix, &format!("one2one_cv4.{i}")))?;
+        }
+        self.proto.load_state_dict(sd, &prefixed(prefix, "proto"))?;
+        Ok(())
+    }
+}
+
+/// YOLO v26 instance segmentation model.
+///
+/// Forward returns `(predictions [B, 4+nc+nm, A], protos [B, nm, H/4, W/4])`.
+#[derive(Clone)]
+pub struct Yolo26Segment {
+    pub config: super::config::YoloConfig,
+    pub backbone: YoloBackbone,
+    pub neck: YoloNeck,
+    pub head: Segment26,
+}
+
+impl Yolo26Segment {
+    pub fn with_zero_weights(config: super::config::YoloConfig) -> Self {
+        let scale = config.scale;
+        let [_, _, c2, c3, c4] = super::backbone::scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            neck: YoloNeck::empty(scale),
+            head: Segment26::empty(&[c2, c3, c4], config.nc, 32, 256, config.reg_max),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: super::config::YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: super::config::YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: super::config::YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: super::config::YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<(Tensor, Tensor)> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l10) = self.backbone.forward(&x)?;
+        let (p3, p4, p5) = self.neck.forward(&l4, &l6, &l10)?;
+        self.head.forward(&[p3, p4, p5])
+    }
+}
+
+impl HasStateDict for Yolo26Segment {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.neck.state_dict(prefix));
+        sd.extend(self.head.state_dict(&prefixed(prefix, "23")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.neck.load_state_dict(sd, prefix)?;
+        self.head.load_state_dict(sd, &prefixed(prefix, "23"))?;
+        Ok(())
+    }
+}

--- a/model/src/yolo/semseg.rs
+++ b/model/src/yolo/semseg.rs
@@ -1,0 +1,134 @@
+//! [`Yolo26SemSeg`] — YOLO v26 semantic segmentation.
+//!
+//! Full backbone (layers 0–10) + partial FPN top-down (layers 11–16) +
+//! Conv→Conv2d classifier on P3. Forward returns `[B, nc, H/8, W/8]` logits.
+
+use snafu::ResultExt;
+use svod_tensor::{BoundVariable, Tensor};
+
+use crate::state::{self, HasStateDict, StateDict, prefixed};
+
+use super::backbone::{YoloBackbone, upsample_nearest_2x};
+use super::blocks::conv::{Conv2dBias, YoloConv};
+use super::blocks::csp::C3k2;
+use super::config::{YoloConfig, make_depth};
+use super::error::{Result, StateSnafu, TensorSnafu};
+use super::loader;
+
+/// Semantic segmentation classifier: Conv(k3) → Conv2d(k1, bias).
+///
+/// State-dict keys: `classifier.0.{conv,bn}.*`, `classifier.2.{weight,bias}`.
+#[derive(Clone)]
+pub struct SemSegClassifier {
+    pub conv0: YoloConv,
+    pub conv2: Conv2dBias,
+}
+
+impl SemSegClassifier {
+    pub fn empty(in_ch: usize, nc: usize) -> Self {
+        Self { conv0: YoloConv::empty(in_ch, in_ch, 3, 1, true), conv2: Conv2dBias::empty(in_ch, nc, 1, 1) }
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.conv0.forward(x)?;
+        self.conv2.forward(&x)
+    }
+}
+
+impl HasStateDict for SemSegClassifier {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.conv0.state_dict(&prefixed(prefix, "0"));
+        sd.extend(self.conv2.state_dict(&prefixed(prefix, "2")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.conv0.load_state_dict(sd, &prefixed(prefix, "0"))?;
+        self.conv2.load_state_dict(sd, &prefixed(prefix, "2"))?;
+        Ok(())
+    }
+}
+
+/// YOLO v26 semantic segmentation model.
+///
+/// Forward returns `[B, nc, H/8, W/8]` per-pixel logits.
+#[derive(Clone)]
+pub struct Yolo26SemSeg {
+    pub config: YoloConfig,
+    pub backbone: YoloBackbone,
+    pub c3k2_13: C3k2,
+    pub c3k2_16: C3k2,
+    pub classifier: SemSegClassifier,
+}
+
+impl Yolo26SemSeg {
+    pub fn with_zero_weights(config: YoloConfig) -> Self {
+        let scale = config.scale;
+        let nc = config.nc;
+        let d = |yaml_n| make_depth(yaml_n, scale);
+        let [_, _, c2, c3, c4] = super::backbone::scaled_channels(scale);
+        Self {
+            config: config.clone(),
+            backbone: YoloBackbone::empty(scale),
+            c3k2_13: C3k2::empty(c4 + c3, c3, d(2), true, 0.5, true, false),
+            c3k2_16: C3k2::empty(c3 + c3, c2, d(2), true, 0.5, true, false),
+            classifier: SemSegClassifier::empty(c2, nc),
+        }
+    }
+
+    pub fn from_hub(model_id: &str, config: YoloConfig) -> Result<Self> {
+        Self::from_hub_with_revision(model_id, "main", config)
+    }
+
+    pub fn from_hub_with_revision(model_id: &str, revision: &str, config: YoloConfig) -> Result<Self> {
+        let path = loader::download_safetensors(model_id, revision)?;
+        Self::from_safetensors(&path, config)
+    }
+
+    pub fn from_safetensors(path: &std::path::Path, config: YoloConfig) -> Result<Self> {
+        let sd = loader::prepare_state_dict(path)?;
+        Self::from_state_dict(&sd, config)
+    }
+
+    pub fn from_state_dict(sd: &StateDict, config: YoloConfig) -> Result<Self> {
+        let mut model = Self::with_zero_weights(config);
+        model.load_state_dict(sd, "").context(StateSnafu)?;
+        Ok(model)
+    }
+
+    /// Run the full network. Returns `[B, nc, H/8, W/8]` per-pixel logits.
+    pub fn forward(&self, images: &Tensor, batch: &BoundVariable) -> Result<Tensor> {
+        let x = loader::shrink_batch(images, batch)?;
+        let (l4, l6, l10) = self.backbone.forward(&x)?;
+
+        // Partial FPN top-down (layers 11–16)
+        let up = upsample_nearest_2x(&l10)?;
+        let cat = Tensor::cat(&[&up, &l6], 1).context(TensorSnafu)?;
+        let l13 = self.c3k2_13.forward(&cat)?;
+
+        let up = upsample_nearest_2x(&l13)?;
+        let cat = Tensor::cat(&[&up, &l4], 1).context(TensorSnafu)?;
+        let l16 = self.c3k2_16.forward(&cat)?;
+
+        // Classifier on P3
+        self.classifier.forward(&l16)
+    }
+}
+
+impl HasStateDict for Yolo26SemSeg {
+    fn state_dict(&self, prefix: &str) -> StateDict {
+        let mut sd = self.backbone.state_dict(prefix);
+        sd.extend(self.c3k2_13.state_dict(&prefixed(prefix, "13")));
+        sd.extend(self.c3k2_16.state_dict(&prefixed(prefix, "16")));
+        sd.extend(self.classifier.state_dict(&prefixed(prefix, "17.classifier")));
+        sd
+    }
+
+    fn load_state_dict(&mut self, sd: &StateDict, prefix: &str) -> std::result::Result<(), state::Error> {
+        self.backbone.load_state_dict(sd, prefix)?;
+        self.c3k2_13.load_state_dict(sd, &prefixed(prefix, "13"))?;
+        self.c3k2_16.load_state_dict(sd, &prefixed(prefix, "16"))?;
+        self.classifier.load_state_dict(sd, &prefixed(prefix, "17.classifier"))?;
+        Ok(())
+    }
+}

--- a/scripts/convert_yolo.py
+++ b/scripts/convert_yolo.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate golden test data for YOLO26n parity test.
+
+Outputs golden.safetensors with:
+  - images:        [1, 3, 640, 640] f32 — a deterministic test image
+  - images_shape:  [4] i64 — shape of images
+  - output:        [1, 84, 2100] f32 — PyTorch inference output
+
+Usage:
+  pip install ultralytics safetensors torch
+  python scripts/convert_yolo.py  # writes to data/yolo/golden.safetensors
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+from safetensors.torch import save_file
+
+WEIGHTS_URL_REPO = "ultralytics/yolo26n"
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "data" / "yolo"
+
+
+def main() -> None:
+    from ultralytics import YOLO
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Load model
+    model = YOLO(f"{WEIGHTS_URL_REPO}.pt")
+    model.eval()
+
+    # Create deterministic input: gradient pattern normalized to [0, 1]
+    img = np.zeros((1, 3, 640, 640), dtype=np.float32)
+    for c in range(3):
+        for h in range(640):
+            for w in range(640):
+                img[0, c, h, w] = (h + w + c * 213) / (640 + 640 + 3 * 213)
+
+    images_t = torch.from_numpy(img)
+
+    # Run inference to get the raw model output (pre-NMS)
+    # Ultralytics YOLO.predict returns Results objects; we need the raw tensor.
+    # Use model.model directly (the nn.Module):
+    with torch.no_grad():
+        # YOLO export-mode forward returns [B, 4+nc, A]
+        output = model.model(images_t)
+
+    if isinstance(output, (list, tuple)):
+        output = output[0]
+
+    # Ensure output is [B, C, A]
+    if output.ndim == 3 and output.shape[0] != 1:
+        output = output.permute(0, 2, 1)  # [B, A, C] -> [B, C, A]
+
+    output_np = output.cpu().float().numpy()
+    print(f"output shape: {output_np.shape}")
+
+    # Save
+    golden = {
+        "images": images_t,
+        "images_shape": torch.tensor(list(images_t.shape), dtype=torch.int64),
+        "output": torch.from_numpy(output_np),
+    }
+    out_path = OUTPUT_DIR / "golden.safetensors"
+    save_file(golden, str(out_path))
+    print(f"saved {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tensor/src/nn/resize.rs
+++ b/tensor/src/nn/resize.rs
@@ -1,13 +1,11 @@
 //! Resize operations (ONNX Resize operator building block).
 
 use bon::bon;
-use snafu::ResultExt;
 use svod_dtype::DType;
-use svod_ir::ConstValue;
+use svod_ir::{ConstValue, SInt};
 
 use super::{AspectRatioPolicy, CoordinateTransformMode, NearestMode, ResizeMode};
 use crate::Tensor;
-use crate::error::UOpSnafu;
 
 type Result<T> = crate::Result<T>;
 
@@ -83,17 +81,7 @@ impl Tensor {
         #[builder(default = 0.0)] extrapolation_value: f64,
     ) -> Result<Tensor> {
         let ndim = self.ndim()?;
-        let shape = self.shape()?;
-        // TODO(symbolic-batch): this validates *every* dim is concrete even
-        // though only the `axes` dims are read below (line 107) and only the
-        // non-axes dims are used to build expand shapes (lines 257, 274). For
-        // a symbolic batch with concrete spatial dims (e.g. a JIT input shrunk
-        // to a bound `b`), this fails unnecessarily. Narrow this to the axes
-        // dims, and have the expand-shape construction below carry SInt rather
-        // than going through `usize`. The result is the only thing using
-        // `_shape_dims` is its discard binding — drop it once the rest of the
-        // function stops needing fully-concrete shapes.
-        let _shape_dims = svod_ir::shape::to_vec_usize(&shape).context(UOpSnafu)?;
+        let _shape = self.shape()?;
 
         let axes: Vec<usize> = axes.map(|a| a.to_vec()).unwrap_or_else(|| (0..ndim).collect());
 
@@ -109,22 +97,63 @@ impl Tensor {
             self.try_permute(&perm)?
         };
 
-        // Input spatial dimensions (last len(axes) dims of permuted x)
+        // Input spatial dimensions (last len(axes) dims of permuted x).
+        // Only the spatial (axes) dims must be concrete; the prefix (batch,
+        // channels) may be symbolic and is carried through as SInt.
         let x_shape = x.shape()?;
-        // TODO(symbolic-batch): same issue as above — only `input_shape` (the
-        // trailing spatial dims) is actually used; the non-axes prefix is
-        // copied into `expand_shape` later and never compared to a `usize`,
-        // so it could stay as `SInt` and admit symbolic dims.
-        let x_dims = svod_ir::shape::to_vec_usize(&x_shape).context(UOpSnafu)?;
-        let n_spatial = axes.len();
-        let input_shape: Vec<usize> = x_dims[ndim - n_spatial..].to_vec();
+        let n_axes = axes.len();
 
         // Filter scales/sizes to spatial dims only
-        let scales_trimmed: Option<Vec<f64>> = scales.map(|s| s[s.len().saturating_sub(n_spatial)..].to_vec());
-        let sizes_trimmed: Option<Vec<usize>> = sizes.map(|s| s[s.len().saturating_sub(n_spatial)..].to_vec());
+        let scales_trimmed: Option<Vec<f64>> = scales.map(|s| s[s.len().saturating_sub(n_axes)..].to_vec());
+        let sizes_trimmed: Option<Vec<usize>> = sizes.map(|s| s[s.len().saturating_sub(n_axes)..].to_vec());
+
+        // Identify active axes: axes where the scale != 1.0 (for scales) or
+        // where the output size differs from the input (for sizes). Inactive
+        // axes (e.g. symbolic batch with scale=1.0) are skipped entirely and
+        // carried through as-is, matching tinygrad's interpolate which only
+        // loops over trailing spatial dims.
+        let active_idx: Vec<usize> = match &scales_trimmed {
+            Some(sc) => (0..n_axes).filter(|&i| sc[i] != 1.0).collect(),
+            None => match &sizes_trimmed {
+                Some(sz) => {
+                    // For sizes, we need to compare against input shape.
+                    // Only dims that are concrete and differ are active.
+                    (0..n_axes)
+                        .filter(|&i| {
+                            let in_sz = x_shape[ndim - n_axes + i].as_const();
+                            in_sz.is_none_or(|s| s != sz[i])
+                        })
+                        .collect()
+                }
+                None => (0..n_axes).collect(),
+            },
+        };
+
+        if active_idx.is_empty() {
+            return if perm.iter().enumerate().any(|(i, &p)| p != i as isize) {
+                x.try_permute(&inv_perm_i)
+            } else {
+                Ok(x)
+            };
+        }
+
+        // Only extract/validate the active spatial dims (must be concrete).
+        let input_shape: Vec<usize> = active_idx
+            .iter()
+            .map(|&i| {
+                x_shape[ndim - n_axes + i].as_const().ok_or_else(|| crate::error::Error::SymbolicShapeUnsupported {
+                    operation: "resize on a symbolic spatial dim".to_string(),
+                })
+            })
+            .collect::<Result<_>>()?;
+
+        let scales_active: Option<Vec<f64>> =
+            scales_trimmed.as_ref().map(|sc| active_idx.iter().map(|&i| sc[i]).collect());
+        let sizes_active: Option<Vec<usize>> =
+            sizes_trimmed.as_ref().map(|sz| active_idx.iter().map(|&i| sz[i]).collect());
 
         // Compute output sizes and scales
-        let (output_sizes, final_scales) = if let Some(mut sz) = sizes_trimmed {
+        let (output_sizes, final_scales) = if let Some(mut sz) = sizes_active {
             if keep_aspect_ratio_policy == AspectRatioPolicy::NotLarger
                 || keep_aspect_ratio_policy == AspectRatioPolicy::NotSmaller
             {
@@ -140,13 +169,13 @@ impl Tensor {
                     }
                 }
                 sz = input_shape.iter().map(|&sh| (scale * sh as f64 + 0.5) as usize).collect();
-                let sc = vec![scale; n_spatial];
+                let sc = vec![scale; sz.len()];
                 (sz, sc)
             } else {
                 let sc: Vec<f64> = sz.iter().zip(&input_shape).map(|(&s, &sh)| s as f64 / sh as f64).collect();
                 (sz, sc)
             }
-        } else if let Some(sc) = scales_trimmed {
+        } else if let Some(sc) = scales_active {
             let sz: Vec<usize> = sc.iter().zip(&input_shape).map(|(&s, &sh)| (s * sh as f64) as usize).collect();
             (sz, sc)
         } else {
@@ -163,6 +192,8 @@ impl Tensor {
                 Ok(x)
             };
         }
+
+        let n_spatial = active_idx.len();
 
         // Extract per-spatial-dim ROI (start, end) pairs
         let roi_pairs: Vec<(f64, f64)> = if let Some(roi) = roi {
@@ -258,47 +289,38 @@ impl Tensor {
 
             // Sequential gather per spatial dim
             for (i, idx) in int_indexes.iter().enumerate() {
-                let dim = (ndim - n_spatial + i) as isize;
+                let dim = (ndim - n_axes + active_idx[i]) as isize;
                 let cur_shape = x.shape()?;
-                // TODO(symbolic-batch): `cur_dims` is built only to feed
-                // `expand_shape` below, which forces a `usize → isize` cast on
-                // every dim. For a symbolic prefix this loses information and
-                // aborts here. `try_expand` would need to accept `SInt` (it
-                // already does internally) so we can pass the symbolic dims
-                // through; then we'd substitute `out_sz` at the axis position
-                // and keep the rest of the shape as-is.
-                let cur_dims = svod_ir::shape::to_vec_usize(&cur_shape).context(UOpSnafu)?;
                 let out_sz = output_sizes[i];
 
                 let mut idx_shape = vec![1isize; ndim];
-                idx_shape[ndim - n_spatial + i] = out_sz as isize;
+                idx_shape[ndim - n_axes + active_idx[i]] = out_sz as isize;
                 let idx_reshaped = idx.try_reshape(&idx_shape)?;
 
-                let mut expand_shape: Vec<isize> = cur_dims.iter().map(|&d| d as isize).collect();
-                expand_shape[ndim - n_spatial + i] = out_sz as isize;
+                let mut expand_shape: Vec<SInt> = cur_shape.to_vec();
+                expand_shape[ndim - n_axes + active_idx[i]] = SInt::from(out_sz as i32);
                 let idx_expanded = idx_reshaped.try_expand(&expand_shape)?;
 
                 x = x.gather(dim, &idx_expanded)?;
             }
         } else if mode == ResizeMode::Linear {
-            let mut expand = x_dims.clone();
+            let mut expand: Vec<SInt> = x_shape.to_vec();
             for (i, &out_sz) in output_sizes.iter().enumerate() {
-                let dim_pos = ndim - n_spatial + i;
+                let dim_pos = ndim - n_axes + active_idx[i];
                 let scale = final_scales[i];
                 let input_sz = input_shape[i];
                 let index = &indexes[i];
 
                 let mut reshape = vec![1isize; ndim];
                 reshape[dim_pos] = out_sz as isize;
-                expand[dim_pos] = out_sz;
-                let expand_i: Vec<isize> = expand.iter().map(|&d| d as isize).collect();
+                expand[dim_pos] = SInt::from(out_sz as i32);
 
                 if antialias && scale < 1.0 {
-                    x = interpolate_antialias_linear(&x, index, dim_pos, input_sz, scale, &reshape, &expand_i, &dtype)?;
+                    x = interpolate_antialias_linear(&x, index, dim_pos, input_sz, scale, &reshape, &expand, &dtype)?;
                 } else {
-                    let low = index.floor()?.cast(DType::Int32)?.try_reshape(&reshape)?.try_expand(&expand_i)?;
-                    let high = index.ceil()?.cast(DType::Int32)?.try_reshape(&reshape)?.try_expand(&expand_i)?;
-                    let perc = index.try_sub(&index.floor()?)?.try_reshape(&reshape)?.try_expand(&expand_i)?;
+                    let low = index.floor()?.cast(DType::Int32)?.try_reshape(&reshape)?.try_expand(&expand)?;
+                    let high = index.ceil()?.cast(DType::Int32)?.try_reshape(&reshape)?.try_expand(&expand)?;
+                    let perc = index.try_sub(&index.floor()?)?.try_reshape(&reshape)?.try_expand(&expand)?;
 
                     let dim_i = dim_pos as isize;
                     let gathered_low = x.gather(dim_i, &low)?;
@@ -308,22 +330,19 @@ impl Tensor {
             }
         } else if mode == ResizeMode::Cubic {
             let a = cubic_coeff_a;
-            let mut expand = x_dims.clone();
+            let mut expand: Vec<SInt> = x_shape.to_vec();
             for (i, &out_sz) in output_sizes.iter().enumerate() {
-                let dim_pos = ndim - n_spatial + i;
+                let dim_pos = ndim - n_axes + active_idx[i];
                 let scale = final_scales[i];
                 let input_sz = input_shape[i];
                 let index = &indexes[i];
 
                 let mut reshape = vec![1isize; ndim];
                 reshape[dim_pos] = out_sz as isize;
-                expand[dim_pos] = out_sz;
-                let expand_i: Vec<isize> = expand.iter().map(|&d| d as isize).collect();
+                expand[dim_pos] = SInt::from(out_sz as i32);
 
                 if antialias && scale < 1.0 {
-                    x = interpolate_antialias_cubic(
-                        &x, index, dim_pos, input_sz, scale, a, &reshape, &expand_i, &dtype,
-                    )?;
+                    x = interpolate_antialias_cubic(&x, index, dim_pos, input_sz, scale, a, &reshape, &expand, &dtype)?;
                 } else {
                     let p = index.floor()?.cast(DType::Int32)?;
                     let ratio = index.try_sub(&index.floor()?)?;
@@ -368,14 +387,14 @@ impl Tensor {
                     let max_val = Tensor::const_(ConstValue::Int((input_sz - 1) as i64), DType::Int32);
                     let zero_i = Tensor::const_(ConstValue::Int(0), DType::Int32);
                     let clip = |t: &Tensor| -> Result<Tensor> {
-                        t.clamp().min(&zero_i).max(&max_val).call()?.try_reshape(&reshape)?.try_expand(&expand_i)
+                        t.clamp().min(&zero_i).max(&max_val).call()?.try_reshape(&reshape)?.try_expand(&expand)
                     };
                     let ei0 = clip(&idx0)?;
                     let ei1 = clip(&idx1)?;
                     let ei2 = clip(&idx2)?;
                     let ei3 = clip(&idx3)?;
 
-                    let ec = |c: Tensor| -> Result<Tensor> { c.try_reshape(&reshape)?.try_expand(&expand_i) };
+                    let ec = |c: Tensor| -> Result<Tensor> { c.try_reshape(&reshape)?.try_expand(&expand) };
                     let ec0 = ec(c0)?;
                     let ec1 = ec(c1)?;
                     let ec2 = ec(c2)?;
@@ -394,15 +413,13 @@ impl Tensor {
         // Apply extrapolation for tf_crop_and_resize: out-of-bounds → extrapolation_value
         if let Some(masks) = validity_mask {
             let extrap = Tensor::const_(ConstValue::Float(extrapolation_value), dtype.clone());
-            let x_shape = x.shape()?;
-            let x_dims = svod_ir::shape::to_vec_usize(&x_shape).context(UOpSnafu)?;
-            let expand_shape: Vec<isize> = x_dims.iter().map(|&d| d as isize).collect();
+            let expand_shape: Vec<SInt> = x.shape()?.to_vec();
 
             // Each mask_i is 1D [out_sz_i]; reshape to [1,..,out_sz_i,..,1] and broadcast
             let mut combined: Option<Tensor> = None;
             for (i, mask) in masks.into_iter().enumerate() {
                 let mut shape = vec![1isize; ndim];
-                shape[ndim - n_spatial + i] = output_sizes[i] as isize;
+                shape[ndim - n_axes + active_idx[i]] = output_sizes[i] as isize;
                 let broad = mask.try_reshape(&shape)?.try_expand(&expand_shape)?;
                 combined = Some(match combined {
                     Some(c) => c.bitwise_and(&broad)?,
@@ -501,7 +518,7 @@ fn interpolate_antialias_cubic(
     scale: f64,
     a: f64,
     reshape: &[isize],
-    expand_i: &[isize],
+    expand_i: &[SInt],
     dtype: &DType,
 ) -> Result<Tensor> {
     let i_start = (-2.0_f64 / scale).floor() as i32 + 1;
@@ -544,7 +561,7 @@ fn interpolate_antialias_linear(
     input_sz: usize,
     scale: f64,
     reshape: &[isize],
-    expand_i: &[isize],
+    expand_i: &[SInt],
     dtype: &DType,
 ) -> Result<Tensor> {
     let start = (-1.0_f64 / scale).floor() as i32 + 1;
@@ -583,7 +600,7 @@ fn normalize_and_gather(
     dim_pos: usize,
     input_sz: usize,
     reshape: &[isize],
-    expand_i: &[isize],
+    expand_i: &[SInt],
     dtype: &DType,
 ) -> Result<Tensor> {
     let mut total = coeffs[0].clone();

--- a/tensor/src/shape_ops.rs
+++ b/tensor/src/shape_ops.rs
@@ -880,16 +880,26 @@ impl Tensor {
             }
         };
 
-        let mut ranges: Vec<(isize, isize)> =
-            (0..ndim).map(|d| (0isize, shape[d].as_const().unwrap() as isize)).collect();
+        let mut ranges: Vec<Option<(isize, isize)>> = vec![None; ndim];
         let mut flip_axes: Vec<isize> = Vec::new();
 
         for (i, &axis) in axes.iter().enumerate() {
-            let d = shape[axis].as_const().unwrap() as i64;
             let step = steps[i];
             if step == 0 {
                 return Err(crate::error::Error::IrConstruction { details: "Slice step cannot be 0".into() });
             }
+
+            let d = match shape[axis].as_const() {
+                Some(d) => d as i64,
+                None => {
+                    if starts[i] <= 0 && ends[i] > (i64::MAX / 2) {
+                        continue;
+                    }
+                    return Err(crate::error::Error::SymbolicShapeUnsupported {
+                        operation: "slice_with on a symbolic dim".to_string(),
+                    });
+                }
+            };
 
             let (lower, upper) = if step > 0 { (0i64, d) } else { (-1i64, d - 1) };
             let mut s = starts[i].clamp(-d, d);
@@ -905,12 +915,12 @@ impl Tensor {
             let e = e.clamp(lower, upper);
 
             if step * (e - s) < 0 {
-                ranges[axis] = (0, 0);
+                ranges[axis] = Some((0, 0));
             } else if step < 0 {
                 flip_axes.push(axis as isize);
-                ranges[axis] = ((e + 1) as isize, (s + 1) as isize);
+                ranges[axis] = Some(((e + 1) as isize, (s + 1) as isize));
             } else {
-                ranges[axis] = (s as isize, e as isize);
+                ranges[axis] = Some((s as isize, e as isize));
             }
         }
 
@@ -925,7 +935,9 @@ impl Tensor {
                 continue;
             }
             let cur = result.shape()?;
-            let size = cur[axis].as_const().unwrap();
+            let size = cur[axis].as_const().ok_or_else(|| crate::error::Error::SymbolicShapeUnsupported {
+                operation: "slice_with with step on a symbolic dim".to_string(),
+            })?;
             let padded = size.div_ceil(abs_step) * abs_step;
             if padded > size {
                 let mut p = vec![(0isize, 0isize); cur.len()];


### PR DESCRIPTION
Port of Ultralytics YOLO26 covering every topology variant. Each task is a distinct type sharing common backbone/neck/head infrastructure.

## Models (`model/src/yolo/`)

| Type | Task | Scales |
|---|---|---|
| `Yolo26Detect` | Detection | P3/8–P5/32 |
| `Yolo26DetectP2` | Detection | P2/4–P5/32 |
| `Yolo26DetectP6` | Detection | P3/8–P6/64 |
| `Yolo26Classify` | Classification | — |
| `Yolo26Segment` | Instance segmentation | P3–P5 |
| `Yolo26Obb` | Oriented bounding box | P3–P5 |
| `Yolo26Pose` | Pose estimation (17 kpts) | P3–P5 |
| `Yolo26Depth` | Monocular depth | P3–P5 |
| `Yolo26SemSeg` | Semantic segmentation | P3–P4 |

Architecture: Conv-BN-SiLu FPN+PAN detector with C3k2 CSP blocks (3 inner modes: Bottleneck/C3k/Attn), SPPF with residual shortcut, C2PSA attention (full N×N with reduced key_dim), end2end detection (reg_max=1, top-300 selection, no NMS).

Module structure:

```
yolo/
  blocks/      conv, bottleneck, csp, sppf, attention
  backbone/    standard (P3-P5), p6 (P3-P6)
  neck/        standard, p2, p6
  head.rs      shared: BoxBranch, ClsBranch, make_anchors, dist2bbox
  detect.rs    Detect head + 3 detect topology variants
  classify.rs  segment.rs  obb.rs  pose.rs  depth.rs  semseg.rs
  config.rs    error.rs    loader.rs    jit.rs
```

## Symbolic-batch fixes

- **`slice_with`** (`tensor/src/shape_ops.rs`): Non-sliced dims use `None` ranges instead of requiring concrete sizes, matching tinygrad's `shrink(None → (0, shape[dim]))`. Symbolic batch dims flow through.
- **`resize`** (`tensor/src/nn/resize.rs`): Only validates active spatial axes (scale ≠ 1.0), skipping identity dims so symbolic batch passes through. Expand shapes carry `Vec<SInt>` preserving symbolic dims. Antialias helper signatures updated to match.
- **SInt Add identity** (`ir/src/sint.rs`): `x + 0 → x` prevents spurious `b + 0` chains on non-padded dims.
- **`broadcast_shape`** (`ir/src/shape.rs`): `Const(1)` vs `Symbolic(b)` returns `b` instead of creating a new `max(1, b)` UOp.

