### PR TITLE
model: Whisper continuous batching, proper fp16 support

### DIFF
--- a/arch/src/pipelines/audio.rs
+++ b/arch/src/pipelines/audio.rs
@@ -28,7 +28,7 @@ use snafu::{ResultExt, Snafu};
 pub use svod_runtime::RunProfile;
 use svod_runtime::StageProfile;
 
-pub use crate::rnnt::Word;
+pub use crate::rnnt::{Segment, Word};
 use crate::vad::{AudioChunk, ChunkerOpts, chunks_from_probs, strict_chunk_sample_bound};
 
 // ─── Results ────────────────────────────────────────────────────────────────
@@ -38,8 +38,14 @@ use crate::vad::{AudioChunk, ChunkerOpts, chunks_from_probs, strict_chunk_sample
 /// pipeline crops these to the chunk's core before emitting.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Transcript {
+    /// Uncropped text decoded for this window.
     pub text: String,
+    /// Word timings relative to the decode-window start.
     pub words: Vec<Word>,
+    /// Phrase-level segments from timestamp-token splitting (Whisper). Empty for
+    /// models that don't produce segments. Like `words`, times are
+    /// window-relative.
+    pub segments: Vec<Segment>,
     /// Detected/source language code (e.g. `"ru"`) when the transcriber resolves
     /// one, `None` otherwise. Populated by models that run language detection
     /// (Whisper); left empty by models that don't.
@@ -49,12 +55,15 @@ pub struct Transcript {
 /// One speech region's final transcript. `start_sec`/`end_sec` reference the
 /// original audio; `words` (when present) are core-relative — add `start_sec`
 /// for an absolute timeline.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ChunkResult {
     pub start_sec: f32,
     pub end_sec: f32,
     pub text: String,
     pub words: Option<Vec<Word>>,
+    /// Phrase-level segments (when `RunOptions::segments` is set), cropped to
+    /// the chunk's core. Times are core-relative (add `start_sec` for absolute).
+    pub segments: Option<Vec<Segment>>,
 }
 
 /// Aggregated pipeline output: chunk texts joined by single spaces (empties
@@ -69,14 +78,19 @@ pub struct Transcription {
 }
 
 /// Per-call run switches, orthogonal to a [`Transcriber`]'s construction config
-/// (sizing, decoder choice). Both default to `false`, so one built [`Asr`]
-/// serves profiled/unprofiled and words-on/words-off runs without rebuilding.
+/// (sizing, decoder choice). All default to `false`, so one built [`Asr`]
+/// serves profiled/unprofiled, words-on/off, and segments-on/off runs without
+/// rebuilding.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct RunOptions {
     /// Surface per-word timestamps on [`ChunkResult::words`]. The core-crop runs
     /// regardless (it owns each chunk's text); this only decides whether the
     /// cropped words are returned.
     pub words: bool,
+    /// Surface phrase-level [`Segment`]s on [`ChunkResult::segments`]. Like
+    /// `words`, the split runs regardless; this only decides whether the cropped
+    /// segments are returned.
+    pub segments: bool,
     /// Collect a per-stage [`RunProfile`] on [`Transcription::profile`].
     pub profile: bool,
 }
@@ -107,6 +121,25 @@ pub fn crop_words_to_core(words: Vec<Word>, core_offset_sec: f32, core_duration:
         .collect()
 }
 
+/// Crop decoded segments back to a chunk's core and drop the rest. Same
+/// midpoint-keep logic as [`crop_words_to_core`], applied to [`Segment`]s.
+pub fn crop_segments_to_core(segments: Vec<Segment>, core_offset_sec: f32, core_duration: f32) -> Vec<Segment> {
+    segments
+        .into_iter()
+        .filter_map(|mut s| {
+            let rel_start = s.start - core_offset_sec;
+            let rel_end = s.end - core_offset_sec;
+            let mid = 0.5 * (rel_start + rel_end);
+            if !(0.0..core_duration).contains(&mid) {
+                return None;
+            }
+            s.start = rel_start.clamp(0.0, core_duration);
+            s.end = rel_end.clamp(s.start, core_duration);
+            Some(s)
+        })
+        .collect()
+}
+
 /// Join word texts with single spaces (empties dropped). Reconstructs a chunk's
 /// transcript from its (possibly cropped) words.
 pub fn words_to_text(words: &[Word]) -> String {
@@ -128,7 +161,7 @@ pub trait Vad {
     /// Per-frame speech probabilities for one waveform.
     fn probs(&mut self, waveform: &[f32]) -> Result<Vec<f32>, Self::Error>;
 
-    /// Probabilities for several waveforms. Defaults to looping [`probs`];
+    /// Probabilities for several waveforms. Defaults to looping [`Self::probs`];
     /// override when a VAD can batch whole clips for throughput (e.g. tuning
     /// sweeps).
     fn probs_batch(&mut self, waveforms: &[&[f32]]) -> Result<Vec<Vec<f32>>, Self::Error> {
@@ -292,7 +325,7 @@ pub trait Transcriber {
     /// returning uncropped per-window transcripts plus the per-stage
     /// [`RunProfile`] — populated only when `profile` is set (a per-call choice,
     /// so the same transcriber serves profiled and unprofiled runs). Defaults to
-    /// looping [`transcribe_window`] and **merging** its per-window profiles (via
+    /// looping [`Self::transcribe_window`] and **merging** its per-window profiles (via
     /// [`RunProfile::merge`]); override for a model that batches the encoder and
     /// profiles the batch as a whole.
     fn transcribe_windows(
@@ -313,7 +346,7 @@ pub trait Transcriber {
     }
 
     /// Transcribe one window + its optional profile (sequential fallback).
-    /// Implement this OR [`transcribe_windows`].
+    /// Implement this OR [`Self::transcribe_windows`].
     fn transcribe_window(
         &mut self,
         window: &[f32],
@@ -325,7 +358,7 @@ pub trait Transcriber {
 
     /// Decode each chunk's window, crop its words back to the core, stitch, and
     /// carry the profile (per [`RunOptions`]). Pure host machinery over
-    /// [`transcribe_windows`]; models don't override.
+    /// [`Self::transcribe_windows`]; models don't override.
     fn transcribe_chunks(
         &mut self,
         waveform: &[f32],
@@ -357,14 +390,23 @@ pub trait Transcriber {
         let (transcripts, prof) = self.transcribe_windows(&windows, opts.profile)?;
 
         let want_words = opts.words;
+        let want_segments = opts.segments;
         let chunk_results: Vec<ChunkResult> = transcripts
             .into_iter()
             .zip(&metas)
             .map(|(t, m)| {
-                let cropped = crop_words_to_core(t.words, m.core_offset_sec, m.end_sec - m.start_sec);
+                let core_dur = m.end_sec - m.start_sec;
+                let cropped_words = crop_words_to_core(t.words, m.core_offset_sec, core_dur);
+                let cropped_segments = crop_segments_to_core(t.segments, m.core_offset_sec, core_dur);
                 // Prefer the transcriber's text; reconstruct from words only as fallback.
-                let text = if !t.text.is_empty() { t.text } else { words_to_text(&cropped) };
-                ChunkResult { start_sec: m.start_sec, end_sec: m.end_sec, text, words: want_words.then_some(cropped) }
+                let text = if !t.text.is_empty() { t.text } else { words_to_text(&cropped_words) };
+                ChunkResult {
+                    start_sec: m.start_sec,
+                    end_sec: m.end_sec,
+                    text,
+                    words: want_words.then_some(cropped_words),
+                    segments: want_segments.then_some(cropped_segments),
+                }
             })
             .collect();
 
@@ -374,7 +416,7 @@ pub trait Transcriber {
     }
 
     /// [`transcribe_chunks`](Self::transcribe_chunks) with default
-    /// [`RunOptions`] (no words, no profile).
+    /// [`RunOptions`] (no words, segments, or profile).
     fn transcribe_chunks_default(
         &mut self,
         waveform: &[f32],
@@ -430,10 +472,11 @@ impl<S: Splitter, T: Transcriber> Asr<S, T> {
     }
 
     /// Split → transcribe → crop → stitch. [`RunOptions`] are per-call switches:
-    /// the same `Asr` serves profiled/unprofiled and words-on/words-off runs
-    /// without rebuilding. When `opts.profile` is set, the splitter's wall is
-    /// timed and recorded under its [`profile_label`](Splitter::profile_label)
-    /// ahead of the transcriber's stages.
+    /// the same `Asr` serves profiled/unprofiled, words-on/off, and
+    /// segments-on/off runs without rebuilding. When `opts.profile` is set,
+    /// the splitter's wall is timed and recorded under its
+    /// [`profile_label`](Splitter::profile_label) ahead of the transcriber's
+    /// stages.
     pub fn transcribe(
         &mut self,
         waveform: &[f32],
@@ -456,7 +499,7 @@ impl<S: Splitter, T: Transcriber> Asr<S, T> {
     }
 
     /// [`transcribe`](Self::transcribe) with default [`RunOptions`] (no words,
-    /// no profile) — the common case, without spelling out the struct.
+    /// segments, or profile) — the common case, without spelling out the struct.
     pub fn transcribe_default(&mut self, waveform: &[f32]) -> Result<Transcription, AsrError<S::Error, T::Error>> {
         self.transcribe(waveform, RunOptions::default())
     }

--- a/arch/src/pipelines/audio.rs
+++ b/arch/src/pipelines/audio.rs
@@ -140,10 +140,17 @@ pub fn crop_segments_to_core(segments: Vec<Segment>, core_offset_sec: f32, core_
         .collect()
 }
 
-/// Join word texts with single spaces (empties dropped). Reconstructs a chunk's
-/// transcript from its (possibly cropped) words.
+/// Concatenate exact word fragments and trim only the complete text boundary.
+/// Whitespace-only fragments are ignored; meaningful internal whitespace stays
+/// exactly where the producing tokenizer placed it.
 pub fn words_to_text(words: &[Word]) -> String {
-    words.iter().map(|w| w.text.as_str()).filter(|s| !s.is_empty()).collect::<Vec<_>>().join(" ")
+    let mut text = String::new();
+    for word in words {
+        if !word.text.trim().is_empty() {
+            text.push_str(&word.text);
+        }
+    }
+    text.trim().to_string()
 }
 
 // ─── VAD ─────────────────────────────────────────────────────────────────────
@@ -398,8 +405,10 @@ pub trait Transcriber {
                 let core_dur = m.end_sec - m.start_sec;
                 let cropped_words = crop_words_to_core(t.words, m.core_offset_sec, core_dur);
                 let cropped_segments = crop_segments_to_core(t.segments, m.core_offset_sec, core_dur);
-                // Prefer the transcriber's text; reconstruct from words only as fallback.
-                let text = if !t.text.is_empty() { t.text } else { words_to_text(&cropped_words) };
+                // Cropped fragments own the core text when available; otherwise
+                // retain models that only provide complete-window text.
+                let text =
+                    if cropped_words.is_empty() { t.text.trim().to_string() } else { words_to_text(&cropped_words) };
                 ChunkResult {
                     start_sec: m.start_sec,
                     end_sec: m.end_sec,

--- a/arch/src/pipelines/audio.rs
+++ b/arch/src/pipelines/audio.rs
@@ -40,6 +40,10 @@ use crate::vad::{AudioChunk, ChunkerOpts, chunks_from_probs, strict_chunk_sample
 pub struct Transcript {
     pub text: String,
     pub words: Vec<Word>,
+    /// Detected/source language code (e.g. `"ru"`) when the transcriber resolves
+    /// one, `None` otherwise. Populated by models that run language detection
+    /// (Whisper); left empty by models that don't.
+    pub language: Option<String>,
 }
 
 /// One speech region's final transcript. `start_sec`/`end_sec` reference the

--- a/arch/src/rnnt.rs
+++ b/arch/src/rnnt.rs
@@ -82,10 +82,21 @@ pub struct TokenEmission {
 }
 
 /// A grouped word and its `[start, end)` time span in seconds. Produced by
-/// [`frames_to_words`]. Mirrors upstream GigaAM's `Word` dataclass in
+/// [`RnntDecoder::frames_to_words`]. Mirrors upstream GigaAM's `Word` dataclass in
 /// `gigaam/types.py`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Word {
+    pub text: String,
+    pub start: f32,
+    pub end: f32,
+}
+
+/// A phrase-level segment of a transcript with `[start, end)` time in seconds.
+/// Produced by timestamp-token splitting (e.g. Whisper's `<|t0|> text <|t1|>`
+/// pairs). The containing result defines the time origin: decode-window-relative
+/// in `Transcript`, core-relative in `ChunkResult`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Segment {
     pub text: String,
     pub start: f32,
     pub end: f32,
@@ -358,7 +369,7 @@ impl RnntDecoder {
 
     /// Greedy decode + per-emission `(token_id, frame)` pairs. `emissions[i]`
     /// records which token was emitted and at which encoder frame, in
-    /// decoder output order. Pair with [`frames_to_words`] to recover
+    /// decoder output order. Pair with [`Self::frames_to_words`] to recover
     /// word-level timestamps from a SentencePiece vocabulary.
     pub fn decode_with_timestamps<S: JointStep>(
         &self,

--- a/arch/src/rnnt.rs
+++ b/arch/src/rnnt.rs
@@ -81,9 +81,11 @@ pub struct TokenEmission {
     pub frame: usize,
 }
 
-/// A grouped word and its `[start, end)` time span in seconds. Produced by
-/// [`RnntDecoder::frames_to_words`]. Mirrors upstream GigaAM's `Word` dataclass in
-/// `gigaam/types.py`.
+/// An exact transcript fragment and its `[start, end)` time span in seconds.
+///
+/// `text` retains tokenizer-provided boundary whitespace and punctuation.
+/// Concatenate fragments directly, then trim only the complete transcript or
+/// chunk boundary. Whitespace-only fragments are not emitted.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Word {
     pub text: String,
@@ -110,10 +112,9 @@ struct PendingWord {
 
 fn flush_pending(pending: &mut Option<PendingWord>, frame_shift: f32, words: &mut Vec<Word>) {
     let Some(p) = pending.take() else { return };
-    let trimmed = p.text.trim();
-    if !trimmed.is_empty() {
+    if !p.text.trim().is_empty() {
         words.push(Word {
-            text: trimmed.to_string(),
+            text: p.text,
             start: p.first_frame as f32 * frame_shift,
             end: (p.last_frame + 1) as f32 * frame_shift,
         });
@@ -324,6 +325,7 @@ impl RnntDecoder {
 
         let mut words: Vec<Word> = Vec::new();
         let mut pending: Option<PendingWord> = None;
+        let mut separator = String::new();
 
         for e in emissions {
             let piece = match self.vocabulary.get(e.token_id) {
@@ -332,9 +334,12 @@ impl RnntDecoder {
             };
             if let Some(stripped) = piece.strip_prefix(SP_MARK) {
                 flush_pending(&mut pending, frame_shift, &mut words);
-                pending = Some(PendingWord { text: stripped.to_string(), first_frame: e.frame, last_frame: e.frame });
+                separator.clear();
+                let text = if words.is_empty() { stripped.to_string() } else { format!(" {stripped}") };
+                pending = Some(PendingWord { text, first_frame: e.frame, last_frame: e.frame });
             } else if piece == " " {
                 flush_pending(&mut pending, frame_shift, &mut words);
+                separator.push(' ');
             } else {
                 match &mut pending {
                     Some(p) => {
@@ -342,8 +347,9 @@ impl RnntDecoder {
                         p.last_frame = e.frame;
                     }
                     None => {
-                        pending =
-                            Some(PendingWord { text: piece.to_string(), first_frame: e.frame, last_frame: e.frame });
+                        let mut text = std::mem::take(&mut separator);
+                        text.push_str(piece);
+                        pending = Some(PendingWord { text, first_frame: e.frame, last_frame: e.frame });
                     }
                 }
             }

--- a/arch/src/test/unit/pipelines.rs
+++ b/arch/src/test/unit/pipelines.rs
@@ -100,8 +100,9 @@ fn transcribe_chunks_slices_decode_windows_crops_and_stitches() {
             Transcript {
                 text: String::new(),
                 words: vec![word("pre", 1.0, 3.0), word("a1", 6.0, 8.0), word("post", 16.0, 18.0)],
+                ..Default::default()
             },
-            Transcript { text: String::new(), words: vec![word("b1", 3.0, 5.0)] },
+            Transcript { text: String::new(), words: vec![word("b1", 3.0, 5.0)], ..Default::default() },
         ],
     };
     let out = asr.transcribe_chunks(&waveform, &chunks, RunOptions { words: true, profile: false }).unwrap();
@@ -142,7 +143,7 @@ fn transcribe_chunks_omits_words_when_not_wanted() {
     let waveform = vec![0.0_f32; 20];
     let chunks = vec![AudioChunk::new(0, 10)];
     let mut asr =
-        PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("hi", 1.0, 2.0)] }] };
+        PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("hi", 1.0, 2.0)], ..Default::default() }] };
     // default options → words: false, so cropped words are not surfaced.
     let out = asr.transcribe_chunks_default(&waveform, &chunks).unwrap();
     assert_eq!(out.text, "hi");
@@ -200,9 +201,9 @@ fn asr_composes_split_and_transcribe() {
     let splitter = FixedLengthSplitter::new(10, 1);
     let transcriber = PresetTranscriber {
         out: vec![
-            Transcript { text: String::new(), words: vec![word("one", 1.0, 2.0)] },
-            Transcript { text: String::new(), words: vec![word("two", 1.0, 2.0)] },
-            Transcript { text: String::new(), words: vec![word("three", 1.0, 2.0)] },
+            Transcript { text: String::new(), words: vec![word("one", 1.0, 2.0)], ..Default::default() },
+            Transcript { text: String::new(), words: vec![word("two", 1.0, 2.0)], ..Default::default() },
+            Transcript { text: String::new(), words: vec![word("three", 1.0, 2.0)], ..Default::default() },
         ],
     };
     let mut asr = Asr::new(splitter, transcriber);
@@ -232,7 +233,7 @@ impl Transcriber for ProfilingTranscriber {
             p.push(svod_runtime::StageProfile::host("decode", std::time::Duration::from_millis(1)));
             p
         });
-        Ok((Transcript { text: "x".to_string(), words: Vec::new() }, prof))
+        Ok((Transcript { text: "x".to_string(), words: Vec::new(), ..Default::default() }, prof))
     }
 }
 
@@ -271,7 +272,7 @@ fn asr_surfaces_split_stage_even_when_transcriber_does_not() {
     // surfaces on its own.
     let splitter = VadSplitter::new(MockVad { probs: vec![1.0; 4], samples_per_prob: 1 }, fast_chunker_opts());
     let transcriber =
-        PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("a", 1.0, 2.0)] }] };
+        PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("a", 1.0, 2.0)], ..Default::default() }] };
     let mut asr = Asr::new(splitter, transcriber);
     let out = asr.transcribe(&[0.0_f32; 4], RunOptions { words: false, profile: true }).unwrap();
     let profile = out.profile.expect("vad-only profile surfaces");

--- a/arch/src/test/unit/pipelines.rs
+++ b/arch/src/test/unit/pipelines.rs
@@ -144,8 +144,9 @@ fn transcribe_chunks_empty_returns_default() {
 fn transcribe_chunks_omits_words_when_not_wanted() {
     let waveform = vec![0.0_f32; 20];
     let chunks = vec![AudioChunk::new(0, 10)];
-    let mut asr =
-        PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("hi", 1.0, 2.0)], ..Default::default() }] };
+    let mut asr = PresetTranscriber {
+        out: vec![Transcript { text: String::new(), words: vec![word("hi", 1.0, 2.0)], ..Default::default() }],
+    };
     // default options → words: false, so cropped words are not surfaced.
     let out = asr.transcribe_chunks_default(&waveform, &chunks).unwrap();
     assert_eq!(out.text, "hi");
@@ -245,8 +246,9 @@ fn transcribe_windows_default_merges_per_window_profiles() {
     // merges both `decode` stages into one with summed wall (1 ms × 2).
     let waveform = vec![0.0_f32; 20];
     let chunks = vec![AudioChunk::new(0, 10), AudioChunk::new(10, 20)];
-    let out =
-        ProfilingTranscriber.transcribe_chunks(&waveform, &chunks, RunOptions { profile: true, ..Default::default() }).unwrap();
+    let out = ProfilingTranscriber
+        .transcribe_chunks(&waveform, &chunks, RunOptions { profile: true, ..Default::default() })
+        .unwrap();
     let profile = out.profile.expect("profile collected");
     assert_eq!(profile.stages.len(), 1, "stages merged by name");
     assert_eq!(profile.stage("decode").unwrap().wall, std::time::Duration::from_millis(2));
@@ -273,8 +275,9 @@ fn asr_surfaces_split_stage_even_when_transcriber_does_not() {
     // Profiled run, but the transcriber emits no profile: the `vad` stage still
     // surfaces on its own.
     let splitter = VadSplitter::new(MockVad { probs: vec![1.0; 4], samples_per_prob: 1 }, fast_chunker_opts());
-    let transcriber =
-        PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("a", 1.0, 2.0)], ..Default::default() }] };
+    let transcriber = PresetTranscriber {
+        out: vec![Transcript { text: String::new(), words: vec![word("a", 1.0, 2.0)], ..Default::default() }],
+    };
     let mut asr = Asr::new(splitter, transcriber);
     let out = asr.transcribe(&[0.0_f32; 4], RunOptions { profile: true, ..Default::default() }).unwrap();
     let profile = out.profile.expect("vad-only profile surfaces");

--- a/arch/src/test/unit/pipelines.rs
+++ b/arch/src/test/unit/pipelines.rs
@@ -81,10 +81,18 @@ fn crop_keeps_midpoints_inside_core_and_rebases() {
 }
 
 #[test]
-fn words_to_text_joins_and_drops_empties() {
-    let words = vec![word("hello", 0.0, 0.1), word("", 0.1, 0.1), word("world", 0.2, 0.3)];
-    assert_eq!(words_to_text(&words), "hello world");
+fn words_to_text_concatenates_fragments_and_drops_blanks() {
+    let words =
+        vec![word("  hello", 0.0, 0.1), word("", 0.1, 0.1), word(" \t", 0.1, 0.1), word("  world!  ", 0.2, 0.3)];
+    assert_eq!(words_to_text(&words), "hello  world!");
     assert_eq!(words_to_text(&[]), "");
+}
+
+#[test]
+fn cropped_fragments_reconstruct_without_spacing_heuristics() {
+    let words = vec![word(" prefix", 0.0, 1.0), word(" 23", 2.0, 3.0), word("-м", 3.0, 4.0), word(" доме", 4.0, 5.0)];
+    let cropped = crop_words_to_core(words, 1.5, 4.0);
+    assert_eq!(words_to_text(&cropped), "23-м доме");
 }
 
 // ─── Transcriber::transcribe_chunks default (geometry + crop + stitch) ─────────

--- a/arch/src/test/unit/pipelines.rs
+++ b/arch/src/test/unit/pipelines.rs
@@ -105,7 +105,7 @@ fn transcribe_chunks_slices_decode_windows_crops_and_stitches() {
             Transcript { text: String::new(), words: vec![word("b1", 3.0, 5.0)], ..Default::default() },
         ],
     };
-    let out = asr.transcribe_chunks(&waveform, &chunks, RunOptions { words: true, profile: false }).unwrap();
+    let out = asr.transcribe_chunks(&waveform, &chunks, RunOptions { words: true, ..Default::default() }).unwrap();
     assert_eq!(out.text, "a1 b1");
     assert_eq!(
         out.chunks,
@@ -114,13 +114,15 @@ fn transcribe_chunks_slices_decode_windows_crops_and_stitches() {
                 start_sec: 10.0,
                 end_sec: 20.0,
                 text: "a1".to_string(),
-                words: Some(vec![word("a1", 1.0, 3.0)])
+                words: Some(vec![word("a1", 1.0, 3.0)]),
+                ..Default::default()
             },
             ChunkResult {
                 start_sec: 30.0,
                 end_sec: 40.0,
                 text: "b1".to_string(),
-                words: Some(vec![word("b1", 1.0, 3.0)])
+                words: Some(vec![word("b1", 1.0, 3.0)]),
+                ..Default::default()
             },
         ]
     );
@@ -132,7 +134,7 @@ fn transcribe_chunks_empty_returns_default() {
     // Silence-only audio yields no chunks → empty Transcription, and
     // transcribe_windows is never called (no zero-window batch-math underflow).
     let mut t = PresetTranscriber { out: Vec::new() };
-    let out = t.transcribe_chunks(&[0.0_f32; 10], &[], RunOptions { words: true, profile: false }).unwrap();
+    let out = t.transcribe_chunks(&[0.0_f32; 10], &[], RunOptions { words: true, ..Default::default() }).unwrap();
     assert_eq!(out.text, "");
     assert!(out.chunks.is_empty());
     assert!(out.profile.is_none());
@@ -244,7 +246,7 @@ fn transcribe_windows_default_merges_per_window_profiles() {
     let waveform = vec![0.0_f32; 20];
     let chunks = vec![AudioChunk::new(0, 10), AudioChunk::new(10, 20)];
     let out =
-        ProfilingTranscriber.transcribe_chunks(&waveform, &chunks, RunOptions { words: false, profile: true }).unwrap();
+        ProfilingTranscriber.transcribe_chunks(&waveform, &chunks, RunOptions { profile: true, ..Default::default() }).unwrap();
     let profile = out.profile.expect("profile collected");
     assert_eq!(profile.stages.len(), 1, "stages merged by name");
     assert_eq!(profile.stage("decode").unwrap().wall, std::time::Duration::from_millis(2));
@@ -258,7 +260,7 @@ fn asr_profiles_per_call_without_rebuild() {
     let splitter = VadSplitter::new(MockVad { probs: vec![1.0; 4], samples_per_prob: 1 }, fast_chunker_opts());
     let mut asr = Asr::new(splitter, ProfilingTranscriber);
 
-    let profiled = asr.transcribe(&[0.0_f32; 4], RunOptions { words: false, profile: true }).unwrap();
+    let profiled = asr.transcribe(&[0.0_f32; 4], RunOptions { profile: true, ..Default::default() }).unwrap();
     let profile = profiled.profile.expect("profile");
     let stages: Vec<&str> = profile.stages.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(stages, vec!["vad", "decode"], "VAD stage leads the merged profile");
@@ -274,7 +276,7 @@ fn asr_surfaces_split_stage_even_when_transcriber_does_not() {
     let transcriber =
         PresetTranscriber { out: vec![Transcript { text: String::new(), words: vec![word("a", 1.0, 2.0)], ..Default::default() }] };
     let mut asr = Asr::new(splitter, transcriber);
-    let out = asr.transcribe(&[0.0_f32; 4], RunOptions { words: false, profile: true }).unwrap();
+    let out = asr.transcribe(&[0.0_f32; 4], RunOptions { profile: true, ..Default::default() }).unwrap();
     let profile = out.profile.expect("vad-only profile surfaces");
     let stages: Vec<&str> = profile.stages.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(stages, vec!["vad"]);

--- a/arch/src/test/unit/rnnt.rs
+++ b/arch/src/test/unit/rnnt.rs
@@ -764,7 +764,7 @@ fn test_frames_to_words_sentencepiece_boundaries() {
     let decoder = decoder_with(vec!["\u{2581}hello".into(), "\u{2581}world".into(), "!".into()], 10);
     let emissions = vec![em(0, 0), em(1, 10), em(2, 12)];
     let words = decoder.frames_to_words(&emissions, 0.04);
-    assert_words(&words, &[("hello", 0.0, 0.04), ("world!", 0.40, 0.52)]);
+    assert_words(&words, &[("hello", 0.0, 0.04), (" world!", 0.40, 0.52)]);
 }
 
 #[test]
@@ -786,20 +786,17 @@ fn test_frames_to_words_literal_space_separator() {
     let decoder = decoder_with(vec!["hello".into(), " ".into(), "world".into()], 10);
     let emissions = vec![em(0, 0), em(1, 2), em(2, 3)];
     let words = decoder.frames_to_words(&emissions, 0.1);
-    assert_words(&words, &[("hello", 0.0, 0.1), ("world", 0.3, 0.4)]);
+    assert_words(&words, &[("hello", 0.0, 0.1), (" world", 0.3, 0.4)]);
 }
 
 #[test]
 fn test_frames_to_words_bare_marker_collapses_to_single_space() {
-    // A bare `▁` between two word-initial pieces yields an empty pending word
-    // that flush_pending drops, so the joined transcript single-spaces. The old
-    // raw-replace path produced a double space ("hi  mom"); the word-join is the
-    // canonical text now — pin it so the whitespace normalization can't silently
-    // regress.
+    // A bare marker is whitespace-only and is dropped, while the following
+    // fragment retains its own SentencePiece boundary.
     let decoder = decoder_with(vec!["\u{2581}hi".into(), "\u{2581}".into(), "\u{2581}mom".into()], 10);
     let emissions = vec![em(0, 0), em(1, 1), em(2, 2)];
     let words = decoder.frames_to_words(&emissions, 0.04);
-    assert_words(&words, &[("hi", 0.0, 0.04), ("mom", 0.08, 0.12)]);
+    assert_words(&words, &[("hi", 0.0, 0.04), (" mom", 0.08, 0.12)]);
     assert_eq!(crate::pipelines::audio::words_to_text(&words), "hi mom");
 }
 

--- a/device/src/allocator.rs
+++ b/device/src/allocator.rs
@@ -348,7 +348,14 @@ impl Allocator for CpuAllocator {
     fn _transfer(&self, dest: &RawBuffer, dest_off: usize, src: &RawBuffer, src_off: usize, sz: usize) -> Result<()> {
         match (dest, src) {
             (RawBuffer::Cpu { data: dst, .. }, RawBuffer::Cpu { data: src, .. }) => {
-                // SAFETY: distinct allocations (no aliasing); scheduler exclusivity.
+                if std::ptr::eq(dst, src) {
+                    // Avoid creating aliased references when two buffer
+                    // handles share the same allocation.
+                    let buf = unsafe { &mut *dst.get() };
+                    buf.copy_within(src_off..src_off + sz, dest_off);
+                    return Ok(());
+                }
+                // SAFETY: distinct allocations; scheduler guarantees exclusivity.
                 let dst_buf = unsafe { &mut *dst.get() };
                 let src_buf = unsafe { &*src.get() };
                 dst_buf[dest_off..dest_off + sz].copy_from_slice(&src_buf[src_off..src_off + sz]);

--- a/device/src/buffer.rs
+++ b/device/src/buffer.rs
@@ -512,10 +512,10 @@ impl Buffer {
     /// via the copy engine, without a host-visible mapping.
     pub fn copyin_at(&mut self, dst_off: usize, src: &[u8]) -> Result<()> {
         self.ensure_allocated()?;
-        snafu::ensure!(
-            dst_off + src.len() <= self.size,
-            SizeMismatchSnafu { expected: self.size, actual: dst_off + src.len() }
-        );
+        let end = dst_off
+            .checked_add(src.len())
+            .ok_or(crate::error::Error::SizeMismatch { expected: self.size, actual: usize::MAX })?;
+        snafu::ensure!(end <= self.size, SizeMismatchSnafu { expected: self.size, actual: end });
         self.data.allocator._copyin(self.data.raw(), self.offset + dst_off, src)
     }
 
@@ -576,8 +576,14 @@ impl Buffer {
     pub fn copy_region_from(&mut self, dst_off: usize, src: &Buffer, src_off: usize, len: usize) -> Result<()> {
         self.ensure_allocated()?;
         src.ensure_allocated()?;
-        snafu::ensure!(dst_off + len <= self.size, SizeMismatchSnafu { expected: self.size, actual: dst_off + len });
-        snafu::ensure!(src_off + len <= src.size, SizeMismatchSnafu { expected: src.size, actual: src_off + len });
+        let dst_end = dst_off
+            .checked_add(len)
+            .ok_or(crate::error::Error::SizeMismatch { expected: self.size, actual: usize::MAX })?;
+        let src_end = src_off
+            .checked_add(len)
+            .ok_or(crate::error::Error::SizeMismatch { expected: src.size, actual: usize::MAX })?;
+        snafu::ensure!(dst_end <= self.size, SizeMismatchSnafu { expected: self.size, actual: dst_end });
+        snafu::ensure!(src_end <= src.size, SizeMismatchSnafu { expected: src.size, actual: src_end });
         snafu::ensure!(
             Arc::ptr_eq(&self.data.allocator, &src.data.allocator),
             UnsupportedSnafu { op: "copy_region_from across allocators" }
@@ -591,13 +597,17 @@ impl Buffer {
     /// not overlap.
     pub fn copy_within(&mut self, dst_off: usize, src_off: usize, len: usize) -> Result<()> {
         self.ensure_allocated()?;
+        let dst_end = dst_off
+            .checked_add(len)
+            .ok_or(crate::error::Error::SizeMismatch { expected: self.size, actual: usize::MAX })?;
+        let src_end = src_off
+            .checked_add(len)
+            .ok_or(crate::error::Error::SizeMismatch { expected: self.size, actual: usize::MAX })?;
+        snafu::ensure!(dst_end <= self.size, SizeMismatchSnafu { expected: self.size, actual: dst_end });
+        snafu::ensure!(src_end <= self.size, SizeMismatchSnafu { expected: self.size, actual: src_end });
         snafu::ensure!(
-            dst_off + len <= self.size,
-            SizeMismatchSnafu { expected: self.size, actual: dst_off + len }
-        );
-        snafu::ensure!(
-            src_off + len <= self.size,
-            SizeMismatchSnafu { expected: self.size, actual: src_off + len }
+            len == 0 || dst_end <= src_off || src_end <= dst_off,
+            crate::error::RuntimeSnafu { message: "copy_within regions must not overlap" }
         );
         // No borrow conflict: .raw() returns an owned RawBuffer handle, so we
         // can capture it twice without aliasing &mut self.

--- a/device/src/buffer.rs
+++ b/device/src/buffer.rs
@@ -506,6 +506,19 @@ impl Buffer {
         self.data.allocator._copyin(self.data.raw(), self.offset, src)
     }
 
+    /// Copy `src` into this buffer starting at byte `dst_off`. Partial-write
+    /// counterpart to [`copyout_prefix`] — used to seed a region of a
+    /// device-local buffer (e.g. one lane's KV-cache row) from host memory
+    /// via the copy engine, without a host-visible mapping.
+    pub fn copyin_at(&mut self, dst_off: usize, src: &[u8]) -> Result<()> {
+        self.ensure_allocated()?;
+        snafu::ensure!(
+            dst_off + src.len() <= self.size,
+            SizeMismatchSnafu { expected: self.size, actual: dst_off + src.len() }
+        );
+        self.data.allocator._copyin(self.data.raw(), self.offset + dst_off, src)
+    }
+
     /// Copy data from this buffer to host memory.
     ///
     /// Delegates to the allocator's `_copyout`. Device backends synchronize
@@ -570,6 +583,26 @@ impl Buffer {
             UnsupportedSnafu { op: "copy_region_from across allocators" }
         );
         self.data.allocator._transfer(self.data.raw(), self.offset + dst_off, src.data.raw(), src.offset + src_off, len)
+    }
+
+    /// Copy a region within this buffer to another region in the same buffer
+    /// (on-device SDMA, no host round-trip). Used to relocate a cache row when
+    /// lane compaction shifts a surviving lane to a new row. The regions must
+    /// not overlap.
+    pub fn copy_within(&mut self, dst_off: usize, src_off: usize, len: usize) -> Result<()> {
+        self.ensure_allocated()?;
+        snafu::ensure!(
+            dst_off + len <= self.size,
+            SizeMismatchSnafu { expected: self.size, actual: dst_off + len }
+        );
+        snafu::ensure!(
+            src_off + len <= self.size,
+            SizeMismatchSnafu { expected: self.size, actual: src_off + len }
+        );
+        // No borrow conflict: .raw() returns an owned RawBuffer handle, so we
+        // can capture it twice without aliasing &mut self.
+        let src_raw = self.data.raw();
+        self.data.allocator._transfer(self.data.raw(), self.offset + dst_off, src_raw, self.offset + src_off, len)
     }
 
     /// Synchronize the device (wait for all operations to complete).

--- a/device/src/test/unit/buffer.rs
+++ b/device/src/test/unit/buffer.rs
@@ -70,6 +70,57 @@ fn test_invalid_view() {
     assert!(result.is_err());
 }
 
+fn byte_buffer(allocator: Arc<CpuAllocator>, len: usize) -> Buffer {
+    Buffer::allocate(allocator, DType::UInt8, vec![len], BufferSpec::default()).unwrap()
+}
+
+#[test]
+fn test_copyin_at_writes_region_and_checks_bounds() {
+    let mut buffer = byte_buffer(Arc::new(CpuAllocator), 8);
+    buffer.copyin(&[0; 8]).unwrap();
+
+    buffer.copyin_at(3, &[1, 2, 3]).unwrap();
+    let mut actual = [0; 8];
+    buffer.copyout(&mut actual).unwrap();
+    assert_eq!(actual, [0, 0, 0, 1, 2, 3, 0, 0]);
+
+    assert!(buffer.copyin_at(7, &[1, 2]).is_err());
+    assert!(buffer.copyin_at(usize::MAX, &[1]).is_err());
+}
+
+#[test]
+fn test_copy_region_from_copies_partial_regions_and_checks_both_bounds() {
+    let allocator = Arc::new(CpuAllocator);
+    let mut src = byte_buffer(allocator.clone(), 8);
+    let mut dst = byte_buffer(allocator, 8);
+    src.copyin(&[0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
+    dst.copyin(&[9; 8]).unwrap();
+
+    dst.copy_region_from(2, &src, 3, 3).unwrap();
+    let mut actual = [0; 8];
+    dst.copyout(&mut actual).unwrap();
+    assert_eq!(actual, [9, 9, 3, 4, 5, 9, 9, 9]);
+
+    assert!(dst.copy_region_from(6, &src, 0, 3).is_err());
+    assert!(dst.copy_region_from(0, &src, 7, 2).is_err());
+    assert!(dst.copy_region_from(usize::MAX, &src, 0, 1).is_err());
+}
+
+#[test]
+fn test_copy_within_allows_non_overlapping_regions_and_rejects_overlap() {
+    let mut buffer = byte_buffer(Arc::new(CpuAllocator), 8);
+    buffer.copyin(&[0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
+
+    buffer.copy_within(4, 0, 4).unwrap();
+    let mut actual = [0; 8];
+    buffer.copyout(&mut actual).unwrap();
+    assert_eq!(actual, [0, 1, 2, 3, 0, 1, 2, 3]);
+
+    assert!(buffer.copy_within(2, 0, 4).is_err());
+    assert!(buffer.copy_within(7, 0, 2).is_err());
+    assert!(buffer.copy_within(0, usize::MAX, 1).is_err());
+}
+
 #[cfg(feature = "cuda")]
 #[test]
 fn test_unified_memory_allocation() {

--- a/model/examples/gigaam_infer.rs
+++ b/model/examples/gigaam_infer.rs
@@ -104,7 +104,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let t_transcribe = Instant::now();
     // VAD split → arch pipeline machinery (decode windows → crop → stitch),
     // with the VAD stage folded into the profile.
-    let result = asr.transcribe(&waveform, RunOptions { words: args.timestamps, profile: args.profile })?;
+    let result =
+        asr.transcribe(&waveform, RunOptions { words: args.timestamps, profile: args.profile, ..Default::default() })?;
     let dt_transcribe = t_transcribe.elapsed();
 
     if args.timestamps {

--- a/model/examples/whisper_infer.rs
+++ b/model/examples/whisper_infer.rs
@@ -24,8 +24,8 @@ use clap::Parser;
 
 use svod_arch::pipelines::audio::{Asr, FixedLengthSplitter, RunOptions};
 use svod_model::whisper::{
-    CHUNK_LENGTH, DecodeOptions, SAMPLE_RATE, Whisper, WhisperAlignedTranscriber, WhisperSize, WhisperTask,
-    WhisperTokenizer,
+    CHUNK_LENGTH, DecodeOptions, DecodeStrategy, SAMPLE_RATE, Whisper, WhisperAlignedTranscriber, WhisperSize,
+    WhisperTask, WhisperTokenizer,
 };
 
 #[derive(Parser, Debug)]
@@ -88,7 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let options = DecodeOptions {
         task: args.task,
         language: if args.language == "auto" { None } else { Some(args.language.clone()) },
-        beam_size: Some(5), // beam search — uses KV-cached fast path
+        strategy: DecodeStrategy::Beam { size: 5 },
         ..Default::default()
     };
 

--- a/model/examples/whisper_infer.rs
+++ b/model/examples/whisper_infer.rs
@@ -1,8 +1,8 @@
 //! Whisper inference demo: transcribe a WAV file using Whisper ASR.
 //!
 //! Loads a WAV and runs it through an [`Asr`]: a [`FixedLengthSplitter`] feeds
-//! a [`WhisperTranscriber`]. Each 30-second window is mel → encoder JIT →
-//! greedy decode with logit filters (suppress tokens, timestamp rules).
+//! a [`WhisperAlignedTranscriber`]. Each 30-second window is mel → encoder JIT →
+//! cached beam decoding with temperature fallback, followed by DTW alignment.
 //!
 //! Usage:
 //!   cargo run -p svod-model --release --example whisper_infer -- audio.wav
@@ -11,10 +11,10 @@
 //!
 //! Options:
 //!   --size       Model size: tiny, base, small, medium, large-v3, turbo (default: tiny)
-//!   --language   Language code: en, fr, de, ... (default: en)
+//!   --language   Language code: en, fr, de, ..., or auto (default: auto)
 //!   --task       transcribe or translate (default: transcribe)
 //!   --profile    Print per-stage GPU profile
-//!   --timestamps Print per-chunk timestamps
+//!   --timestamps Print word timestamps
 //!   --repo       HF Hub repo (default: openai/whisper-{size})
 
 use std::path::PathBuf;
@@ -24,7 +24,8 @@ use clap::Parser;
 
 use svod_arch::pipelines::audio::{Asr, FixedLengthSplitter, RunOptions};
 use svod_model::whisper::{
-    CHUNK_LENGTH, DecodeOptions, SAMPLE_RATE, Whisper, WhisperSize, WhisperTokenizer, WhisperTranscriber,
+    CHUNK_LENGTH, DecodeOptions, SAMPLE_RATE, Whisper, WhisperAlignedTranscriber, WhisperSize, WhisperTask,
+    WhisperTokenizer,
 };
 
 #[derive(Parser, Debug)]
@@ -47,9 +48,9 @@ struct Args {
 
     /// Task: transcribe or translate.
     #[arg(long, default_value = "transcribe")]
-    task: String,
+    task: WhisperTask,
 
-    /// Print per-chunk timestamps.
+    /// Print word timestamps.
     #[arg(long)]
     timestamps: bool,
 
@@ -85,9 +86,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tokenizer = WhisperTokenizer::from_hub(multilingual, num_languages)?;
 
     let options = DecodeOptions {
-        task: args.task.clone(),
+        task: args.task,
         language: if args.language == "auto" { None } else { Some(args.language.clone()) },
-        without_timestamps: true,
         beam_size: Some(5), // beam search — uses KV-cached fast path
         ..Default::default()
     };
@@ -96,18 +96,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let window_samples = CHUNK_LENGTH * SAMPLE_RATE;
     let splitter = FixedLengthSplitter::new(window_samples, SAMPLE_RATE);
 
-    let transcriber = WhisperTranscriber::new(model, tokenizer, options, size, window_samples)?;
+    let transcriber = WhisperAlignedTranscriber::new(model, tokenizer, options, size, window_samples)?;
 
     let mut asr = Asr::new(splitter, transcriber);
 
     println!("Transcribing...");
     let t_transcribe = Instant::now();
-    let result = asr.transcribe(&waveform, RunOptions { words: args.timestamps, profile: args.profile })?;
+    let result =
+        asr.transcribe(&waveform, RunOptions { words: args.timestamps, profile: args.profile, ..Default::default() })?;
     let dt_transcribe = t_transcribe.elapsed();
 
-    for chunk in &result.chunks {
-        if !chunk.text.is_empty() {
-            println!("  [{:>6.1}s] {}", chunk.start_sec, chunk.text);
+    if args.timestamps {
+        for chunk in &result.chunks {
+            for word in chunk.words.as_deref().unwrap_or_default() {
+                println!(
+                    "  [{:>6.2}s - {:>6.2}s] {}",
+                    chunk.start_sec + word.start,
+                    chunk.start_sec + word.end,
+                    word.text.trim(),
+                );
+            }
+        }
+    } else {
+        for chunk in &result.chunks {
+            if !chunk.text.is_empty() {
+                println!("  [{:>6.1}s] {}", chunk.start_sec, chunk.text);
+            }
         }
     }
 

--- a/model/examples/whisper_infer.rs
+++ b/model/examples/whisper_infer.rs
@@ -8,25 +8,33 @@
 //!   cargo run -p svod-model --release --example whisper_infer -- audio.wav
 //!   cargo run -p svod-model --release --example whisper_infer -- audio.wav --profile
 //!   cargo run -p svod-model --release --example whisper_infer -- audio.wav --size base
+//!   cargo run -p svod-model --release --example whisper_infer -- audio.wav --warmup 1 --runs 5 --profile
 //!
 //! Options:
 //!   --size       Model size: tiny, base, small, medium, large-v3, turbo (default: tiny)
 //!   --language   Language code: en, fr, de, ..., or auto (default: auto)
 //!   --task       transcribe or translate (default: transcribe)
-//!   --profile    Print per-stage GPU profile
+//!   --profile    Run and print a separate per-stage GPU profile
 //!   --timestamps Print word timestamps
 //!   --repo       HF Hub repo (default: openai/whisper-{size})
 
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 use svod_arch::pipelines::audio::{Asr, FixedLengthSplitter, RunOptions};
 use svod_model::whisper::{
-    CHUNK_LENGTH, DecodeOptions, DecodeStrategy, SAMPLE_RATE, Whisper, WhisperAlignedTranscriber, WhisperSize,
-    WhisperTask, WhisperTokenizer,
+    CHUNK_LENGTH, DecodeOptions, DecodeStrategy, SAMPLE_RATE, Whisper, WhisperAlignedTranscriber, WhisperPlan,
+    WhisperSize, WhisperTask, WhisperTokenizer,
 };
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Strategy {
+    Greedy,
+    Beam,
+    Sample,
+}
 
 #[derive(Parser, Debug)]
 #[command(about = "Whisper ASR transcription demo", long_about = None)]
@@ -49,6 +57,38 @@ struct Args {
     /// Task: transcribe or translate.
     #[arg(long, default_value = "transcribe")]
     task: WhisperTask,
+
+    /// Primary decoding strategy.
+    #[arg(long, value_enum, default_value_t = Strategy::Beam)]
+    strategy: Strategy,
+
+    /// Beam width used by `--strategy beam`.
+    #[arg(long, default_value_t = 5)]
+    beam_size: usize,
+
+    /// Temperature used by `--strategy sample`.
+    #[arg(long, default_value_t = 0.8)]
+    temperature: f32,
+
+    /// Disable quality-gated sampling fallback.
+    #[arg(long)]
+    no_fallback: bool,
+
+    /// Reproducible base seed for sampling and sampling fallback.
+    #[arg(long)]
+    sampling_seed: Option<u64>,
+
+    /// Override the concrete decoder row capacity.
+    #[arg(long)]
+    decoder_slots: Option<usize>,
+
+    /// Untimed warmup iterations.
+    #[arg(long, default_value_t = 0)]
+    warmup: usize,
+
+    /// Timed steady-state iterations.
+    #[arg(long, default_value_t = 1)]
+    runs: usize,
 
     /// Print word timestamps.
     #[arg(long)]
@@ -88,23 +128,71 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let options = DecodeOptions {
         task: args.task,
         language: if args.language == "auto" { None } else { Some(args.language.clone()) },
-        strategy: DecodeStrategy::Beam { size: 5 },
+        strategy: match args.strategy {
+            Strategy::Greedy => DecodeStrategy::Greedy,
+            Strategy::Beam => DecodeStrategy::Beam { size: args.beam_size },
+            Strategy::Sample => DecodeStrategy::Sample { temperature: args.temperature },
+        },
+        fallback: (!args.no_fallback).then(Default::default),
+        sampling_seed: args.sampling_seed,
         ..Default::default()
     };
+    if args.runs == 0 {
+        return Err("--runs must be non-zero".into());
+    }
 
     // Fixed-length 30s windows (no VAD dependency)
     let window_samples = CHUNK_LENGTH * SAMPLE_RATE;
     let splitter = FixedLengthSplitter::new(window_samples, SAMPLE_RATE);
 
-    let transcriber = WhisperAlignedTranscriber::new(model, tokenizer, options, size, window_samples)?;
+    let mut plan = WhisperPlan::for_model(&model.dims, size);
+    if let Some(decoder_slots) = args.decoder_slots {
+        plan.decoder_slots = decoder_slots;
+    }
+    println!(
+        "Plan: encoder batch {}, decoder slots {}, alignment batch {}",
+        plan.encoder_batch, plan.decoder_slots, plan.alignment_batch,
+    );
+    let transcriber = WhisperAlignedTranscriber::new_with_plan(model, tokenizer, options, size, window_samples, plan)?;
 
     let mut asr = Asr::new(splitter, transcriber);
 
-    println!("Transcribing...");
-    let t_transcribe = Instant::now();
-    let result =
-        asr.transcribe(&waveform, RunOptions { words: args.timestamps, profile: args.profile, ..Default::default() })?;
-    let dt_transcribe = t_transcribe.elapsed();
+    for iteration in 0..args.warmup {
+        let started = Instant::now();
+        let _ = asr.transcribe(&waveform, RunOptions::default())?;
+        println!("Warmup {}/{}: {:.3}s", iteration + 1, args.warmup, started.elapsed().as_secs_f64());
+    }
+
+    println!("Running {} measured iteration(s)...", args.runs);
+    let mut durations = Vec::with_capacity(args.runs);
+    let mut result = None;
+    for iteration in 0..args.runs {
+        let started = Instant::now();
+        let current =
+            asr.transcribe(&waveform, RunOptions { words: args.timestamps, profile: false, ..Default::default() })?;
+        let elapsed = started.elapsed();
+        let rtf = rtf(elapsed, duration_s);
+        println!("Run {}/{}: {:.3}s, RTF {:.5}x", iteration + 1, args.runs, elapsed.as_secs_f64(), rtf);
+        durations.push(elapsed);
+        result = Some(current);
+    }
+    let result = result.expect("at least one measured run");
+
+    if args.profile {
+        println!("\nRunning separate profiling pass (excluded from RTF)...");
+        let profiled = asr.transcribe(&waveform, RunOptions { profile: true, ..Default::default() })?;
+        if let Some(profile) = &profiled.profile {
+            println!("\n--- Profile ---\n{profile}");
+            for stage in &profile.stages {
+                if !stage.meta.is_empty() {
+                    println!("{} metadata:", stage.name);
+                    for (key, value) in &stage.meta {
+                        println!("  {key}: {value}");
+                    }
+                }
+            }
+        }
+    }
 
     if args.timestamps {
         for chunk in &result.chunks {
@@ -125,19 +213,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    if let Some(profile) = &result.profile {
-        println!("\n--- Profile ---\n{profile}");
-    }
-
     println!("\n--- Transcript ---\n{}", result.text);
+    let min = durations.iter().copied().min().unwrap_or(Duration::ZERO);
+    let max = durations.iter().copied().max().unwrap_or(Duration::ZERO);
+    let avg = durations.iter().sum::<Duration>() / durations.len() as u32;
     println!(
-        "\nTotal: {:.2}s; transcribe: {:.2}s; loop RTF: {:.4}x",
+        "\nMeasured: min {:.3}s / avg {:.3}s / max {:.3}s over {} run(s)",
+        min.as_secs_f64(),
+        avg.as_secs_f64(),
+        max.as_secs_f64(),
+        durations.len(),
+    );
+    println!(
+        "RTF: min {:.5}x / avg {:.5}x; throughput {:.2}x realtime; total process {:.2}s",
+        rtf(min, duration_s),
+        rtf(avg, duration_s),
+        if avg.is_zero() { 0.0 } else { duration_s / avg.as_secs_f64() as f32 },
         t_total.elapsed().as_secs_f32(),
-        dt_transcribe.as_secs_f32(),
-        if duration_s > 0.0 { dt_transcribe.as_secs_f32() / duration_s } else { 0.0 },
     );
 
     Ok(())
+}
+
+fn rtf(elapsed: Duration, audio_seconds: f32) -> f64 {
+    if audio_seconds > 0.0 { elapsed.as_secs_f64() / audio_seconds as f64 } else { 0.0 }
 }
 
 fn load_wav(path: &PathBuf) -> Result<(Vec<f32>, u32), Box<dyn std::error::Error>> {

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -428,7 +428,7 @@ impl svod_arch::pipelines::audio::Transcriber for GigaAmTranscriber {
                         t_decode += t_dec.elapsed();
 
                         let words = ctc_frames_to_words(&text, &frames, frame_shift);
-                        transcripts.push(Transcript { text, words });
+                        transcripts.push(Transcript { text, words, ..Default::default() });
                     }
                 }
                 HeadDecoder::Rnnt { .. } => {
@@ -494,7 +494,7 @@ impl svod_arch::pipelines::audio::Transcriber for GigaAmTranscriber {
                     // `frames_to_words` strips the SentencePiece `▁` markers, so
                     // `words_to_text` reconstructs the window transcript.
                     let words = decoder.frames_to_words(&emissions, frame_shift);
-                    transcripts.push(Transcript { text: words_to_text(&words), words });
+                    transcripts.push(Transcript { text: words_to_text(&words), words, ..Default::default() });
                 }
             }
         }

--- a/model/src/gigaam/transcribe.rs
+++ b/model/src/gigaam/transcribe.rs
@@ -116,6 +116,7 @@ pub(crate) enum HeadDecoder {
 pub(crate) fn ctc_frames_to_words(text: &str, frames: &[usize], frame_shift: f32) -> Vec<Word> {
     let mut words: Vec<Word> = Vec::new();
     let mut current = String::new();
+    let mut separator = String::new();
     let mut first_frame = 0usize;
     let mut last_frame = 0usize;
 
@@ -132,10 +133,12 @@ pub(crate) fn ctc_frames_to_words(text: &str, frames: &[usize], frame_shift: f32
     for (ch, &frame) in text.chars().zip(frames.iter()) {
         if ch == ' ' {
             commit(&mut words, &mut current, first_frame, last_frame);
+            separator.push(ch);
             continue;
         }
         if current.is_empty() {
             first_frame = frame;
+            current.push_str(&std::mem::take(&mut separator));
         }
         current.push(ch);
         last_frame = frame;
@@ -491,8 +494,8 @@ impl svod_arch::pipelines::audio::Transcriber for GigaAmTranscriber {
                 for (li, (_raw, emissions)) in lane_results.into_iter().enumerate() {
                     let window_len = windows[wave_start + li].len();
                     let frame_shift = (window_len as f32 / sample_rate_hz as f32) / (valid[li].max(1) as f32);
-                    // `frames_to_words` strips the SentencePiece `▁` markers, so
-                    // `words_to_text` reconstructs the window transcript.
+                    // `frames_to_words` converts SentencePiece boundaries into
+                    // exact leading-space fragments for direct reconstruction.
                     let words = decoder.frames_to_words(&emissions, frame_shift);
                     transcripts.push(Transcript { text: words_to_text(&words), words, ..Default::default() });
                 }

--- a/model/src/test/unit/transcribe.rs
+++ b/model/src/test/unit/transcribe.rs
@@ -27,34 +27,34 @@ fn ctc_frames_to_words_single_word() {
 
 #[test]
 fn ctc_frames_to_words_two_words_with_space() {
-    // "hi mom" — space at frame 12 should commit "hi" and start "mom".
+    // "hi mom" — the separator belongs to the following exact fragment.
     let words = ctc_frames_to_words("hi mom", &[5, 6, 12, 20, 21, 22], 0.05);
     assert_eq!(
         words,
         vec![
             Word { text: "hi".to_string(), start: 5.0 * 0.05, end: 7.0 * 0.05 },
-            Word { text: "mom".to_string(), start: 20.0 * 0.05, end: 23.0 * 0.05 },
+            Word { text: " mom".to_string(), start: 20.0 * 0.05, end: 23.0 * 0.05 },
         ]
     );
 }
 
 #[test]
 fn ctc_frames_to_words_leading_and_trailing_spaces() {
-    // " hi " — leading space commits nothing; trailing flushes "hi".
+    // Outer spaces survive in fragments; complete rendering trims them.
     let words = ctc_frames_to_words(" hi ", &[3, 5, 6, 9], 0.04);
-    assert_eq!(words, vec![Word { text: "hi".to_string(), start: 5.0 * 0.04, end: 7.0 * 0.04 }],);
+    assert_eq!(words, vec![Word { text: " hi".to_string(), start: 5.0 * 0.04, end: 7.0 * 0.04 }],);
+    assert_eq!(svod_arch::pipelines::audio::words_to_text(&words), "hi");
 }
 
 #[test]
 fn ctc_frames_to_words_consecutive_spaces() {
-    // "a  b" — two spaces between, second commits an empty pending and is
-    // a no-op.
+    // Consecutive separators are retained on the following fragment.
     let words = ctc_frames_to_words("a  b", &[2, 3, 4, 7], 0.04);
     assert_eq!(
         words,
         vec![
             Word { text: "a".to_string(), start: 2.0 * 0.04, end: 3.0 * 0.04 },
-            Word { text: "b".to_string(), start: 7.0 * 0.04, end: 8.0 * 0.04 },
+            Word { text: "  b".to_string(), start: 7.0 * 0.04, end: 8.0 * 0.04 },
         ]
     );
 }

--- a/model/src/test/unit/whisper/batched_step.rs
+++ b/model/src/test/unit/whisper/batched_step.rs
@@ -1,18 +1,9 @@
-//! Verifies that a single compiled `WhisperDecoderStepBatchedJit` plan
-//! serves multiple batch sizes via `execute_with_vars(&[("b", n)])` — the
-//! JIT contract that continuous batching depends on.
-//!
-//! Mirrors `test/unit/modernbert/jit.rs::jit_rebinds_batch_without_reprepare`:
-//! compile once at `max_batch`, rebind `b` to 1 / 2 / max at execute time,
-//! confirm the live rows differ across batch sizes (proving the symbolic dim
-//! actually flows through attention/embedding/cat/reshape, not silently
-//! ignored) and are finite.
+//! Fixed-capacity decoder-step graph tests.
 
 use svod_dtype::DType;
 use svod_tensor::Tensor;
 
-use crate::jit::InputSpec;
-use crate::whisper::{ModelDimensions, Whisper, WhisperDecoderStepBatchedJit, WhisperSize};
+use crate::whisper::{ModelDimensions, Whisper, WhisperSize};
 
 /// Tiny config so the CPU JIT graph compiles in seconds. `n_text_ctx` is kept
 /// small (8) to shrink the self-attention buffers — the step JIT only needs
@@ -27,179 +18,24 @@ fn tiny_dims() -> ModelDimensions {
     dims
 }
 
-/// One plan, many batch sizes: prepare `WhisperDecoderStepBatchedJit` at
-/// `max_batch = 4`, then execute with `b` rebound to 1, 2, and 4. This is
-/// the exact contract continuous batching relies on — if it holds, the
-/// scheduler dispatches one compiled plan per step regardless of how many
-/// lanes are live.
 #[test]
-#[ignore = "heavy: Whisper step JIT graph compile through the CPU backend"]
-fn batched_step_rebinds_batch_without_reprepare() {
-    let dims = tiny_dims();
-    let max_batch = 4usize;
-    let model = Whisper::empty(dims.clone());
-    let mut jit = WhisperDecoderStepBatchedJit::new(model).with_b_bound(max_batch);
-
-    let n_state = dims.n_text_state;
-    let n_head = dims.n_text_head;
-    let n_layer = dims.n_text_layer;
-    let d_head = n_state / n_head;
-    let n_vocab = dims.n_vocab;
-    let n_text_ctx = dims.n_text_ctx;
-    let n_audio_ctx = 8; // tiny encoder ctx; only shape matters here
-
-    // Prepare once at max_batch. InputSpec sizes the buffers; the symbolic
-    // `b` shrinks the live rows at execute time.
-    jit.prepare_with_config(
-        InputSpec::i32(&[max_batch, 1]),
-        InputSpec::f32(&[max_batch, 1, n_state]),
-        InputSpec::f32(&[max_batch, n_text_ctx, n_layer * n_head, d_head]),
-        InputSpec::f32(&[max_batch, n_text_ctx, n_layer * n_head, d_head]),
-        InputSpec::f32(&[max_batch, n_audio_ctx, n_layer * n_head, d_head]),
-        InputSpec::f32(&[max_batch, n_audio_ctx, n_layer * n_head, d_head]),
-        InputSpec::f32(&[max_batch, 1, 1, n_text_ctx + 1]),
-        &svod_tensor::PrepareConfig::from_env(),
-    )
-    .expect("prepare");
-
-    // Distinct token per lane so we can tell lanes apart in the output.
-    let token_vals: Vec<i32> = (0..max_batch as i32).collect();
-    // Distinct positional embeddings per lane.
-    let pos_emb_vals: Vec<f32> = (0..(max_batch * n_state)).map(|i| i as f32 * 0.001).collect();
-    // Caches filled with small distinct values per lane.
-    let self_k_vals: Vec<f32> =
-        (0..(max_batch * n_text_ctx * n_layer * n_head * d_head)).map(|i| (i % 7) as f32 * 0.01).collect();
-    let cross_k_vals: Vec<f32> =
-        (0..(max_batch * n_audio_ctx * n_layer * n_head * d_head)).map(|i| (i % 11) as f32 * 0.01).collect();
-
-    write_i32(jit.token_mut().expect("token buffer"), &token_vals);
-    write_f32(jit.pos_emb_mut().expect("pos_emb buffer"), &pos_emb_vals);
-    write_f32(jit.self_k_cache_mut().expect("self_k buffer"), &self_k_vals);
-    write_f32(jit.self_v_cache_mut().expect("self_v buffer"), &self_k_vals);
-    write_f32(jit.cross_k_mut().expect("cross_k buffer"), &cross_k_vals);
-    write_f32(jit.cross_v_mut().expect("cross_v buffer"), &cross_k_vals);
-    // All-attend mask: zeros (0.0 = attend, the additive identity).
-    let mask_vals = vec![0.0f32; max_batch * (n_text_ctx + 1)];
-    write_f32(jit.self_mask_mut().expect("mask buffer"), &mask_vals);
-
-    // Execute at each batch size and read the logits output.
-    let logits_buf_len = max_batch * n_vocab;
-    let mut prev_live: Option<Vec<f32>> = None;
-    for &b in &[1usize, 2, max_batch] {
-        jit.execute_with_vars(&[("b", b as i64)]).expect("execute");
-
-        let out = jit.logits().expect("logits buffer");
-        let all = read_f32(out, logits_buf_len);
-        // The output buffer is max_batch-sized; only the first b*n_vocab
-        // elements are live.
-        assert_eq!(all.len(), logits_buf_len, "output buffer should be max_batch-sized, not b={b}-sized");
-        let live = b * n_vocab;
-        assert!(
-            all[..live].iter().all(|v| v.is_finite()),
-            "non-finite logits for b={b}"
-        );
-
-        if let Some(prev) = &prev_live {
-            // Lane-0 logits must be identical across batch sizes (the symbolic
-            // batch doesn't change lane-0's math). This guards against a silent
-            // fallback that ignores `b` and always computes max_batch lanes with
-            // garbage in the unused rows leaking into lane 0.
-            let lane0_now = &all[..n_vocab];
-            let lane0_prev = &prev[..n_vocab];
-            assert_eq!(
-                lane0_now, lane0_prev,
-                "lane-0 logits changed when only the batch size changed — symbolic `b` not threaded correctly",
-            );
-        }
-        prev_live = Some(all[..live].to_vec());
-    }
-
-    // Sanity: different lanes should produce different logits (distinct tokens
-    // + distinct caches), confirming lanes are genuinely independent.
-    if let Some(full) = &prev_live {
-        let lane0 = &full[0..n_vocab];
-        let lane1 = &full[n_vocab..2 * n_vocab];
-        assert_ne!(lane0, lane1, "lanes 0 and 1 produced identical logits — lanes not independent?");
-    }
-}
-
-// ─── Buffer helpers (host-visible mapping) ─────────────────────────────────
-
-fn write_i32(buf: &svod_device::Buffer, data: &[i32]) {
-    let dst = buf.as_host_bytes_mut().expect("host bytes");
-    let bytes = bytemuck::cast_slice(data);
-    let n = bytes.len().min(dst.len());
-    dst[..n].copy_from_slice(&bytes[..n]);
-}
-
-fn write_f32(buf: &svod_device::Buffer, data: &[f32]) {
-    let dst = buf.as_host_bytes_mut().expect("host bytes");
-    let bytes = bytemuck::cast_slice(data);
-    let n = bytes.len().min(dst.len());
-    dst[..n].copy_from_slice(&bytes[..n]);
-}
-
-fn read_f32(buf: &svod_device::Buffer, n: usize) -> Vec<f32> {
-    let src = buf.as_host_bytes().expect("host bytes");
-    let n = n.min(src.len() / std::mem::size_of::<f32>());
-    bytemuck::cast_slice(&src[..n * std::mem::size_of::<f32>()]).to_vec()
-}
-
-/// Eager (non-JIT) check that `forward_step_batched`'s graph constructs with a
-/// symbolic batch dimension threading through every op (embedding, attention,
-/// split_heads, cat, permute, reshape) without hitting a `SymbolicShapeUnsupported`
-/// error. This is the core feasibility question for continuous batching — if the
-/// graph builds, the JIT can compile it with `b` as a `DefineVar`.
-///
-/// Value equality against `forward_step` is established by the JIT test below
-/// (where `b` is bound at execute time); the eager path can't read symbolic-
-/// shaped output via `as_ndarray`, so we only assert successful realization here.
-#[test]
-fn forward_step_batched_graph_builds_with_symbolic_batch() {
+fn forward_step_fixed_batch_keeps_batch_concrete() {
     let dims = tiny_dims();
     let model = Whisper::empty(dims.clone());
-    let n_state = dims.n_text_state;
-    let n_head = dims.n_text_head;
-    let n_layer = dims.n_text_layer;
-    let d_head = n_state / n_head;
-    let n_text_ctx = dims.n_text_ctx;
-    let n_audio_ctx = 8;
-    let batch = 2usize;
+    let (batch, n_audio_ctx) = (2usize, 8usize);
+    let d_head = dims.n_text_state / dims.n_text_head;
+    let layer_heads = dims.n_text_layer * dims.n_text_head;
+    let token = Tensor::zeros(&[batch, 1], DType::Int32).unwrap();
+    let pos_emb = Tensor::zeros(&[batch, 1, dims.n_text_state], DType::Float32).unwrap();
+    let self_k = Tensor::zeros(&[batch, dims.n_text_ctx, layer_heads, d_head], DType::Float32).unwrap();
+    let self_v = Tensor::zeros(&[batch, dims.n_text_ctx, layer_heads, d_head], DType::Float32).unwrap();
+    let cross_k = Tensor::zeros(&[batch, n_audio_ctx, layer_heads, d_head], DType::Float32).unwrap();
+    let cross_v = Tensor::zeros(&[batch, n_audio_ctx, layer_heads, d_head], DType::Float32).unwrap();
+    let mask = Tensor::zeros(&[batch, 1, 1, dims.n_text_ctx + 1], DType::Float32).unwrap();
 
-    let token = Tensor::from_slice((0..batch as i32).collect::<Vec<_>>())
-        .try_reshape([batch, 1usize])
-        .unwrap()
-        .cast(DType::Int32)
-        .unwrap();
-    let pos_emb = Tensor::zeros(&[batch, 1, n_state], DType::Float32).unwrap();
-    let self_k = Tensor::zeros(&[batch, n_text_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
-    let self_v = Tensor::zeros(&[batch, n_text_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
-    let cross_k = Tensor::zeros(&[batch, n_audio_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
-    let cross_v = Tensor::zeros(&[batch, n_audio_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
-    let mask = Tensor::zeros(&[batch, 1, 1, n_text_ctx + 1], DType::Float32).unwrap();
-
-    // Symbolic-batch graph: `b` is an unbound variable. Every input is shrunk
-    // to `b` on dim 0 and the batch threads through the whole decoder.
-    let b_var = svod_tensor::Variable::new("b", 1, 8);
-    let b_bound = b_var.bind(batch as i64).unwrap();
-    let (logits, new_k, new_v) = model
-        .decode_step_batched(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &mask, &b_bound)
-        .unwrap();
-
-    // The batch dim stays symbolic on the output metadata; the n_vocab and
-    // per-position dims are concrete. If any op had rejected the symbolic
-    // batch, `.decode_step_batched` would have returned SymbolicShapeUnsupported
-    // before we got here.
-    let logits_shape = logits.shape().unwrap();
-    assert_eq!(logits_shape.len(), 2);
-    assert!(logits_shape[0].as_const().is_none(), "batch dim should still be symbolic pre-realize");
-    assert_eq!(logits_shape[1].as_const(), Some(dims.n_vocab));
-
-    let k_shape = new_k.shape().unwrap();
-    assert_eq!(k_shape.len(), 4);
-    assert!(k_shape[0].as_const().is_none(), "new_k batch dim should still be symbolic");
-
-    let v_shape = new_v.shape().unwrap();
-    assert_eq!(v_shape.len(), 4);
-    assert!(v_shape[0].as_const().is_none(), "new_v batch dim should still be symbolic");
+    let (logits, new_k, new_v) =
+        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &mask).unwrap();
+    assert_eq!(logits.shape().unwrap()[0].as_const(), Some(batch));
+    assert_eq!(new_k.shape().unwrap()[0].as_const(), Some(batch));
+    assert_eq!(new_v.shape().unwrap()[0].as_const(), Some(batch));
 }

--- a/model/src/test/unit/whisper/batched_step.rs
+++ b/model/src/test/unit/whisper/batched_step.rs
@@ -1,0 +1,205 @@
+//! Verifies that a single compiled `WhisperDecoderStepBatchedJit` plan
+//! serves multiple batch sizes via `execute_with_vars(&[("b", n)])` — the
+//! JIT contract that continuous batching depends on.
+//!
+//! Mirrors `test/unit/modernbert/jit.rs::jit_rebinds_batch_without_reprepare`:
+//! compile once at `max_batch`, rebind `b` to 1 / 2 / max at execute time,
+//! confirm the live rows differ across batch sizes (proving the symbolic dim
+//! actually flows through attention/embedding/cat/reshape, not silently
+//! ignored) and are finite.
+
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+use crate::jit::InputSpec;
+use crate::whisper::{ModelDimensions, Whisper, WhisperDecoderStepBatchedJit, WhisperSize};
+
+/// Tiny config so the CPU JIT graph compiles in seconds. `n_text_ctx` is kept
+/// small (8) to shrink the self-attention buffers — the step JIT only needs
+/// one position of cache populated for this test.
+fn tiny_dims() -> ModelDimensions {
+    // Start from WhisperSize::Tiny's structural dims, but shrink the text
+    // context and vocab so the compile graph is minimal. The step JIT's cache
+    // buffers scale with n_text_ctx.
+    let mut dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    dims.n_text_ctx = 8;
+    dims.n_vocab = 64;
+    dims
+}
+
+/// One plan, many batch sizes: prepare `WhisperDecoderStepBatchedJit` at
+/// `max_batch = 4`, then execute with `b` rebound to 1, 2, and 4. This is
+/// the exact contract continuous batching relies on — if it holds, the
+/// scheduler dispatches one compiled plan per step regardless of how many
+/// lanes are live.
+#[test]
+#[ignore = "heavy: Whisper step JIT graph compile through the CPU backend"]
+fn batched_step_rebinds_batch_without_reprepare() {
+    let dims = tiny_dims();
+    let max_batch = 4usize;
+    let model = Whisper::empty(dims.clone());
+    let mut jit = WhisperDecoderStepBatchedJit::new(model).with_b_bound(max_batch);
+
+    let n_state = dims.n_text_state;
+    let n_head = dims.n_text_head;
+    let n_layer = dims.n_text_layer;
+    let d_head = n_state / n_head;
+    let n_vocab = dims.n_vocab;
+    let n_text_ctx = dims.n_text_ctx;
+    let n_audio_ctx = 8; // tiny encoder ctx; only shape matters here
+
+    // Prepare once at max_batch. InputSpec sizes the buffers; the symbolic
+    // `b` shrinks the live rows at execute time.
+    jit.prepare_with_config(
+        InputSpec::i32(&[max_batch, 1]),
+        InputSpec::f32(&[max_batch, 1, n_state]),
+        InputSpec::f32(&[max_batch, n_text_ctx, n_layer * n_head, d_head]),
+        InputSpec::f32(&[max_batch, n_text_ctx, n_layer * n_head, d_head]),
+        InputSpec::f32(&[max_batch, n_audio_ctx, n_layer * n_head, d_head]),
+        InputSpec::f32(&[max_batch, n_audio_ctx, n_layer * n_head, d_head]),
+        InputSpec::f32(&[max_batch, 1, 1, n_text_ctx + 1]),
+        &svod_tensor::PrepareConfig::from_env(),
+    )
+    .expect("prepare");
+
+    // Distinct token per lane so we can tell lanes apart in the output.
+    let token_vals: Vec<i32> = (0..max_batch as i32).collect();
+    // Distinct positional embeddings per lane.
+    let pos_emb_vals: Vec<f32> = (0..(max_batch * n_state)).map(|i| i as f32 * 0.001).collect();
+    // Caches filled with small distinct values per lane.
+    let self_k_vals: Vec<f32> =
+        (0..(max_batch * n_text_ctx * n_layer * n_head * d_head)).map(|i| (i % 7) as f32 * 0.01).collect();
+    let cross_k_vals: Vec<f32> =
+        (0..(max_batch * n_audio_ctx * n_layer * n_head * d_head)).map(|i| (i % 11) as f32 * 0.01).collect();
+
+    write_i32(jit.token_mut().expect("token buffer"), &token_vals);
+    write_f32(jit.pos_emb_mut().expect("pos_emb buffer"), &pos_emb_vals);
+    write_f32(jit.self_k_cache_mut().expect("self_k buffer"), &self_k_vals);
+    write_f32(jit.self_v_cache_mut().expect("self_v buffer"), &self_k_vals);
+    write_f32(jit.cross_k_mut().expect("cross_k buffer"), &cross_k_vals);
+    write_f32(jit.cross_v_mut().expect("cross_v buffer"), &cross_k_vals);
+    // All-attend mask: zeros (0.0 = attend, the additive identity).
+    let mask_vals = vec![0.0f32; max_batch * (n_text_ctx + 1)];
+    write_f32(jit.self_mask_mut().expect("mask buffer"), &mask_vals);
+
+    // Execute at each batch size and read the logits output.
+    let logits_buf_len = max_batch * n_vocab;
+    let mut prev_live: Option<Vec<f32>> = None;
+    for &b in &[1usize, 2, max_batch] {
+        jit.execute_with_vars(&[("b", b as i64)]).expect("execute");
+
+        let out = jit.logits().expect("logits buffer");
+        let all = read_f32(out, logits_buf_len);
+        // The output buffer is max_batch-sized; only the first b*n_vocab
+        // elements are live.
+        assert_eq!(all.len(), logits_buf_len, "output buffer should be max_batch-sized, not b={b}-sized");
+        let live = b * n_vocab;
+        assert!(
+            all[..live].iter().all(|v| v.is_finite()),
+            "non-finite logits for b={b}"
+        );
+
+        if let Some(prev) = &prev_live {
+            // Lane-0 logits must be identical across batch sizes (the symbolic
+            // batch doesn't change lane-0's math). This guards against a silent
+            // fallback that ignores `b` and always computes max_batch lanes with
+            // garbage in the unused rows leaking into lane 0.
+            let lane0_now = &all[..n_vocab];
+            let lane0_prev = &prev[..n_vocab];
+            assert_eq!(
+                lane0_now, lane0_prev,
+                "lane-0 logits changed when only the batch size changed — symbolic `b` not threaded correctly",
+            );
+        }
+        prev_live = Some(all[..live].to_vec());
+    }
+
+    // Sanity: different lanes should produce different logits (distinct tokens
+    // + distinct caches), confirming lanes are genuinely independent.
+    if let Some(full) = &prev_live {
+        let lane0 = &full[0..n_vocab];
+        let lane1 = &full[n_vocab..2 * n_vocab];
+        assert_ne!(lane0, lane1, "lanes 0 and 1 produced identical logits — lanes not independent?");
+    }
+}
+
+// ─── Buffer helpers (host-visible mapping) ─────────────────────────────────
+
+fn write_i32(buf: &svod_device::Buffer, data: &[i32]) {
+    let dst = buf.as_host_bytes_mut().expect("host bytes");
+    let bytes = bytemuck::cast_slice(data);
+    let n = bytes.len().min(dst.len());
+    dst[..n].copy_from_slice(&bytes[..n]);
+}
+
+fn write_f32(buf: &svod_device::Buffer, data: &[f32]) {
+    let dst = buf.as_host_bytes_mut().expect("host bytes");
+    let bytes = bytemuck::cast_slice(data);
+    let n = bytes.len().min(dst.len());
+    dst[..n].copy_from_slice(&bytes[..n]);
+}
+
+fn read_f32(buf: &svod_device::Buffer, n: usize) -> Vec<f32> {
+    let src = buf.as_host_bytes().expect("host bytes");
+    let n = n.min(src.len() / std::mem::size_of::<f32>());
+    bytemuck::cast_slice(&src[..n * std::mem::size_of::<f32>()]).to_vec()
+}
+
+/// Eager (non-JIT) check that `forward_step_batched`'s graph constructs with a
+/// symbolic batch dimension threading through every op (embedding, attention,
+/// split_heads, cat, permute, reshape) without hitting a `SymbolicShapeUnsupported`
+/// error. This is the core feasibility question for continuous batching — if the
+/// graph builds, the JIT can compile it with `b` as a `DefineVar`.
+///
+/// Value equality against `forward_step` is established by the JIT test below
+/// (where `b` is bound at execute time); the eager path can't read symbolic-
+/// shaped output via `as_ndarray`, so we only assert successful realization here.
+#[test]
+fn forward_step_batched_graph_builds_with_symbolic_batch() {
+    let dims = tiny_dims();
+    let model = Whisper::empty(dims.clone());
+    let n_state = dims.n_text_state;
+    let n_head = dims.n_text_head;
+    let n_layer = dims.n_text_layer;
+    let d_head = n_state / n_head;
+    let n_text_ctx = dims.n_text_ctx;
+    let n_audio_ctx = 8;
+    let batch = 2usize;
+
+    let token = Tensor::from_slice((0..batch as i32).collect::<Vec<_>>())
+        .try_reshape([batch, 1usize])
+        .unwrap()
+        .cast(DType::Int32)
+        .unwrap();
+    let pos_emb = Tensor::zeros(&[batch, 1, n_state], DType::Float32).unwrap();
+    let self_k = Tensor::zeros(&[batch, n_text_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
+    let self_v = Tensor::zeros(&[batch, n_text_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
+    let cross_k = Tensor::zeros(&[batch, n_audio_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
+    let cross_v = Tensor::zeros(&[batch, n_audio_ctx, n_layer * n_head, d_head], DType::Float32).unwrap();
+    let mask = Tensor::zeros(&[batch, 1, 1, n_text_ctx + 1], DType::Float32).unwrap();
+
+    // Symbolic-batch graph: `b` is an unbound variable. Every input is shrunk
+    // to `b` on dim 0 and the batch threads through the whole decoder.
+    let b_var = svod_tensor::Variable::new("b", 1, 8);
+    let b_bound = b_var.bind(batch as i64).unwrap();
+    let (logits, new_k, new_v) = model
+        .decode_step_batched(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &mask, &b_bound)
+        .unwrap();
+
+    // The batch dim stays symbolic on the output metadata; the n_vocab and
+    // per-position dims are concrete. If any op had rejected the symbolic
+    // batch, `.decode_step_batched` would have returned SymbolicShapeUnsupported
+    // before we got here.
+    let logits_shape = logits.shape().unwrap();
+    assert_eq!(logits_shape.len(), 2);
+    assert!(logits_shape[0].as_const().is_none(), "batch dim should still be symbolic pre-realize");
+    assert_eq!(logits_shape[1].as_const(), Some(dims.n_vocab));
+
+    let k_shape = new_k.shape().unwrap();
+    assert_eq!(k_shape.len(), 4);
+    assert!(k_shape[0].as_const().is_none(), "new_k batch dim should still be symbolic");
+
+    let v_shape = new_v.shape().unwrap();
+    assert_eq!(v_shape.len(), 4);
+    assert!(v_shape[0].as_const().is_none(), "new_v batch dim should still be symbolic");
+}

--- a/model/src/test/unit/whisper/batched_step.rs
+++ b/model/src/test/unit/whisper/batched_step.rs
@@ -3,6 +3,7 @@
 use svod_dtype::DType;
 use svod_tensor::Tensor;
 
+use crate::whisper::decoder::cached_step_mask;
 use crate::whisper::{ModelDimensions, Whisper, WhisperSize};
 
 /// Tiny config so the CPU JIT graph compiles in seconds. `n_text_ctx` is kept
@@ -31,11 +32,25 @@ fn forward_step_fixed_batch_keeps_batch_concrete() {
     let self_v = Tensor::zeros(&[batch, dims.n_text_ctx, layer_heads, d_head], DType::Float32).unwrap();
     let cross_k = Tensor::zeros(&[batch, n_audio_ctx, layer_heads, d_head], DType::Float32).unwrap();
     let cross_v = Tensor::zeros(&[batch, n_audio_ctx, layer_heads, d_head], DType::Float32).unwrap();
-    let mask = Tensor::zeros(&[batch, 1, 1, dims.n_text_ctx + 1], DType::Float32).unwrap();
+    let key_lens = Tensor::zeros(&[batch], DType::Int32).unwrap();
 
-    let (logits, new_k, new_v) =
-        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &mask).unwrap();
+    let (mut logits, new_k, new_v) =
+        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &key_lens).unwrap();
     assert_eq!(logits.shape().unwrap()[0].as_const(), Some(batch));
     assert_eq!(new_k.shape().unwrap()[0].as_const(), Some(batch));
     assert_eq!(new_v.shape().unwrap()[0].as_const(), Some(batch));
+    logits.realize().unwrap();
+    assert!(logits.as_vec::<f32>().unwrap().into_iter().all(f32::is_finite));
+}
+
+#[test]
+fn cached_step_key_lengths_mask_only_prefix_and_appended_key() {
+    let key_lens = Tensor::from_slice([0i32, 3]);
+    let mut mask = cached_step_mask(&key_lens, 2, 6).unwrap();
+    assert_eq!(mask.shape().unwrap().iter().map(|dim| dim.as_const().unwrap()).collect::<Vec<_>>(), [2, 1, 1, 6]);
+    mask.realize().unwrap();
+    assert_eq!(
+        mask.as_vec::<bool>().unwrap(),
+        [true, true, true, true, true, false, false, false, false, true, true, false]
+    );
 }

--- a/model/src/test/unit/whisper/batched_step.rs
+++ b/model/src/test/unit/whisper/batched_step.rs
@@ -3,7 +3,7 @@
 use svod_dtype::DType;
 use svod_tensor::Tensor;
 
-use crate::whisper::decoder::cached_step_mask;
+use crate::whisper::decoder::{StepAttentionMode, cached_step_mask};
 use crate::whisper::{ModelDimensions, Whisper, WhisperSize};
 
 /// Tiny config so the CPU JIT graph compiles in seconds. `n_text_ctx` is kept
@@ -53,4 +53,66 @@ fn cached_step_key_lengths_mask_only_prefix_and_appended_key() {
         mask.as_vec::<bool>().unwrap(),
         [true, true, true, true, true, false, false, false, false, true, true, false]
     );
+}
+
+#[test]
+#[ignore = "GPU: custom single-query self/cross attention vs generic SDPA on a supported AMD device"]
+fn decoder_step_attention_modes_match_generic_gpu_sdpa() {
+    let Some(arch) = svod_tensor::config::amd_test_arch() else {
+        eprintln!("skip: no AMD device");
+        return;
+    };
+    if !matches!(arch, svod_dtype::AmdArch::Gfx942 | svod_dtype::AmdArch::Gfx1151) {
+        eprintln!("skip: {arch:?} is not supported by single-query attention");
+        return;
+    }
+
+    let mut dims = tiny_dims();
+    // Production cross-attention length: split=4 creates 375-key chunks, which
+    // also exercises the partial kernel's ragged subgroup tile.
+    dims.n_audio_ctx = 1500;
+    dims.n_text_ctx = 7;
+    dims.dtype = DType::Float32;
+    let model = Whisper::empty(dims.clone());
+    let (batch, d_head) = (2, dims.n_text_state / dims.n_text_head);
+    let layer_heads = dims.n_text_layer * dims.n_text_head;
+    let token = Tensor::from_slice([1i32, 2]).try_reshape([batch, 1]).unwrap();
+    let pos_emb = Tensor::randn(&[batch, 1, dims.n_text_state]).unwrap();
+    let self_k = Tensor::randn(&[batch, dims.n_text_ctx, layer_heads, d_head]).unwrap();
+    let self_v = Tensor::randn(&[batch, dims.n_text_ctx, layer_heads, d_head]).unwrap();
+    let cross_k = Tensor::randn(&[batch, dims.n_audio_ctx, layer_heads, d_head]).unwrap();
+    let cross_v = Tensor::randn(&[batch, dims.n_audio_ctx, layer_heads, d_head]).unwrap();
+    let key_lens = Tensor::from_slice([2i32, 5]);
+
+    let mut outputs = [
+        StepAttentionMode::Generic,
+        StepAttentionMode::CustomSelf,
+        StepAttentionMode::CustomCross { split: 1 },
+        StepAttentionMode::CustomCross { split: 4 },
+        StepAttentionMode::CustomBoth { split: 1 },
+        StepAttentionMode::CustomBoth { split: 4 },
+    ]
+    .map(|mode| {
+        model
+            .decoder
+            .forward_step_with_attention_mode(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &key_lens, mode)
+            .unwrap()
+            .0
+    });
+    Tensor::realize_batch(outputs.iter_mut()).unwrap();
+    let reference = outputs[0].as_vec::<f32>().unwrap();
+    for (mode, output) in [
+        StepAttentionMode::CustomSelf,
+        StepAttentionMode::CustomCross { split: 1 },
+        StepAttentionMode::CustomCross { split: 4 },
+        StepAttentionMode::CustomBoth { split: 1 },
+        StepAttentionMode::CustomBoth { split: 4 },
+    ]
+    .into_iter()
+    .zip(&outputs[1..])
+    {
+        let got = output.as_vec::<f32>().unwrap();
+        let max_abs = got.iter().zip(&reference).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+        assert!(max_abs < 3e-4, "{mode:?} logits differ from generic SDPA by {max_abs:e}");
+    }
 }

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -6,8 +6,8 @@
 use svod_arch::pipelines::audio::Transcriber;
 
 use crate::whisper::{
-    DecodeOptions, DecodeStrategy, ModelDimensions, WhisperAlignedTranscriber, WhisperPlan, WhisperSize, WhisperTask,
-    WhisperTokenizer,
+    DecodeOptions, DecodeStrategy, ModelDimensions, N_TEXT_CTX, WhisperAlignedTranscriber, WhisperPlan, WhisperSize,
+    WhisperTask, WhisperTokenizer,
 };
 
 /// Loads whisper-tiny + tokenizer from HuggingFace Hub and builds a
@@ -70,6 +70,12 @@ fn generalized_scheduler_runs_greedy_with_slot_refill() {
     assert!(decode.meta["dispatches"].parse::<usize>().unwrap() > 0);
     assert_eq!(decode.meta["executions"], decode.meta["dispatches"]);
     assert!(decode.meta["active_row_steps"].parse::<usize>().unwrap() > 0);
+    let active_steps = decode.meta["active_row_steps"].parse::<usize>().unwrap();
+    let capped_steps = N_TEXT_CTX / 2 - 1;
+    assert!(
+        active_steps < capped_steps,
+        "fake-window greedy decode approached the per-window token cap instead of emitting EOT: {active_steps}/{capped_steps} aggregate steps"
+    );
     assert!(decode.meta["row_utilization"].parse::<f64>().unwrap() > 0.0);
     assert!(profile.stage("cross_kv_projection").is_some());
     assert!(profile.stage("prefill").is_some());

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -1,8 +1,7 @@
 //! Correctness tests for fixed-slot decode scheduling.
 //!
-//! The heavy tests (marked `#[ignore]`) load real `whisper-tiny` weights and
-//! compare stable-slot refill with the serial greedy path. Run with `cargo test
-//! -- --ignored`.
+//! The heavy tests (marked `#[ignore]`) load real `whisper-tiny` weights. Run
+//! them with `cargo test -- --ignored`.
 
 use svod_arch::pipelines::audio::Transcriber;
 
@@ -13,15 +12,14 @@ use crate::whisper::{
 
 /// Loads whisper-tiny + tokenizer from HuggingFace Hub and builds a
 /// transcriber with the same options soroka uses.
-fn tiny_transcriber() -> WhisperAlignedTranscriber {
+fn tiny_transcriber(decoder_slots: usize) -> WhisperAlignedTranscriber {
     let repo = "openai/whisper-tiny";
     let dims = ModelDimensions::for_size(WhisperSize::Tiny);
     let model = crate::whisper::Whisper::from_hub(repo, "main", dims).unwrap();
     let multilingual = model.is_multilingual();
     let num_languages = model.dims.num_languages();
     let tokenizer = WhisperTokenizer::from_hub(multilingual, num_languages).unwrap();
-    // Greedy + no fallback makes the two scheduling strategies directly
-    // comparable.
+    // Greedy + no fallback is deterministic across slot geometries.
     let options = DecodeOptions {
         task: WhisperTask::Transcribe,
         language: None,
@@ -30,7 +28,7 @@ fn tiny_transcriber() -> WhisperAlignedTranscriber {
         ..DecodeOptions::default()
     };
     let mut plan = WhisperPlan::for_model(&model.dims, WhisperSize::Tiny);
-    plan.decoder_slots = 1; // force slot refill across the two test windows
+    plan.decoder_slots = decoder_slots;
     plan.alignment_batch = 1;
     WhisperAlignedTranscriber::new_with_plan(model, tokenizer, options, WhisperSize::Tiny, 480_000, plan).unwrap()
 }
@@ -48,22 +46,68 @@ fn fake_windows() -> Vec<Vec<f32>> {
         .collect()
 }
 
-/// Stable slot refill must produce the same text as serial greedy decoding.
+/// Slot refill must not change deterministic greedy output.
 #[test]
 #[ignore = "heavy: real whisper-tiny weights + JIT compile"]
-fn batched_greedy_matches_serial_greedy() {
-    let mut tx = tiny_transcriber();
-    tx.set_language(Some("en".to_string())); // pin language so detection doesn't diverge
+fn generalized_scheduler_runs_greedy_with_slot_refill() {
+    let mut refill = tiny_transcriber(1);
+    let mut concurrent = tiny_transcriber(2);
+    refill.set_language(Some("en".to_string()));
+    concurrent.set_language(Some("en".to_string()));
 
     let windows = fake_windows();
     let refs: Vec<&[f32]> = windows.iter().map(|w| w.as_slice()).collect();
 
-    let (serial, _) = tx.transcribe_windows(&refs, false).expect("serial transcribe");
+    let (refilled, _) = refill.transcribe_windows(&refs, false).expect("refilled greedy transcribe");
+    let (concurrent, _) = concurrent.transcribe_windows(&refs, false).expect("concurrent greedy transcribe");
+    assert_eq!(refilled.len(), concurrent.len());
+    for (index, (refilled, concurrent)) in refilled.iter().zip(concurrent).enumerate() {
+        assert_eq!(refilled.text, concurrent.text, "window {index}: slot geometry changed greedy output");
+    }
+}
 
-    let batched = tx.transcribe_windows_batched_greedy(&refs).expect("batched greedy transcribe");
-
-    assert_eq!(serial.len(), batched.len(), "transcript count mismatch");
-    for (i, (serial, batched)) in serial.iter().zip(batched.iter()).enumerate() {
-        assert_eq!(serial.text, batched.text, "window {i}: scheduling changed decoded text");
+#[test]
+#[ignore = "heavy: real whisper-tiny weights + JIT compile"]
+fn generalized_scheduler_runs_beam_sizes_two_and_five() {
+    for size in [2, 5] {
+        let repo = "openai/whisper-tiny";
+        let dims = ModelDimensions::for_size(WhisperSize::Tiny);
+        let model = crate::whisper::Whisper::from_hub(repo, "main", dims).unwrap();
+        let multilingual = model.is_multilingual();
+        let num_languages = model.dims.num_languages();
+        let options = DecodeOptions {
+            language: Some("en".to_string()),
+            strategy: DecodeStrategy::Beam { size },
+            fallback: None,
+            sample_len: Some(4),
+            ..DecodeOptions::default()
+        };
+        let mut refill_plan = WhisperPlan::for_model(&model.dims, WhisperSize::Tiny);
+        refill_plan.decoder_slots = size;
+        let mut concurrent_plan = refill_plan.clone();
+        concurrent_plan.decoder_slots = size * 2;
+        let mut refill = WhisperAlignedTranscriber::new_with_plan(
+            model.clone(),
+            WhisperTokenizer::from_hub(multilingual, num_languages).unwrap(),
+            options.clone(),
+            WhisperSize::Tiny,
+            480_000,
+            refill_plan,
+        )
+        .unwrap();
+        let mut concurrent = WhisperAlignedTranscriber::new_with_plan(
+            model,
+            WhisperTokenizer::from_hub(multilingual, num_languages).unwrap(),
+            options,
+            WhisperSize::Tiny,
+            480_000,
+            concurrent_plan,
+        )
+        .unwrap();
+        let windows = fake_windows();
+        let refs: Vec<_> = windows.iter().map(Vec::as_slice).collect();
+        let (refilled, _) = refill.transcribe_windows(&refs, false).unwrap();
+        let (concurrent, _) = concurrent.transcribe_windows(&refs, false).unwrap();
+        assert_eq!(refilled, concurrent, "beam-{size} output changed with physical slot geometry");
     }
 }

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -1,35 +1,37 @@
-//! Correctness tests for the batched decode path.
+//! Correctness tests for fixed-slot decode scheduling.
 //!
 //! The heavy tests (marked `#[ignore]`) load real `whisper-tiny` weights and
-//! verify that the batched path produces the same transcripts as the legacy
-//! single-stream path. Run with `cargo test -- --ignored`.
+//! compare stable-slot refill with the serial greedy path. Run with `cargo test
+//! -- --ignored`.
 
 use svod_arch::pipelines::audio::Transcriber;
 
-use crate::whisper::{DecodeOptions, ModelDimensions, WhisperSize, WhisperTokenizer, WhisperTranscriber};
+use crate::whisper::{
+    DecodeOptions, ModelDimensions, WhisperAlignedTranscriber, WhisperPlan, WhisperSize, WhisperTask, WhisperTokenizer,
+};
 
 /// Loads whisper-tiny + tokenizer from HuggingFace Hub and builds a
 /// transcriber with the same options soroka uses.
-fn tiny_transcriber() -> WhisperTranscriber {
+fn tiny_transcriber() -> WhisperAlignedTranscriber {
     let repo = "openai/whisper-tiny";
     let dims = ModelDimensions::for_size(WhisperSize::Tiny);
     let model = crate::whisper::Whisper::from_hub(repo, "main", dims).unwrap();
     let multilingual = model.is_multilingual();
     let num_languages = model.dims.num_languages();
     let tokenizer = WhisperTokenizer::from_hub(multilingual, num_languages).unwrap();
-    // Greedy + no fallback: matches the batched path's decode strategy so the
-    // two are directly comparable. The batched path forces these internally
-    // (temperature_inc=0, beam_size=None); the legacy path honors whatever the
-    // transcriber was built with, so set them here too.
+    // Greedy + no fallback makes the two scheduling strategies directly
+    // comparable.
     let options = DecodeOptions {
-        task: "transcribe".to_string(),
+        task: WhisperTask::Transcribe,
         language: None,
-        without_timestamps: true,
         beam_size: None,
         temperature_inc: 0.0,
         ..DecodeOptions::default()
     };
-    WhisperTranscriber::new(model, tokenizer, options, WhisperSize::Tiny, 480_000).unwrap()
+    let mut plan = WhisperPlan::for_model(&model.dims, WhisperSize::Tiny);
+    plan.decoder_slots = 1; // force slot refill across the two test windows
+    plan.alignment_batch = 1;
+    WhisperAlignedTranscriber::new_with_plan(model, tokenizer, options, WhisperSize::Tiny, 480_000, plan).unwrap()
 }
 
 /// Two sine-wave "audio" windows (distinct frequencies) — enough to drive the
@@ -45,27 +47,22 @@ fn fake_windows() -> Vec<Vec<f32>> {
         .collect()
 }
 
-/// `transcribe_windows_batched` must produce the same text as the legacy
-/// `transcribe_windows` for the same windows. Both paths run the same encoder
-/// and prefill; the difference is the step loop (batched vs serial). This is
-/// the end-to-end correctness guard for the continuous-batching primitive.
+/// Stable slot refill must produce the same text as serial greedy decoding.
 #[test]
 #[ignore = "heavy: real whisper-tiny weights + JIT compile"]
-fn batched_matches_legacy_transcribe() {
+fn batched_greedy_matches_serial_greedy() {
     let mut tx = tiny_transcriber();
     tx.set_language(Some("en".to_string())); // pin language so detection doesn't diverge
 
     let windows = fake_windows();
     let refs: Vec<&[f32]> = windows.iter().map(|w| w.as_slice()).collect();
 
-    // Legacy single-stream path.
-    let (legacy, _) = tx.transcribe_windows(&refs, false).expect("legacy transcribe");
+    let (serial, _) = tx.transcribe_windows(&refs, false).expect("serial transcribe");
 
-    // Batched path.
-    let batched = tx.transcribe_windows_batched(&refs).expect("batched transcribe");
+    let batched = tx.transcribe_windows_batched_greedy(&refs).expect("batched greedy transcribe");
 
-    assert_eq!(legacy.len(), batched.len(), "transcript count mismatch");
-    for (i, (l, b)) in legacy.iter().zip(batched.iter()).enumerate() {
-        assert_eq!(l.text, b.text, "window {i}: text differs between legacy and batched");
+    assert_eq!(serial.len(), batched.len(), "transcript count mismatch");
+    for (i, (serial, batched)) in serial.iter().zip(batched.iter()).enumerate() {
+        assert_eq!(serial.text, batched.text, "window {i}: scheduling changed decoded text");
     }
 }

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -59,11 +59,16 @@ fn generalized_scheduler_runs_greedy_with_slot_refill() {
     let refs: Vec<&[f32]> = windows.iter().map(|w| w.as_slice()).collect();
 
     let (refilled, _) = refill.transcribe_windows(&refs, false).expect("refilled greedy transcribe");
-    let (concurrent, _) = concurrent.transcribe_windows(&refs, false).expect("concurrent greedy transcribe");
+    let (concurrent, profile) = concurrent.transcribe_windows(&refs, true).expect("concurrent greedy transcribe");
     assert_eq!(refilled.len(), concurrent.len());
     for (index, (refilled, concurrent)) in refilled.iter().zip(concurrent).enumerate() {
         assert_eq!(refilled.text, concurrent.text, "window {index}: slot geometry changed greedy output");
     }
+    let profile = profile.unwrap();
+    let decode = profile.stage("decode").unwrap();
+    assert!(decode.meta["dispatches"].parse::<usize>().unwrap() > 0);
+    assert!(decode.meta["active_row_steps"].parse::<usize>().unwrap() > 0);
+    assert!(decode.meta["row_utilization"].parse::<f64>().unwrap() > 0.0);
 }
 
 #[test]

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -5,10 +5,20 @@
 
 use svod_arch::pipelines::audio::Transcriber;
 
+use crate::whisper::transcribe::bounded_window_batches;
 use crate::whisper::{
     DecodeOptions, DecodeStrategy, ModelDimensions, N_TEXT_CTX, WhisperAlignedTranscriber, WhisperPlan, WhisperSize,
     WhisperTask, WhisperTokenizer,
 };
+
+#[test]
+fn long_form_windows_are_consumed_in_bounded_retention_batches() {
+    let windows: Vec<_> = (0..19).collect();
+    let batches: Vec<_> = bounded_window_batches(&windows, 8).map(|batch| batch.to_vec()).collect();
+
+    assert_eq!(batches.iter().map(Vec::len).collect::<Vec<_>>(), [8, 8, 3]);
+    assert_eq!(batches.concat(), windows);
+}
 
 /// Loads whisper-tiny + tokenizer from HuggingFace Hub and builds a
 /// transcriber with the same options soroka uses.

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -116,3 +116,48 @@ fn generalized_scheduler_runs_beam_sizes_two_and_five() {
         assert_eq!(refilled, concurrent, "beam-{size} output changed with physical slot geometry");
     }
 }
+
+#[test]
+#[ignore = "heavy: real whisper-tiny weights + JIT compile"]
+fn seeded_sampling_is_independent_of_slot_geometry() {
+    let repo = "openai/whisper-tiny";
+    let dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    let model = crate::whisper::Whisper::from_hub(repo, "main", dims).unwrap();
+    let multilingual = model.is_multilingual();
+    let num_languages = model.dims.num_languages();
+    let options = DecodeOptions {
+        language: Some("en".to_string()),
+        strategy: DecodeStrategy::Sample { temperature: 0.8 },
+        fallback: None,
+        sampling_seed: Some(42),
+        sample_len: Some(4),
+        ..DecodeOptions::default()
+    };
+    let mut serial_plan = WhisperPlan::for_model(&model.dims, WhisperSize::Tiny);
+    serial_plan.decoder_slots = 1;
+    let mut concurrent_plan = serial_plan.clone();
+    concurrent_plan.decoder_slots = 2;
+    let mut serial = WhisperAlignedTranscriber::new_with_plan(
+        model.clone(),
+        WhisperTokenizer::from_hub(multilingual, num_languages).unwrap(),
+        options.clone(),
+        WhisperSize::Tiny,
+        480_000,
+        serial_plan,
+    )
+    .unwrap();
+    let mut concurrent = WhisperAlignedTranscriber::new_with_plan(
+        model,
+        WhisperTokenizer::from_hub(multilingual, num_languages).unwrap(),
+        options,
+        WhisperSize::Tiny,
+        480_000,
+        concurrent_plan,
+    )
+    .unwrap();
+    let windows = fake_windows();
+    let refs: Vec<_> = windows.iter().map(Vec::as_slice).collect();
+    let (serial, _) = serial.transcribe_windows(&refs, false).unwrap();
+    let (concurrent, _) = concurrent.transcribe_windows(&refs, false).unwrap();
+    assert_eq!(serial, concurrent);
+}

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -1,0 +1,71 @@
+//! Correctness tests for the batched decode path.
+//!
+//! The heavy tests (marked `#[ignore]`) load real `whisper-tiny` weights and
+//! verify that the batched path produces the same transcripts as the legacy
+//! single-stream path. Run with `cargo test -- --ignored`.
+
+use svod_arch::pipelines::audio::Transcriber;
+
+use crate::whisper::{DecodeOptions, ModelDimensions, WhisperSize, WhisperTokenizer, WhisperTranscriber};
+
+/// Loads whisper-tiny + tokenizer from HuggingFace Hub and builds a
+/// transcriber with the same options soroka uses.
+fn tiny_transcriber() -> WhisperTranscriber {
+    let repo = "openai/whisper-tiny";
+    let dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    let model = crate::whisper::Whisper::from_hub(repo, "main", dims).unwrap();
+    let multilingual = model.is_multilingual();
+    let num_languages = model.dims.num_languages();
+    let tokenizer = WhisperTokenizer::from_hub(multilingual, num_languages).unwrap();
+    // Greedy + no fallback: matches the batched path's decode strategy so the
+    // two are directly comparable. The batched path forces these internally
+    // (temperature_inc=0, beam_size=None); the legacy path honors whatever the
+    // transcriber was built with, so set them here too.
+    let options = DecodeOptions {
+        task: "transcribe".to_string(),
+        language: None,
+        without_timestamps: true,
+        beam_size: None,
+        temperature_inc: 0.0,
+        ..DecodeOptions::default()
+    };
+    WhisperTranscriber::new(model, tokenizer, options, WhisperSize::Tiny, 480_000).unwrap()
+}
+
+/// Two sine-wave "audio" windows (distinct frequencies) — enough to drive the
+/// encoder/decoder without needing a real speech fixture. The point is
+/// *deterministic equality* between paths, not transcript quality.
+fn fake_windows() -> Vec<Vec<f32>> {
+    let sr = 16_000usize;
+    (0..2)
+        .map(|wi| {
+            let freq = 220.0 * 2_f32.powi(wi);
+            (0..sr).map(|t| (freq * t as f32 * 2.0 * std::f32::consts::PI / sr as f32).sin() * 0.3).collect()
+        })
+        .collect()
+}
+
+/// `transcribe_windows_batched` must produce the same text as the legacy
+/// `transcribe_windows` for the same windows. Both paths run the same encoder
+/// and prefill; the difference is the step loop (batched vs serial). This is
+/// the end-to-end correctness guard for the continuous-batching primitive.
+#[test]
+#[ignore = "heavy: real whisper-tiny weights + JIT compile"]
+fn batched_matches_legacy_transcribe() {
+    let mut tx = tiny_transcriber();
+    tx.set_language(Some("en".to_string())); // pin language so detection doesn't diverge
+
+    let windows = fake_windows();
+    let refs: Vec<&[f32]> = windows.iter().map(|w| w.as_slice()).collect();
+
+    // Legacy single-stream path.
+    let (legacy, _) = tx.transcribe_windows(&refs, false).expect("legacy transcribe");
+
+    // Batched path.
+    let batched = tx.transcribe_windows_batched(&refs).expect("batched transcribe");
+
+    assert_eq!(legacy.len(), batched.len(), "transcript count mismatch");
+    for (i, (l, b)) in legacy.iter().zip(batched.iter()).enumerate() {
+        assert_eq!(l.text, b.text, "window {i}: text differs between legacy and batched");
+    }
+}

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -7,7 +7,8 @@
 use svod_arch::pipelines::audio::Transcriber;
 
 use crate::whisper::{
-    DecodeOptions, ModelDimensions, WhisperAlignedTranscriber, WhisperPlan, WhisperSize, WhisperTask, WhisperTokenizer,
+    DecodeOptions, DecodeStrategy, ModelDimensions, WhisperAlignedTranscriber, WhisperPlan, WhisperSize, WhisperTask,
+    WhisperTokenizer,
 };
 
 /// Loads whisper-tiny + tokenizer from HuggingFace Hub and builds a
@@ -24,8 +25,8 @@ fn tiny_transcriber() -> WhisperAlignedTranscriber {
     let options = DecodeOptions {
         task: WhisperTask::Transcribe,
         language: None,
-        beam_size: None,
-        temperature_inc: 0.0,
+        strategy: DecodeStrategy::Greedy,
+        fallback: None,
         ..DecodeOptions::default()
     };
     let mut plan = WhisperPlan::for_model(&model.dims, WhisperSize::Tiny);

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -65,11 +65,17 @@ fn generalized_scheduler_runs_greedy_with_slot_refill() {
         assert_eq!(refilled.text, concurrent.text, "window {index}: slot geometry changed greedy output");
     }
     let profile = profile.unwrap();
-    let decode = profile.stage("decode").unwrap();
+    let decode = profile.stage("decoder_step").unwrap();
     assert!(!decode.kernels.is_empty());
     assert!(decode.meta["dispatches"].parse::<usize>().unwrap() > 0);
+    assert_eq!(decode.meta["executions"], decode.meta["dispatches"]);
     assert!(decode.meta["active_row_steps"].parse::<usize>().unwrap() > 0);
     assert!(decode.meta["row_utilization"].parse::<f64>().unwrap() > 0.0);
+    assert!(profile.stage("cross_kv_projection").is_some());
+    assert!(profile.stage("prefill").is_some());
+    assert!(profile.stage("decoder_scheduler_total").is_some());
+    assert!(profile.stage("alignment_graph").is_some());
+    assert!(profile.stage("alignment_cpu_dtw").is_some());
 }
 
 #[test]

--- a/model/src/test/unit/whisper/batched_transcribe.rs
+++ b/model/src/test/unit/whisper/batched_transcribe.rs
@@ -66,6 +66,7 @@ fn generalized_scheduler_runs_greedy_with_slot_refill() {
     }
     let profile = profile.unwrap();
     let decode = profile.stage("decode").unwrap();
+    assert!(!decode.kernels.is_empty());
     assert!(decode.meta["dispatches"].parse::<usize>().unwrap() > 0);
     assert!(decode.meta["active_row_steps"].parse::<usize>().unwrap() > 0);
     assert!(decode.meta["row_utilization"].parse::<f64>().unwrap() > 0.0);

--- a/model/src/test/unit/whisper/beam.rs
+++ b/model/src/test/unit/whisper/beam.rs
@@ -1,0 +1,190 @@
+use std::collections::HashSet;
+
+use crate::whisper::decode::{
+    BeamCandidate, BeamHypothesis, BeamSurvivor, SlotAllocator, attempt_strategies, collect_ordered,
+    finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps, select_beam_candidates, strategy_width,
+};
+use crate::whisper::{DecodeOptions, DecodeStrategy, FallbackPolicy};
+
+fn parent(logical_id: usize, sum_logprob: f32) -> BeamHypothesis {
+    BeamHypothesis { logical_id, tokens: vec![logical_id as u32], token_probs: vec![], sum_logprob }
+}
+
+fn candidate(parent_index: usize, parent_logical_id: usize, parent_row: usize, token_id: u32) -> BeamCandidate {
+    BeamCandidate { parent_index, parent_logical_id, parent_row, token_id, token_logprob: -0.25, sum_logprob: -1.0 }
+}
+
+#[test]
+fn candidate_ties_use_logical_parent_then_token_not_physical_row() {
+    let parents = [parent(20, -0.75), parent(10, -0.75)];
+    let candidates = vec![candidate(0, 20, 0, 1), candidate(1, 10, 3, 9), candidate(1, 10, 3, 2)];
+    let mut next_id = 100;
+
+    let (active, finished, survivors) = select_beam_candidates(&parents, candidates, 3, 99, 3, &mut next_id);
+
+    assert!(finished.is_empty());
+    assert_eq!(active.iter().map(|beam| *beam.tokens.last().unwrap()).collect::<Vec<_>>(), [2, 9, 1]);
+    assert_eq!(survivors.iter().map(|beam| beam.parent_row).collect::<Vec<_>>(), [3, 3, 0]);
+    assert_eq!(active.iter().map(|beam| beam.logical_id).collect::<Vec<_>>(), [100, 101, 102]);
+}
+
+#[test]
+fn candidate_selection_preserves_eot_probability_for_final_accounting() {
+    let parents = [parent(0, -0.75)];
+    let mut eot = candidate(0, 0, 2, 7);
+    eot.token_logprob = -0.5;
+    eot.sum_logprob = -1.25;
+    let mut next_id = 1;
+
+    let (active, finished, survivors) = select_beam_candidates(&parents, vec![eot], 1, 7, 1, &mut next_id);
+
+    assert!(active.is_empty());
+    assert!(survivors.is_empty());
+    assert_eq!(finished[0].tokens, [0, 7]);
+    assert_eq!(finished[0].token_probs, [-0.5f32].map(f32::exp));
+    assert_eq!(finished[0].sum_logprob, -1.25);
+}
+
+#[test]
+fn finalization_adds_eot_without_changing_generated_tokens_or_probabilities() {
+    let active = vec![BeamHypothesis {
+        logical_id: 4,
+        tokens: vec![50, 10, 11],
+        token_probs: vec![0.8, 0.7],
+        sum_logprob: -0.4,
+    }];
+
+    let best = finalize_beam_hypotheses(active, vec![], 1, 99, 1).unwrap();
+
+    assert_eq!(best.tokens, [50, 10, 11, 99]);
+    assert_eq!(best.tokens.len() - 1 - 1, 2);
+    assert_eq!(best.token_probs, [0.8, 0.7]);
+}
+
+#[test]
+fn row_assignment_retains_one_child_per_parent_and_uses_inactive_rows() {
+    let survivors = [
+        BeamSurvivor { logical_id: 8, parent_row: 3 },
+        BeamSurvivor { logical_id: 2, parent_row: 1 },
+        BeamSurvivor { logical_id: 9, parent_row: 3 },
+        BeamSurvivor { logical_id: 4, parent_row: 1 },
+    ];
+
+    let plan = plan_beam_rows(&[0, 1, 2, 3], &survivors).unwrap();
+
+    assert_eq!(plan.rows, [3, 1, 0, 2]);
+    assert_eq!(plan.copies.iter().map(|copy| (copy.src_row, copy.dst_row)).collect::<Vec<_>>(), [(3, 0), (1, 2)]);
+}
+
+#[test]
+fn row_assignment_rejects_invalid_geometry() {
+    let survivor = BeamSurvivor { logical_id: 0, parent_row: 4 };
+    assert!(plan_beam_rows(&[0, 1], &[survivor]).is_err());
+    assert!(plan_beam_rows(&[0, 0], &[]).is_err());
+}
+
+#[test]
+fn row_assignment_invariants_hold_for_all_small_parent_sequences() {
+    // Exhaust all parent selections up to four survivors. This gives the same
+    // invariant coverage as a generated property while remaining deterministic.
+    for len in 0usize..=4 {
+        for encoded in 0usize..4usize.pow(len as u32) {
+            let mut value = encoded;
+            let survivors: Vec<_> = (0..len)
+                .map(|logical_id| {
+                    let parent_row = value % 4;
+                    value /= 4;
+                    BeamSurvivor { logical_id: len - logical_id, parent_row }
+                })
+                .collect();
+            let plan = plan_beam_rows(&[0, 1, 2, 3], &survivors).unwrap();
+            let parents: HashSet<_> = survivors.iter().map(|survivor| survivor.parent_row).collect();
+            let destinations: HashSet<_> = plan.rows.iter().copied().collect();
+
+            assert_eq!(destinations.len(), survivors.len());
+            assert!(plan.copies.iter().all(|copy| !parents.contains(&copy.dst_row)));
+            assert!(plan.copies.iter().all(|copy| parents.contains(&copy.src_row)));
+            assert_eq!(plan.copies.len(), survivors.len() - parents.len());
+        }
+    }
+}
+
+#[test]
+fn generated_token_budget_counts_the_prefill_token() {
+    assert_eq!(remaining_sample_steps(0), 0);
+    assert_eq!(remaining_sample_steps(1), 0);
+    assert_eq!(remaining_sample_steps(5), 4);
+}
+
+#[test]
+fn admission_is_atomic_for_mixed_widths_and_refills_after_release() {
+    let mut slots = SlotAllocator::new(5);
+    let beam = slots.reserve(10, 3).unwrap().unwrap();
+    let sample = slots.reserve(11, 1).unwrap().unwrap();
+    assert_eq!(beam, [0, 1, 2]);
+    assert_eq!(sample, [3]);
+
+    let before = slots.owners().to_vec();
+    assert_eq!(slots.reserve(12, 2).unwrap(), None);
+    assert_eq!(slots.owners(), before); // no partial reservation
+
+    slots.release(10);
+    let refill = slots.reserve(12, 2).unwrap().unwrap();
+    assert_eq!(refill, [0, 1]);
+    let rows: HashSet<_> = beam.into_iter().chain(sample).chain(refill.iter().copied()).collect();
+    assert_eq!(rows.len(), 4);
+    assert_eq!(slots.owners().iter().filter(|owner| **owner == Some(12)).count(), 2);
+}
+
+#[test]
+fn admission_rejects_width_over_capacity_without_ownership() {
+    let mut slots = SlotAllocator::new(2);
+    assert_eq!(slots.reserve(0, 3), Err("decode attempt width exceeds decoder slots"));
+    assert!(slots.owners().iter().all(Option::is_none));
+}
+
+#[test]
+fn fallback_sequence_changes_beam_attempt_to_width_one_sampling() {
+    let options = DecodeOptions {
+        strategy: DecodeStrategy::Beam { size: 5 },
+        fallback: Some(FallbackPolicy { sampling_temperatures: vec![0.4, 0.8], ..FallbackPolicy::default() }),
+        ..DecodeOptions::default()
+    };
+    let strategies = attempt_strategies(&options);
+    assert_eq!(
+        strategies,
+        [
+            DecodeStrategy::Beam { size: 5 },
+            DecodeStrategy::Sample { temperature: 0.4 },
+            DecodeStrategy::Sample { temperature: 0.8 },
+        ]
+    );
+    assert_eq!(strategies.into_iter().map(strategy_width).collect::<Vec<_>>(), [5, 1, 1]);
+}
+
+#[test]
+fn cache_copy_plan_moves_only_the_valid_prefix_in_payload_simulation() {
+    let survivors = [BeamSurvivor { logical_id: 0, parent_row: 2 }, BeamSurvivor { logical_id: 1, parent_row: 2 }];
+    let plan = plan_beam_rows(&[0, 1, 2], &survivors).unwrap();
+    let row_stride = 6;
+    let valid_prefix = 3;
+    let mut payload: Vec<_> = (0..3).flat_map(|row| (0..row_stride).map(move |column| row * 10 + column)).collect();
+    for copy in plan.copies {
+        let src = copy.src_row * row_stride;
+        let dst = copy.dst_row * row_stride;
+        let prefix = payload[src..src + valid_prefix].to_vec();
+        payload[dst..dst + valid_prefix].copy_from_slice(&prefix);
+    }
+    let cloned_row = plan.rows[1];
+    assert_eq!(&payload[cloned_row * row_stride..cloned_row * row_stride + valid_prefix], &[20, 21, 22]);
+    assert_eq!(&payload[cloned_row * row_stride + valid_prefix..(cloned_row + 1) * row_stride], &[3, 4, 5]);
+}
+
+#[test]
+fn scheduler_collection_preserves_input_order_after_out_of_order_completion() {
+    let mut completed = vec![None; 3];
+    for (request, value) in [(2, "third"), (0, "first"), (1, "second")] {
+        completed[request] = Some(value);
+    }
+    assert_eq!(collect_ordered(completed).unwrap(), ["first", "second", "third"]);
+}

--- a/model/src/test/unit/whisper/beam.rs
+++ b/model/src/test/unit/whisper/beam.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
 use crate::whisper::decode::{
-    BeamCandidate, BeamHypothesis, BeamSurvivor, SlotAllocator, attempt_strategies, collect_ordered,
-    finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps, select_beam_candidates, strategy_width,
+    BeamCandidate, BeamHypothesis, BeamSurvivor, DecodeScheduleStats, SlotAllocator, attempt_strategies,
+    collect_ordered, finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps, select_beam_candidates,
+    strategy_width,
 };
 use crate::whisper::{DecodeOptions, DecodeStrategy, FallbackPolicy};
 
@@ -187,4 +188,41 @@ fn scheduler_collection_preserves_input_order_after_out_of_order_completion() {
         completed[request] = Some(value);
     }
     assert_eq!(collect_ordered(completed).unwrap(), ["first", "second", "third"]);
+}
+
+#[test]
+fn scheduler_stats_merge_across_encoder_batches() {
+    let mut total = DecodeScheduleStats {
+        dispatches: 2,
+        active_row_steps: 6,
+        reserved_row_steps: 8,
+        capacity_row_steps: 10,
+        cache_clone_ops: 1,
+        cache_clone_bytes: 128,
+        attempts: 2,
+        fallback_attempts: 0,
+    };
+    total.merge(DecodeScheduleStats {
+        dispatches: 1,
+        active_row_steps: 2,
+        reserved_row_steps: 3,
+        capacity_row_steps: 5,
+        cache_clone_ops: 2,
+        cache_clone_bytes: 256,
+        attempts: 2,
+        fallback_attempts: 1,
+    });
+    assert_eq!(
+        total,
+        DecodeScheduleStats {
+            dispatches: 3,
+            active_row_steps: 8,
+            reserved_row_steps: 11,
+            capacity_row_steps: 15,
+            cache_clone_ops: 3,
+            cache_clone_bytes: 384,
+            attempts: 4,
+            fallback_attempts: 1,
+        }
+    );
 }

--- a/model/src/test/unit/whisper/beam.rs
+++ b/model/src/test/unit/whisper/beam.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use crate::whisper::decode::{
     BeamCandidate, BeamHypothesis, BeamSurvivor, DecodeScheduleStats, SlotAllocator, attempt_strategies,
-    collect_ordered, derived_sampling_seed, finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps,
+    beam_clone_copy_accounting, cache_append_copy_accounting, collect_ordered, derived_sampling_seed,
+    finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps, scheduler_seed_copy_accounting,
     select_beam_candidates, strategy_width,
 };
 use crate::whisper::{DecodeOptions, DecodeStrategy, FallbackPolicy};
@@ -210,6 +211,7 @@ fn scheduler_stats_merge_across_encoder_batches() {
         cache_clone_bytes: 128,
         attempts: 2,
         fallback_attempts: 0,
+        copies: Default::default(),
     };
     total.merge(DecodeScheduleStats {
         dispatches: 1,
@@ -220,6 +222,7 @@ fn scheduler_stats_merge_across_encoder_batches() {
         cache_clone_bytes: 256,
         attempts: 2,
         fallback_attempts: 1,
+        copies: Default::default(),
     });
     assert_eq!(
         total,
@@ -232,6 +235,14 @@ fn scheduler_stats_merge_across_encoder_batches() {
             cache_clone_bytes: 384,
             attempts: 4,
             fallback_attempts: 1,
+            copies: Default::default(),
         }
     );
+}
+
+#[test]
+fn scheduler_copy_accounting_counts_physical_transfers() {
+    assert_eq!(scheduler_seed_copy_accounting(3, 120, 400), (12, 3120));
+    assert_eq!(cache_append_copy_accounting(3, 64), (6, 384));
+    assert_eq!(beam_clone_copy_accounting(2, 5, 64), (4, 1280));
 }

--- a/model/src/test/unit/whisper/beam.rs
+++ b/model/src/test/unit/whisper/beam.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use crate::whisper::decode::{
     BeamCandidate, BeamHypothesis, BeamSurvivor, DecodeScheduleStats, SlotAllocator, attempt_strategies,
-    collect_ordered, finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps, select_beam_candidates,
-    strategy_width,
+    collect_ordered, derived_sampling_seed, finalize_beam_hypotheses, plan_beam_rows, remaining_sample_steps,
+    select_beam_candidates, strategy_width,
 };
 use crate::whisper::{DecodeOptions, DecodeStrategy, FallbackPolicy};
 
@@ -161,6 +161,15 @@ fn fallback_sequence_changes_beam_attempt_to_width_one_sampling() {
         ]
     );
     assert_eq!(strategies.into_iter().map(strategy_width).collect::<Vec<_>>(), [5, 1, 1]);
+}
+
+#[test]
+fn sampling_seed_is_stable_and_request_specific() {
+    let base = 0x1234_5678_9abc_def0;
+    assert_eq!(derived_sampling_seed(base, 0), base);
+    assert_eq!(derived_sampling_seed(base, 1), derived_sampling_seed(base, 1));
+    assert_ne!(derived_sampling_seed(base, 1), derived_sampling_seed(base, 2));
+    assert_ne!(derived_sampling_seed(base, 0), derived_sampling_seed(base, 1));
 }
 
 #[test]

--- a/model/src/test/unit/whisper/dtw.rs
+++ b/model/src/test/unit/whisper/dtw.rs
@@ -63,3 +63,82 @@ fn median_filter_preserves_smooth() {
         assert!((out[i] - data[i]).abs() < 1.0, "median filter changed smooth data at {i}");
     }
 }
+
+#[test]
+fn selected_alignment_ignores_compiled_padding() {
+    let (heads, text_stride, audio_stride) = (2, 8, 6);
+    let (valid_text, valid_audio) = (5, 4);
+    let mut a = vec![0.0f32; heads * text_stride * audio_stride];
+    let mut b = vec![1000.0f32; a.len()];
+    for head in 0..heads {
+        for text in 0..valid_text {
+            for frame in 0..valid_audio {
+                let index = (head * text_stride + text) * audio_stride + frame;
+                let value = -((text as isize - frame as isize).abs() as f32) + head as f32 * 0.1;
+                a[index] = value;
+                b[index] = value;
+            }
+        }
+    }
+
+    let path_a = dtw::find_alignment_path_selected(&a, heads, text_stride, audio_stride, valid_text, valid_audio, 3, 1);
+    let path_b = dtw::find_alignment_path_selected(&b, heads, text_stride, audio_stride, valid_text, valid_audio, 3, 1);
+    assert_eq!(path_a, path_b);
+}
+
+#[test]
+fn word_timings_accept_empty_alignment_path() {
+    let timings = dtw::path_to_word_timings(&[], &[], &[0, 1], &["hello".to_string()], &[vec![1]], &[0.5], 50.0);
+    assert!(timings.is_empty());
+}
+
+#[test]
+fn word_probability_averages_decoder_token_probabilities() {
+    let timings = dtw::path_to_word_timings(
+        &[0, 1, 2],
+        &[0, 1, 2],
+        &[0, 2],
+        &["hello".to_string()],
+        &[vec![10, 11]],
+        &[0.2, 0.8],
+        50.0,
+    );
+    assert_eq!(timings.len(), 1);
+    assert!((timings[0].probability - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn missing_token_probabilities_do_not_produce_nan() {
+    let timings = dtw::path_to_word_timings(&[0, 1], &[0, 1], &[0, 1], &["hello".to_string()], &[vec![10]], &[], 50.0);
+    assert_eq!(timings[0].probability, 0.0);
+}
+
+#[test]
+fn punctuation_attaches_without_changing_timing() {
+    let timings = dtw::path_to_word_timings(
+        &[0, 1, 2],
+        &[0, 1, 2],
+        &[0, 1, 2],
+        &["hello".to_string(), "!".to_string()],
+        &[vec![10], vec![11]],
+        &[0.8, 0.9],
+        50.0,
+    );
+    assert_eq!(timings[0].word, "hello!");
+    assert_eq!(timings[0].tokens, [10, 11]);
+    assert_eq!(timings[0].start, 0.0);
+    assert_eq!(timings[0].end, 0.02);
+    assert!(timings[1].word.is_empty());
+}
+
+#[test]
+fn sentence_boundary_long_duration_is_truncated() {
+    let mut words = vec![
+        dtw::WordTiming { word: "hello".into(), tokens: vec![1], start: 0.0, end: 0.2, probability: 1.0 },
+        dtw::WordTiming { word: ".".into(), tokens: vec![2], start: 0.2, end: 2.2, probability: 1.0 },
+        dtw::WordTiming { word: " next".into(), tokens: vec![3], start: 2.2, end: 2.4, probability: 1.0 },
+    ];
+    dtw::clean_up_word_timings(&mut words);
+    assert!((words[1].end - 0.6).abs() < 1e-6);
+    assert_eq!(words[0].word, "hello.");
+}

--- a/model/src/test/unit/whisper/mod.rs
+++ b/model/src/test/unit/whisper/mod.rs
@@ -1,5 +1,6 @@
 mod batched_step;
 mod batched_transcribe;
+mod beam;
 mod dtw;
 mod language;
 mod model;

--- a/model/src/test/unit/whisper/mod.rs
+++ b/model/src/test/unit/whisper/mod.rs
@@ -1,3 +1,5 @@
+mod batched_step;
+mod batched_transcribe;
 mod dtw;
 mod language;
 mod model;

--- a/model/src/test/unit/whisper/mod.rs
+++ b/model/src/test/unit/whisper/mod.rs
@@ -4,3 +4,5 @@ mod dtw;
 mod language;
 mod model;
 mod parity;
+mod segments;
+mod tokenizer;

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -111,6 +111,41 @@ fn materialized_cross_kv_matches_reference_projection() {
 }
 
 #[test]
+fn low_precision_cross_projection_keeps_fp32_cache_storage() {
+    let mut dims = small_decoder_dims();
+    dims.dtype = DType::Float16;
+    let model = Whisper::empty(dims.clone());
+    let audio_values: Vec<f32> =
+        (0..dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 13.0) * 0.037).collect();
+    let audio = Tensor::from_slice(audio_values).try_reshape([1usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
+    let native_audio = audio.cast(DType::Float16).unwrap();
+
+    let (mut expected_k, mut expected_v) = reference_cross_kv_projection(&model, &native_audio);
+    let (mut legacy_k, mut legacy_v) = reference_cross_kv_projection(&model, &audio);
+    let (mut actual_k, mut actual_v) = model.project_cross_kv(&audio).unwrap();
+    Tensor::realize_batch([
+        &mut expected_k,
+        &mut expected_v,
+        &mut legacy_k,
+        &mut legacy_v,
+        &mut actual_k,
+        &mut actual_v,
+    ])
+    .unwrap();
+
+    for ((expected, legacy), actual) in
+        [(&expected_k, &legacy_k), (&expected_v, &legacy_v)].into_iter().zip([&actual_k, &actual_v])
+    {
+        assert_eq!(actual.uop().dtype(), DType::Float32);
+        let expected = expected.as_vec::<f32>().unwrap();
+        let legacy = legacy.as_vec::<f32>().unwrap();
+        let actual = actual.as_vec::<f32>().unwrap();
+        assert_eq!(actual, expected, "projection must use the model activation dtype before FP32 cache storage");
+        assert_ne!(legacy, expected, "fixture must detect projection inherited from the FP32 encoder output");
+    }
+}
+
+#[test]
 fn prepared_cross_kv_materializes_each_projection_before_packing() {
     let mut dims = small_decoder_dims();
     dims.n_text_layer = 3;
@@ -378,6 +413,33 @@ fn alignment_forward_exports_only_selected_heads() {
     assert_eq!(shape[1].as_const(), Some(heads.len()));
     assert_eq!(shape[2].as_const(), Some(4));
     assert_eq!(shape[3].as_const(), Some(8));
+}
+
+#[test]
+fn alignment_compute_does_not_inherit_fp32_cache_storage_dtype() {
+    let mut dims = small_decoder_dims();
+    dims.dtype = DType::Float16;
+    let model = Whisper::empty(dims.clone());
+    let features = Tensor::from_slice(
+        (0..dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 11.0) * 0.029).collect::<Vec<_>>(),
+    )
+    .try_reshape([1usize, dims.n_audio_ctx, dims.n_text_state])
+    .unwrap();
+    let tokens = Tensor::from_slice([1i32, 2, 3, 4]).try_reshape([1usize, 4]).unwrap();
+    let heads = [(0, 0), (1, 1)];
+    let (cross_k, cross_v) = model.project_cross_kv(&features).unwrap();
+    assert_eq!(cross_k.uop().dtype(), DType::Float32);
+
+    let mut actual = model.align_with_cross_kv(&tokens, &cross_k, &cross_v, &heads).unwrap();
+    let low_k = cross_k.cast(DType::Float16).unwrap();
+    let low_v = cross_v.cast(DType::Float16).unwrap();
+    let mut expected = model.align_with_cross_kv(&tokens, &low_k, &low_v, &heads).unwrap();
+    Tensor::realize_batch([&mut actual, &mut expected]).unwrap();
+
+    let actual = actual.as_vec::<f32>().unwrap();
+    let expected = expected.as_vec::<f32>().unwrap();
+    let max_delta = actual.iter().zip(&expected).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    assert!(max_delta < 1e-5, "FP32 cache storage changed low-precision alignment compute by {max_delta}");
 }
 
 fn eager_audio_feature_alignment_reference(

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -262,13 +262,10 @@ fn cached_steps_match_teacher_forced_full_prefix() {
             .unwrap();
         let self_k = Tensor::from_slice(&cache_k).try_reshape([1usize, dims.n_text_ctx, layer_heads, d_head]).unwrap();
         let self_v = Tensor::from_slice(&cache_v).try_reshape([1usize, dims.n_text_ctx, layer_heads, d_head]).unwrap();
-        let mut mask_values = vec![0.0f32; dims.n_text_ctx + 1];
-        mask_values[pos..dims.n_text_ctx].fill(f32::NEG_INFINITY);
-        let mask = Tensor::from_slice(&mask_values).try_reshape([1usize, 1, 1, dims.n_text_ctx + 1]).unwrap();
-        assert_eq!(mask_values.len() * std::mem::size_of::<f32>(), (dims.n_text_ctx + 1) * 4);
+        let key_lens = Tensor::from_slice([pos as i32]);
 
         let (mut step_logits, mut new_k, mut new_v) =
-            model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &mask).unwrap();
+            model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &key_lens).unwrap();
         prefix.push(next_token);
         let full_tokens = Tensor::from_slice(&prefix).try_reshape([1usize, prefix.len()]).unwrap();
         let mut teacher = model.decode_with_cross_kv(&full_tokens, &cross_k, &cross_v).unwrap();

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -172,81 +172,6 @@ fn projected_cross_kv_and_prefill_shapes_are_concrete() {
 }
 
 #[test]
-fn float16_cache_producers_preserve_dtype_at_numerical_boundaries() {
-    let mut dims = small_decoder_dims();
-    dims.dtype = DType::Float16;
-    let model = Whisper::empty(dims.clone());
-    let audio = Tensor::zeros(&[1, dims.n_audio_ctx, dims.n_text_state], DType::Float32).unwrap();
-    let tokens = Tensor::from_slice([1i32, 2, 3]).try_reshape([1usize, 3]).unwrap();
-
-    assert_eq!(model.cross_cache_output_dtype().unwrap(), DType::Float16);
-    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
-    assert_eq!(cross_k.uop().dtype(), DType::Float16);
-    assert_eq!(cross_v.uop().dtype(), DType::Float16);
-
-    let (logits, self_k, self_v) = model.decode_prefill(&tokens, &cross_k, &cross_v, 0).unwrap();
-    assert_eq!(logits.uop().dtype(), DType::Float32);
-    assert_eq!(self_k.uop().dtype(), DType::Float16);
-    assert_eq!(self_v.uop().dtype(), DType::Float16);
-
-    let qk = model.align_with_cross_kv(&tokens, &cross_k, &cross_v, &[(0, 0)]).unwrap();
-    assert_eq!(qk.uop().dtype(), DType::Float32);
-
-    let token = Tensor::from_slice([4i32]).try_reshape([1usize, 1]).unwrap();
-    let pos_emb = Tensor::zeros(&[1, 1, dims.n_text_state], DType::Float32).unwrap();
-    let cache_shape = [1, dims.n_text_ctx, dims.n_text_layer * dims.n_text_head, 4];
-    let self_k_cache = Tensor::zeros(&cache_shape, DType::Float16).unwrap();
-    let self_v_cache = Tensor::zeros(&cache_shape, DType::Float16).unwrap();
-    let mask = Tensor::zeros(&[1, 1, 1, dims.n_text_ctx + 1], DType::Bool).unwrap();
-    let (step_logits, new_k, new_v) =
-        model.decode_step(&token, &pos_emb, &self_k_cache, &self_v_cache, &cross_k, &cross_v, &mask).unwrap();
-    assert_eq!(step_logits.uop().dtype(), DType::Float32);
-    assert_eq!(new_k.uop().dtype(), DType::Float16);
-    assert_eq!(new_v.uop().dtype(), DType::Float16);
-}
-
-#[test]
-fn inconsistent_cross_projection_state_is_rejected() {
-    let mut dims = small_decoder_dims();
-    dims.dtype = DType::Float16;
-    let mut model = Whisper::empty(dims);
-    model.decoder.blocks[1].cross_attn.value.weight =
-        model.decoder.blocks[1].cross_attn.value.weight.cast(DType::Float32).unwrap();
-    let error = model.cross_cache_output_dtype().unwrap_err();
-    assert!(error.to_string().contains("K/V projection output dtypes are inconsistent"));
-}
-
-#[test]
-fn bool_step_mask_matches_legacy_additive_mask() {
-    let dims = small_decoder_dims();
-    let model = Whisper::empty(dims.clone());
-    let token = Tensor::from_slice([4i32]).try_reshape([1usize, 1]).unwrap();
-    let pos_emb = Tensor::zeros(&[1, 1, dims.n_text_state], DType::Float32).unwrap();
-    let self_shape = [1, dims.n_text_ctx, dims.n_text_layer * dims.n_text_head, 4];
-    let self_k = Tensor::zeros(&self_shape, DType::Float32).unwrap();
-    let self_v = Tensor::zeros(&self_shape, DType::Float32).unwrap();
-    let audio = Tensor::zeros(&[1, dims.n_audio_ctx, dims.n_text_state], DType::Float32).unwrap();
-    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
-    let pos = 3;
-    let mut bool_values = vec![false; dims.n_text_ctx + 1];
-    bool_values[pos..dims.n_text_ctx].fill(true);
-    let bool_mask = Tensor::from_slice(bool_values).try_reshape([1usize, 1, 1, dims.n_text_ctx + 1]).unwrap();
-    let mut additive_values = vec![0.0f32; dims.n_text_ctx + 1];
-    additive_values[pos..dims.n_text_ctx].fill(f32::NEG_INFINITY);
-    let additive_mask = Tensor::from_slice(additive_values).try_reshape([1usize, 1, 1, dims.n_text_ctx + 1]).unwrap();
-
-    let (mut bool_logits, _, _) =
-        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &bool_mask).unwrap();
-    let (mut additive_logits, _, _) =
-        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &additive_mask).unwrap();
-    Tensor::realize_batch([&mut bool_logits, &mut additive_logits]).unwrap();
-    let bool_logits = bool_logits.as_vec::<f32>().unwrap();
-    let additive_logits = additive_logits.as_vec::<f32>().unwrap();
-    let max_delta = bool_logits.iter().zip(additive_logits).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
-    assert!(max_delta < 1e-5, "bool step mask drifted by {max_delta}");
-}
-
-#[test]
 fn prepared_cross_kv_prefill_matches_direct_decoder() {
     let dims = small_decoder_dims();
     let model = Whisper::empty(dims.clone());
@@ -330,8 +255,7 @@ fn prepared_language_detector_has_one_token_and_one_logits_row() {
 #[test]
 #[ignore = "heavy: prepares the cross projection and prefill graphs through the CPU backend"]
 fn prepared_cross_kv_graph_reuses_device_local_outputs() {
-    let mut dims = small_decoder_dims();
-    dims.dtype = DType::Float16;
+    let dims = small_decoder_dims();
     let model = Whisper::empty(dims.clone());
     let cache_shape = [1, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
     let mut config = svod_tensor::PrepareConfig::from_env();
@@ -340,15 +264,13 @@ fn prepared_cross_kv_graph_reuses_device_local_outputs() {
     let mut cross = WhisperCrossKvJit::new(model.clone());
     cross.prepare_with_config(InputSpec::f32(&[1, dims.n_audio_ctx, dims.n_text_state]), &config).unwrap();
     cross.execute().unwrap();
-    assert_eq!(cross.cross_k().unwrap().dtype(), DType::Float16);
-    assert_eq!(cross.cross_v().unwrap().dtype(), DType::Float16);
 
     let mut prefill = WhisperPrefillJit::new(model);
     prefill
         .prepare(
             InputSpec::i32(&[1, 3]),
-            InputSpec::new(&cache_shape, DType::Float16).device_local(),
-            InputSpec::new(&cache_shape, DType::Float16).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
         )
         .unwrap();
     let cross_k = cross.cross_k().unwrap();
@@ -359,16 +281,14 @@ fn prepared_cross_kv_graph_reuses_device_local_outputs() {
     prefill.execute().unwrap();
 
     assert_eq!(prefill.logits().unwrap().size(), 3 * dims.n_vocab * std::mem::size_of::<f32>());
-    assert_eq!(prefill.self_k().unwrap().dtype(), DType::Float16);
-    assert_eq!(prefill.self_v().unwrap().dtype(), DType::Float16);
     assert_eq!(prefill.prepared_cross_k_mut().unwrap().size(), cross_k.size());
     assert_eq!(prefill.prepared_cross_v_mut().unwrap().size(), cross_v.size());
 
     let mut detector = WhisperDecoderJit::new(Whisper::empty(dims.clone()));
     detector
         .prepare(
-            InputSpec::new(&cache_shape, DType::Float16).device_local(),
-            InputSpec::new(&cache_shape, DType::Float16).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
             InputSpec::i32(&[1, 1]),
         )
         .unwrap();

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -3,8 +3,12 @@
 use svod_dtype::DType;
 use svod_tensor::Tensor;
 
+use crate::jit::InputSpec;
 use crate::state::HasStateDict;
-use crate::whisper::{ModelDimensions, Whisper, WhisperSize};
+use crate::whisper::{
+    DecodeOptions, DecodeResult, ModelDimensions, Whisper, WhisperCrossKvJit, WhisperDecoderJit, WhisperPlan,
+    WhisperPrefillJit, WhisperSize,
+};
 
 fn make_dims() -> ModelDimensions {
     ModelDimensions::for_size(WhisperSize::Tiny)
@@ -45,6 +49,131 @@ fn decoder_forward_shape() {
     assert_eq!(shape[0].as_const(), Some(1));
     assert_eq!(shape[1].as_const(), Some(4));
     assert_eq!(shape[2].as_const(), Some(dims.n_vocab));
+}
+
+fn small_decoder_dims() -> ModelDimensions {
+    ModelDimensions {
+        n_mels: 4,
+        n_audio_ctx: 5,
+        n_audio_state: 8,
+        n_audio_head: 2,
+        n_audio_layer: 1,
+        n_vocab: 16,
+        n_text_ctx: 8,
+        n_text_state: 8,
+        n_text_head: 2,
+        n_text_layer: 2,
+        dtype: DType::Float32,
+    }
+}
+
+#[test]
+fn projected_cross_kv_and_prefill_shapes_are_concrete() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let audio = Tensor::zeros(&[1, dims.n_audio_ctx, dims.n_text_state], DType::Float32).unwrap();
+    let tokens = Tensor::from_slice([1i32, 2, 3]).try_reshape([1usize, 3]).unwrap();
+
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    let expected_cross = [1, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    for cache in [&cross_k, &cross_v] {
+        let shape = cache.shape().unwrap();
+        assert_eq!(shape.iter().map(|dim| dim.as_const().unwrap()).collect::<Vec<_>>(), expected_cross);
+    }
+
+    let (logits, self_k, self_v) = model.decode_prefill(&tokens, &cross_k, &cross_v, 0).unwrap();
+    assert_eq!(
+        logits.shape().unwrap().iter().map(|dim| dim.as_const().unwrap()).collect::<Vec<_>>(),
+        [1, 3, dims.n_vocab]
+    );
+    let expected_self = [1, 3, dims.n_text_layer * dims.n_text_head, 4];
+    for cache in [&self_k, &self_v] {
+        assert_eq!(cache.shape().unwrap().iter().map(|dim| dim.as_const().unwrap()).collect::<Vec<_>>(), expected_self);
+    }
+}
+
+#[test]
+fn prepared_cross_kv_prefill_matches_direct_decoder() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let audio_values: Vec<f32> = (0..dims.n_audio_ctx * dims.n_text_state).map(|i| i as f32 * 0.01).collect();
+    let audio = Tensor::from_slice(audio_values).try_reshape([1usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
+    let tokens = Tensor::from_slice([1i32, 2, 3]).try_reshape([1usize, 3]).unwrap();
+
+    let mut direct = model.decode(&tokens, &audio, 0).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    let (mut prepared, _, _) = model.decode_prefill(&tokens, &cross_k, &cross_v, 0).unwrap();
+    direct.realize().unwrap();
+    prepared.realize().unwrap();
+    let direct = direct.as_vec::<f32>().unwrap();
+    let prepared = prepared.as_vec::<f32>().unwrap();
+    let max_delta = direct.iter().zip(&prepared).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    assert!(max_delta < 1e-5, "prepared cross-cache logits drifted by {max_delta}");
+}
+
+#[test]
+#[ignore = "heavy: prepares the cross projection and prefill graphs through the CPU backend"]
+fn prepared_cross_kv_graph_reuses_device_local_outputs() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let cache_shape = [1, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    let mut config = svod_tensor::PrepareConfig::from_env();
+    config.device_local_outputs = true;
+
+    let mut cross = WhisperCrossKvJit::new(model.clone());
+    cross.prepare_with_config(InputSpec::f32(&[1, dims.n_audio_ctx, dims.n_text_state]), &config).unwrap();
+    cross.execute().unwrap();
+
+    let mut prefill = WhisperPrefillJit::new(model);
+    prefill
+        .prepare(
+            InputSpec::i32(&[1, 3]),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+        )
+        .unwrap();
+    let cross_k = cross.cross_k().unwrap();
+    prefill.prepared_cross_k_mut().unwrap().copy_region_from(0, cross_k, 0, cross_k.size()).unwrap();
+    let cross_v = cross.cross_v().unwrap();
+    prefill.prepared_cross_v_mut().unwrap().copy_region_from(0, cross_v, 0, cross_v.size()).unwrap();
+    prefill.tokens_mut().unwrap().copyin(bytemuck::cast_slice(&[1i32, 2, 3])).unwrap();
+    prefill.execute().unwrap();
+
+    assert_eq!(prefill.logits().unwrap().size(), 3 * dims.n_vocab * std::mem::size_of::<f32>());
+    assert_eq!(prefill.prepared_cross_k_mut().unwrap().size(), cross_k.size());
+    assert_eq!(prefill.prepared_cross_v_mut().unwrap().size(), cross_v.size());
+
+    let mut detector = WhisperDecoderJit::new(Whisper::empty(dims.clone()));
+    detector
+        .prepare(
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::i32(&[1, dims.n_text_ctx]),
+        )
+        .unwrap();
+    detector.prepared_cross_k_mut().unwrap().copy_region_from(0, cross_k, 0, cross_k.size()).unwrap();
+    detector.prepared_cross_v_mut().unwrap().copy_region_from(0, cross_v, 0, cross_v.size()).unwrap();
+    detector.tokens_mut().unwrap().copyin(bytemuck::cast_slice(&vec![0i32; dims.n_text_ctx])).unwrap();
+    detector.execute().unwrap();
+    assert_eq!(detector.output().unwrap().size(), dims.n_text_ctx * dims.n_vocab * std::mem::size_of::<f32>());
+}
+
+#[test]
+fn alignment_forward_exports_only_selected_heads() {
+    let dims = make_dims();
+    let model = Whisper::empty(dims.clone());
+    let features = Tensor::zeros(&[2, 8, dims.n_text_state], DType::Float32).unwrap();
+    let tokens = Tensor::from_slice([50363i32, 50364, 50359, 50257, 50363, 50364, 50359, 50257])
+        .try_reshape([2usize, 4])
+        .unwrap();
+    let heads = &[(2, 2), (3, 0)];
+
+    let qk = model.align(&tokens, &features, heads).unwrap();
+    let shape = qk.shape().unwrap();
+    assert_eq!(shape[0].as_const(), Some(2));
+    assert_eq!(shape[1].as_const(), Some(heads.len()));
+    assert_eq!(shape[2].as_const(), Some(4));
+    assert_eq!(shape[3].as_const(), Some(8));
 }
 
 #[test]
@@ -124,4 +253,37 @@ fn alignment_heads_nonempty() {
         let heads = size.alignment_heads();
         assert!(!heads.is_empty(), "{:?} has no alignment heads", size);
     }
+}
+
+#[test]
+fn prepared_plan_has_concrete_nonzero_capacities() {
+    let dims = ModelDimensions::for_size(WhisperSize::LargeV2);
+    let plan = WhisperPlan::for_model(&dims, WhisperSize::LargeV2);
+    assert!(plan.encoder_batch > 0);
+    assert!(plan.decoder_slots > 0);
+    assert!(plan.alignment_batch > 0);
+    assert!(plan.alignment_batch <= plan.encoder_batch);
+    plan.validate().unwrap();
+}
+
+#[test]
+fn no_speech_skip_respects_logprob_override() {
+    let options = DecodeOptions::default();
+    let mut result = DecodeResult {
+        tokens: vec![1, 2],
+        token_probs: vec![0.2, 0.3],
+        text: "hallucination".to_string(),
+        avg_logprob: -2.0,
+        no_speech_prob: 0.9,
+        temperature: 0.0,
+        compression_ratio: 1.0,
+        language: Some("en".to_string()),
+    };
+    assert!(result.should_skip(&options));
+    result.clear_speech();
+    assert!(result.tokens.is_empty());
+    assert!(result.text.is_empty());
+
+    result.avg_logprob = -0.5;
+    assert!(!result.should_skip(&options));
 }

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -68,7 +68,7 @@ fn small_decoder_dims() -> ModelDimensions {
     }
 }
 
-fn old_cross_kv_projection(model: &Whisper, audio: &Tensor) -> (Tensor, Tensor) {
+fn reference_cross_kv_projection(model: &Whisper, audio: &Tensor) -> (Tensor, Tensor) {
     let mut keys = Vec::with_capacity(model.decoder.blocks.len());
     let mut values = Vec::with_capacity(model.decoder.blocks.len());
     for block in &model.decoder.blocks {
@@ -83,7 +83,7 @@ fn old_cross_kv_projection(model: &Whisper, audio: &Tensor) -> (Tensor, Tensor) 
 }
 
 #[test]
-fn packed_cross_kv_matches_per_layer_projection() {
+fn materialized_cross_kv_matches_reference_projection() {
     let mut dims = small_decoder_dims();
     dims.n_text_layer = 3;
     let seed = Whisper::empty(dims.clone());
@@ -92,7 +92,7 @@ fn packed_cross_kv_matches_per_layer_projection() {
         (0..2 * dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 31.0) * 0.017).collect();
     let audio = Tensor::from_slice(audio_values).try_reshape([2usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
 
-    let (mut expected_k, mut expected_v) = old_cross_kv_projection(&model, &audio);
+    let (mut expected_k, mut expected_v) = reference_cross_kv_projection(&model, &audio);
     let (mut actual_k, mut actual_v) = model.project_cross_kv(&audio).unwrap();
     Tensor::realize_batch([&mut expected_k, &mut expected_v, &mut actual_k, &mut actual_v]).unwrap();
 
@@ -106,12 +106,12 @@ fn packed_cross_kv_matches_per_layer_projection() {
         let expected = expected.as_vec::<f32>().unwrap();
         let actual = actual.as_vec::<f32>().unwrap();
         let max_delta = expected.iter().zip(&actual).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
-        assert!(max_delta < 1e-5, "packed cross projection drifted by {max_delta}");
+        assert!(max_delta < 1e-5, "materialized cross projection drifted by {max_delta}");
     }
 }
 
 #[test]
-fn prepared_cross_kv_has_two_single_reduction_kernels() {
+fn prepared_cross_kv_materializes_each_projection_before_packing() {
     let mut dims = small_decoder_dims();
     dims.n_text_layer = 3;
     let seed = Whisper::empty(dims.clone());
@@ -120,16 +120,30 @@ fn prepared_cross_kv_has_two_single_reduction_kernels() {
     jit.prepare(InputSpec::f32(&[1, dims.n_audio_ctx, dims.n_text_state])).unwrap();
 
     let kernels = jit.prepared_kernels().unwrap();
-    assert_eq!(kernels.len(), 2, "packed weights must not be materialized during inference");
-    for kernel in kernels {
-        let reductions = kernel
-            .ast
-            .toposort()
-            .into_iter()
-            .filter(|uop| matches!(uop.op(), Op::Range { axis_type: AxisType::Reduce, .. }))
-            .count();
-        assert_eq!(reductions, 1, "each packed projection must have one reduction axis");
-    }
+    let reduction_counts: Vec<_> = kernels
+        .iter()
+        .map(|kernel| {
+            kernel
+                .ast
+                .toposort()
+                .into_iter()
+                .filter(|uop| matches!(uop.op(), Op::Range { axis_type: AxisType::Reduce, .. }))
+                .count()
+        })
+        .collect();
+    assert!(
+        reduction_counts.iter().all(|&count| count <= 1),
+        "no dispatch may contain repeated independent reductions: {reduction_counts:?}"
+    );
+    assert_eq!(
+        reduction_counts.iter().filter(|&&count| count == 1).count(),
+        2 * dims.n_text_layer,
+        "each layer must have independent key and value projection kernels: {reduction_counts:?}"
+    );
+    assert!(
+        reduction_counts.iter().filter(|&&count| count == 0).count() >= 2,
+        "key and value packing must remain reduction-free: {reduction_counts:?}"
+    );
 }
 
 #[test]

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -172,6 +172,81 @@ fn projected_cross_kv_and_prefill_shapes_are_concrete() {
 }
 
 #[test]
+fn float16_cache_producers_preserve_dtype_at_numerical_boundaries() {
+    let mut dims = small_decoder_dims();
+    dims.dtype = DType::Float16;
+    let model = Whisper::empty(dims.clone());
+    let audio = Tensor::zeros(&[1, dims.n_audio_ctx, dims.n_text_state], DType::Float32).unwrap();
+    let tokens = Tensor::from_slice([1i32, 2, 3]).try_reshape([1usize, 3]).unwrap();
+
+    assert_eq!(model.cross_cache_output_dtype().unwrap(), DType::Float16);
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    assert_eq!(cross_k.uop().dtype(), DType::Float16);
+    assert_eq!(cross_v.uop().dtype(), DType::Float16);
+
+    let (logits, self_k, self_v) = model.decode_prefill(&tokens, &cross_k, &cross_v, 0).unwrap();
+    assert_eq!(logits.uop().dtype(), DType::Float32);
+    assert_eq!(self_k.uop().dtype(), DType::Float16);
+    assert_eq!(self_v.uop().dtype(), DType::Float16);
+
+    let qk = model.align_with_cross_kv(&tokens, &cross_k, &cross_v, &[(0, 0)]).unwrap();
+    assert_eq!(qk.uop().dtype(), DType::Float32);
+
+    let token = Tensor::from_slice([4i32]).try_reshape([1usize, 1]).unwrap();
+    let pos_emb = Tensor::zeros(&[1, 1, dims.n_text_state], DType::Float32).unwrap();
+    let cache_shape = [1, dims.n_text_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    let self_k_cache = Tensor::zeros(&cache_shape, DType::Float16).unwrap();
+    let self_v_cache = Tensor::zeros(&cache_shape, DType::Float16).unwrap();
+    let mask = Tensor::zeros(&[1, 1, 1, dims.n_text_ctx + 1], DType::Bool).unwrap();
+    let (step_logits, new_k, new_v) =
+        model.decode_step(&token, &pos_emb, &self_k_cache, &self_v_cache, &cross_k, &cross_v, &mask).unwrap();
+    assert_eq!(step_logits.uop().dtype(), DType::Float32);
+    assert_eq!(new_k.uop().dtype(), DType::Float16);
+    assert_eq!(new_v.uop().dtype(), DType::Float16);
+}
+
+#[test]
+fn inconsistent_cross_projection_state_is_rejected() {
+    let mut dims = small_decoder_dims();
+    dims.dtype = DType::Float16;
+    let mut model = Whisper::empty(dims);
+    model.decoder.blocks[1].cross_attn.value.weight =
+        model.decoder.blocks[1].cross_attn.value.weight.cast(DType::Float32).unwrap();
+    let error = model.cross_cache_output_dtype().unwrap_err();
+    assert!(error.to_string().contains("K/V projection output dtypes are inconsistent"));
+}
+
+#[test]
+fn bool_step_mask_matches_legacy_additive_mask() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let token = Tensor::from_slice([4i32]).try_reshape([1usize, 1]).unwrap();
+    let pos_emb = Tensor::zeros(&[1, 1, dims.n_text_state], DType::Float32).unwrap();
+    let self_shape = [1, dims.n_text_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    let self_k = Tensor::zeros(&self_shape, DType::Float32).unwrap();
+    let self_v = Tensor::zeros(&self_shape, DType::Float32).unwrap();
+    let audio = Tensor::zeros(&[1, dims.n_audio_ctx, dims.n_text_state], DType::Float32).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    let pos = 3;
+    let mut bool_values = vec![false; dims.n_text_ctx + 1];
+    bool_values[pos..dims.n_text_ctx].fill(true);
+    let bool_mask = Tensor::from_slice(bool_values).try_reshape([1usize, 1, 1, dims.n_text_ctx + 1]).unwrap();
+    let mut additive_values = vec![0.0f32; dims.n_text_ctx + 1];
+    additive_values[pos..dims.n_text_ctx].fill(f32::NEG_INFINITY);
+    let additive_mask = Tensor::from_slice(additive_values).try_reshape([1usize, 1, 1, dims.n_text_ctx + 1]).unwrap();
+
+    let (mut bool_logits, _, _) =
+        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &bool_mask).unwrap();
+    let (mut additive_logits, _, _) =
+        model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &additive_mask).unwrap();
+    Tensor::realize_batch([&mut bool_logits, &mut additive_logits]).unwrap();
+    let bool_logits = bool_logits.as_vec::<f32>().unwrap();
+    let additive_logits = additive_logits.as_vec::<f32>().unwrap();
+    let max_delta = bool_logits.iter().zip(additive_logits).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    assert!(max_delta < 1e-5, "bool step mask drifted by {max_delta}");
+}
+
+#[test]
 fn prepared_cross_kv_prefill_matches_direct_decoder() {
     let dims = small_decoder_dims();
     let model = Whisper::empty(dims.clone());
@@ -255,7 +330,8 @@ fn prepared_language_detector_has_one_token_and_one_logits_row() {
 #[test]
 #[ignore = "heavy: prepares the cross projection and prefill graphs through the CPU backend"]
 fn prepared_cross_kv_graph_reuses_device_local_outputs() {
-    let dims = small_decoder_dims();
+    let mut dims = small_decoder_dims();
+    dims.dtype = DType::Float16;
     let model = Whisper::empty(dims.clone());
     let cache_shape = [1, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
     let mut config = svod_tensor::PrepareConfig::from_env();
@@ -264,13 +340,15 @@ fn prepared_cross_kv_graph_reuses_device_local_outputs() {
     let mut cross = WhisperCrossKvJit::new(model.clone());
     cross.prepare_with_config(InputSpec::f32(&[1, dims.n_audio_ctx, dims.n_text_state]), &config).unwrap();
     cross.execute().unwrap();
+    assert_eq!(cross.cross_k().unwrap().dtype(), DType::Float16);
+    assert_eq!(cross.cross_v().unwrap().dtype(), DType::Float16);
 
     let mut prefill = WhisperPrefillJit::new(model);
     prefill
         .prepare(
             InputSpec::i32(&[1, 3]),
-            InputSpec::f32(&cache_shape).device_local(),
-            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::new(&cache_shape, DType::Float16).device_local(),
+            InputSpec::new(&cache_shape, DType::Float16).device_local(),
         )
         .unwrap();
     let cross_k = cross.cross_k().unwrap();
@@ -281,14 +359,16 @@ fn prepared_cross_kv_graph_reuses_device_local_outputs() {
     prefill.execute().unwrap();
 
     assert_eq!(prefill.logits().unwrap().size(), 3 * dims.n_vocab * std::mem::size_of::<f32>());
+    assert_eq!(prefill.self_k().unwrap().dtype(), DType::Float16);
+    assert_eq!(prefill.self_v().unwrap().dtype(), DType::Float16);
     assert_eq!(prefill.prepared_cross_k_mut().unwrap().size(), cross_k.size());
     assert_eq!(prefill.prepared_cross_v_mut().unwrap().size(), cross_v.size());
 
     let mut detector = WhisperDecoderJit::new(Whisper::empty(dims.clone()));
     detector
         .prepare(
-            InputSpec::f32(&cache_shape).device_local(),
-            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::new(&cache_shape, DType::Float16).device_local(),
+            InputSpec::new(&cache_shape, DType::Float16).device_local(),
             InputSpec::i32(&[1, 1]),
         )
         .unwrap();

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -146,6 +146,48 @@ fn low_precision_cross_projection_keeps_fp32_cache_storage() {
 }
 
 #[test]
+fn low_precision_load_preserves_openai_fp32_parameters() {
+    let source_dims = small_decoder_dims();
+    let source = Whisper::empty(source_dims.clone()).state_dict("");
+    let mut low_dims = source_dims;
+    low_dims.dtype = DType::Float16;
+    let model = Whisper::from_state_dict(&source, low_dims).unwrap();
+
+    assert_eq!(model.encoder.conv1.weight.uop().dtype(), DType::Float16);
+    assert_eq!(model.encoder.blocks[0].attn.query.weight.uop().dtype(), DType::Float16);
+    assert_eq!(model.encoder.positional_embedding.uop().dtype(), DType::Float32);
+    assert_eq!(model.encoder.blocks[0].attn_ln.weight.uop().dtype(), DType::Float32);
+    assert_eq!(model.decoder.token_embedding.uop().dtype(), DType::Float32);
+    assert_eq!(model.decoder.positional_embedding.uop().dtype(), DType::Float32);
+    assert_eq!(model.decoder.blocks[0].cross_attn_ln.bias.uop().dtype(), DType::Float32);
+    assert_eq!(model.decoder.ln.weight.uop().dtype(), DType::Float32);
+}
+
+#[test]
+fn low_precision_prefill_does_not_inherit_fp32_cache_storage_dtype() {
+    let source_dims = small_decoder_dims();
+    let source = Whisper::empty(source_dims.clone()).state_dict("");
+    let mut dims = source_dims;
+    dims.dtype = DType::Float16;
+    let model = Whisper::from_state_dict(&source, dims.clone()).unwrap();
+    let audio = Tensor::from_slice(
+        (0..dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 9.0) * 0.031).collect::<Vec<_>>(),
+    )
+    .try_reshape([1usize, dims.n_audio_ctx, dims.n_text_state])
+    .unwrap();
+    let tokens = Tensor::from_slice([1i32, 2, 3]).try_reshape([1usize, 3]).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    assert_eq!(cross_k.uop().dtype(), DType::Float32);
+
+    let (mut actual, _, _) = model.decode_prefill(&tokens, &cross_k, &cross_v, 0).unwrap();
+    let (mut expected, _, _) = model
+        .decode_prefill(&tokens, &cross_k.cast(DType::Float16).unwrap(), &cross_v.cast(DType::Float16).unwrap(), 0)
+        .unwrap();
+    Tensor::realize_batch([&mut actual, &mut expected]).unwrap();
+    assert_eq!(actual.as_vec::<f32>().unwrap(), expected.as_vec::<f32>().unwrap());
+}
+
+#[test]
 fn prepared_cross_kv_materializes_each_projection_before_packing() {
     let mut dims = small_decoder_dims();
     dims.n_text_layer = 3;

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -191,6 +191,68 @@ fn prepared_cross_kv_prefill_matches_direct_decoder() {
 }
 
 #[test]
+fn one_token_language_logits_match_full_context_sot_logits() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let audio_values: Vec<f32> = (0..dims.n_audio_ctx * dims.n_text_state).map(|i| i as f32 * 0.013).collect();
+    let audio = Tensor::from_slice(audio_values).try_reshape([1usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    let mut padded_tokens = vec![0i32; dims.n_text_ctx];
+    padded_tokens[0] = 1;
+    let full_tokens = Tensor::from_slice(padded_tokens).try_reshape([1usize, dims.n_text_ctx]).unwrap();
+    let one_token = Tensor::from_slice([1i32]).try_reshape([1usize, 1]).unwrap();
+
+    let mut full = model.decode_with_cross_kv(&full_tokens, &cross_k, &cross_v).unwrap();
+    let mut one = model.decode_with_cross_kv(&one_token, &cross_k, &cross_v).unwrap();
+    Tensor::realize_batch([&mut full, &mut one]).unwrap();
+    let full = full.as_vec::<f32>().unwrap();
+    let one = one.as_vec::<f32>().unwrap();
+    let max_delta = full[..dims.n_vocab].iter().zip(&one).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    assert!(max_delta < 1e-5, "one-token SOT logits drifted by {max_delta}");
+
+    let language_tokens = [2usize, 5, 9, 12];
+    let rank = |logits: &[f32]| {
+        let mut ranked = language_tokens.map(|token| (token, logits[token]));
+        ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+        ranked
+    };
+    assert_eq!(rank(&full[..dims.n_vocab]).map(|(token, _)| token), rank(&one).map(|(token, _)| token));
+}
+
+#[test]
+fn prepared_language_detector_has_one_token_and_one_logits_row() {
+    const WHISPER_TEXT_CONTEXT: i64 = 448;
+
+    let dims = small_decoder_dims();
+    let cache_shape = [1, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    let model = Whisper::empty(dims.clone());
+    let audio = Tensor::zeros(&[1, dims.n_audio_ctx, dims.n_text_state], DType::Float32).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    let token = Tensor::from_slice([1i32]).try_reshape([1usize, 1]).unwrap();
+    let logits = model.decode_with_cross_kv(&token, &cross_k, &cross_v).unwrap();
+    assert_eq!(
+        logits.shape().unwrap().iter().map(|dim| dim.as_const().unwrap()).collect::<Vec<_>>(),
+        [1, 1, dims.n_vocab]
+    );
+
+    let mut detector = WhisperDecoderJit::new(model);
+    detector
+        .prepare(
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::i32(&[1, 1]),
+        )
+        .unwrap();
+    assert_eq!(detector.tokens_mut().unwrap().size(), std::mem::size_of::<i32>());
+    assert_eq!(detector.output().unwrap().size(), dims.n_vocab * std::mem::size_of::<f32>());
+    assert!(detector.prepared_kernels().unwrap().iter().all(|kernel| {
+        kernel.ast.toposort().into_iter().all(|uop| {
+            !matches!(uop.op(), Op::Const(value) if matches!(value.0, ConstValue::Int(WHISPER_TEXT_CONTEXT) | ConstValue::UInt(448)))
+        })
+    }));
+}
+
+#[test]
 #[ignore = "heavy: prepares the cross projection and prefill graphs through the CPU backend"]
 fn prepared_cross_kv_graph_reuses_device_local_outputs() {
     let dims = small_decoder_dims();
@@ -227,14 +289,14 @@ fn prepared_cross_kv_graph_reuses_device_local_outputs() {
         .prepare(
             InputSpec::f32(&cache_shape).device_local(),
             InputSpec::f32(&cache_shape).device_local(),
-            InputSpec::i32(&[1, dims.n_text_ctx]),
+            InputSpec::i32(&[1, 1]),
         )
         .unwrap();
     detector.prepared_cross_k_mut().unwrap().copy_region_from(0, cross_k, 0, cross_k.size()).unwrap();
     detector.prepared_cross_v_mut().unwrap().copy_region_from(0, cross_v, 0, cross_v.size()).unwrap();
-    detector.tokens_mut().unwrap().copyin(bytemuck::cast_slice(&vec![0i32; dims.n_text_ctx])).unwrap();
+    detector.tokens_mut().unwrap().copyin(bytemuck::cast_slice(&[0i32])).unwrap();
     detector.execute().unwrap();
-    assert_eq!(detector.output().unwrap().size(), dims.n_text_ctx * dims.n_vocab * std::mem::size_of::<f32>());
+    assert_eq!(detector.output().unwrap().size(), dims.n_vocab * std::mem::size_of::<f32>());
 }
 
 #[test]

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -6,8 +6,8 @@ use svod_tensor::Tensor;
 use crate::jit::InputSpec;
 use crate::state::HasStateDict;
 use crate::whisper::{
-    DecodeOptions, DecodeResult, ModelDimensions, Whisper, WhisperCrossKvJit, WhisperDecoderJit, WhisperPlan,
-    WhisperPrefillJit, WhisperSize,
+    DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, ModelDimensions, Whisper, WhisperCrossKvJit,
+    WhisperDecoderJit, WhisperPlan, WhisperPrefillJit, WhisperSize,
 };
 
 fn make_dims() -> ModelDimensions {
@@ -267,6 +267,31 @@ fn prepared_plan_has_concrete_nonzero_capacities() {
 }
 
 #[test]
+fn default_decode_policy_is_explicit_openai_fallback() {
+    let options = DecodeOptions::default();
+    assert_eq!(options.strategy, DecodeStrategy::Beam { size: 5 });
+    assert_eq!(options.fallback.unwrap().sampling_temperatures, [0.2, 0.4, 0.6, 0.8, 1.0]);
+}
+
+#[test]
+fn decode_policy_rejects_invalid_geometry_and_temperatures() {
+    let invalid_beam = DecodeOptions { strategy: DecodeStrategy::Beam { size: 0 }, ..Default::default() };
+    assert!(invalid_beam.validate().is_err());
+
+    let invalid_sample = DecodeOptions { strategy: DecodeStrategy::Sample { temperature: 0.0 }, ..Default::default() };
+    assert!(invalid_sample.validate().is_err());
+
+    let invalid_fallback = DecodeOptions {
+        fallback: Some(FallbackPolicy { sampling_temperatures: vec![f32::NAN], ..FallbackPolicy::default() }),
+        ..Default::default()
+    };
+    assert!(invalid_fallback.validate().is_err());
+
+    let invalid_silence = DecodeOptions { no_speech_threshold: Some(1.1), ..Default::default() };
+    assert!(invalid_silence.validate().is_err());
+}
+
+#[test]
 fn no_speech_skip_respects_logprob_override() {
     let options = DecodeOptions::default();
     let mut result = DecodeResult {
@@ -286,4 +311,21 @@ fn no_speech_skip_respects_logprob_override() {
 
     result.avg_logprob = -0.5;
     assert!(!result.should_skip(&options));
+}
+
+#[test]
+fn confident_silence_cancels_quality_fallback() {
+    let options = DecodeOptions::default();
+    let fallback = options.fallback.as_ref().unwrap();
+    let result = DecodeResult {
+        tokens: Vec::new(),
+        token_probs: Vec::new(),
+        text: String::new(),
+        avg_logprob: -2.0,
+        no_speech_prob: 0.9,
+        temperature: 0.0,
+        compression_ratio: 3.0,
+        language: Some("en".to_string()),
+    };
+    assert!(!crate::whisper::decode::check_fallback(&result, fallback, &options));
 }

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -1,7 +1,7 @@
 //! Forward shape + state-dict round-trip tests for Whisper model.
 
 use svod_dtype::DType;
-use svod_ir::ConstValue;
+use svod_ir::{AxisType, ConstValue, Op};
 use svod_tensor::Tensor;
 
 use crate::jit::InputSpec;
@@ -65,6 +65,70 @@ fn small_decoder_dims() -> ModelDimensions {
         n_text_head: 2,
         n_text_layer: 2,
         dtype: DType::Float32,
+    }
+}
+
+fn old_cross_kv_projection(model: &Whisper, audio: &Tensor) -> (Tensor, Tensor) {
+    let mut keys = Vec::with_capacity(model.decoder.blocks.len());
+    let mut values = Vec::with_capacity(model.decoder.blocks.len());
+    for block in &model.decoder.blocks {
+        let key = block.cross_attn.key.forward(audio).unwrap();
+        let value = block.cross_attn.value.forward(audio).unwrap();
+        keys.push(block.cross_attn.split_heads(&key).unwrap().try_permute(&[0, 2, 1, 3]).unwrap());
+        values.push(block.cross_attn.split_heads(&value).unwrap().try_permute(&[0, 2, 1, 3]).unwrap());
+    }
+    let keys = Tensor::cat(&keys.iter().collect::<Vec<_>>(), 2).unwrap().cast(DType::Float32).unwrap();
+    let values = Tensor::cat(&values.iter().collect::<Vec<_>>(), 2).unwrap().cast(DType::Float32).unwrap();
+    (keys, values)
+}
+
+#[test]
+fn packed_cross_kv_matches_per_layer_projection() {
+    let mut dims = small_decoder_dims();
+    dims.n_text_layer = 3;
+    let seed = Whisper::empty(dims.clone());
+    let model = Whisper::from_state_dict(&seed.state_dict(""), dims.clone()).unwrap();
+    let audio_values: Vec<f32> =
+        (0..2 * dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 31.0) * 0.017).collect();
+    let audio = Tensor::from_slice(audio_values).try_reshape([2usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
+
+    let (mut expected_k, mut expected_v) = old_cross_kv_projection(&model, &audio);
+    let (mut actual_k, mut actual_v) = model.project_cross_kv(&audio).unwrap();
+    Tensor::realize_batch([&mut expected_k, &mut expected_v, &mut actual_k, &mut actual_v]).unwrap();
+
+    let expected_shape = [2, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    for (expected, actual) in [(&expected_k, &actual_k), (&expected_v, &actual_v)] {
+        assert_eq!(actual.uop().dtype(), DType::Float32);
+        assert_eq!(
+            actual.shape().unwrap().iter().map(|dim| dim.as_const().unwrap()).collect::<Vec<_>>(),
+            expected_shape
+        );
+        let expected = expected.as_vec::<f32>().unwrap();
+        let actual = actual.as_vec::<f32>().unwrap();
+        let max_delta = expected.iter().zip(&actual).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+        assert!(max_delta < 1e-5, "packed cross projection drifted by {max_delta}");
+    }
+}
+
+#[test]
+fn prepared_cross_kv_has_two_single_reduction_kernels() {
+    let mut dims = small_decoder_dims();
+    dims.n_text_layer = 3;
+    let seed = Whisper::empty(dims.clone());
+    let model = Whisper::from_state_dict(&seed.state_dict(""), dims.clone()).unwrap();
+    let mut jit = WhisperCrossKvJit::new(model);
+    jit.prepare(InputSpec::f32(&[1, dims.n_audio_ctx, dims.n_text_state])).unwrap();
+
+    let kernels = jit.prepared_kernels().unwrap();
+    assert_eq!(kernels.len(), 2, "packed weights must not be materialized during inference");
+    for kernel in kernels {
+        let reductions = kernel
+            .ast
+            .toposort()
+            .into_iter()
+            .filter(|uop| matches!(uop.op(), Op::Range { axis_type: AxisType::Reduce, .. }))
+            .count();
+        assert_eq!(reductions, 1, "each packed projection must have one reduction axis");
     }
 }
 

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -1,13 +1,14 @@
 //! Forward shape + state-dict round-trip tests for Whisper model.
 
 use svod_dtype::DType;
+use svod_ir::ConstValue;
 use svod_tensor::Tensor;
 
 use crate::jit::InputSpec;
 use crate::state::HasStateDict;
 use crate::whisper::{
-    DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, ModelDimensions, Whisper, WhisperCrossKvJit,
-    WhisperDecoderJit, WhisperPlan, WhisperPrefillJit, WhisperSize,
+    DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, ModelDimensions, Whisper, WhisperAlignmentJit,
+    WhisperAlignmentModel, WhisperCrossKvJit, WhisperDecoderJit, WhisperPlan, WhisperPrefillJit, WhisperSize,
 };
 
 fn make_dims() -> ModelDimensions {
@@ -168,12 +169,122 @@ fn alignment_forward_exports_only_selected_heads() {
         .unwrap();
     let heads = &[(2, 2), (3, 0)];
 
-    let qk = model.align(&tokens, &features, heads).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&features).unwrap();
+    let qk = model.align_with_cross_kv(&tokens, &cross_k, &cross_v, heads).unwrap();
     let shape = qk.shape().unwrap();
     assert_eq!(shape[0].as_const(), Some(2));
     assert_eq!(shape[1].as_const(), Some(heads.len()));
     assert_eq!(shape[2].as_const(), Some(4));
     assert_eq!(shape[3].as_const(), Some(8));
+}
+
+fn eager_audio_feature_alignment_reference(
+    model: &Whisper,
+    tokens: &Tensor,
+    features: &Tensor,
+    alignment_heads: &[(usize, usize)],
+) -> Tensor {
+    let seq_len = tokens.shape().unwrap()[1].as_const().unwrap();
+    let tok_emb = model.decoder.token_embedding.embedding(tokens).unwrap();
+    let pos_emb = model.decoder.positional_embedding.try_shrink([Some((0isize, seq_len as isize)), None]).unwrap();
+    let mut x = tok_emb.try_add(&pos_emb).unwrap().cast(features.uop().dtype()).unwrap();
+    let mask = crate::whisper::causal_mask(seq_len, x.uop().dtype().clone()).unwrap();
+    let mut selected: Vec<Option<Tensor>> = (0..alignment_heads.len()).map(|_| None).collect();
+
+    for (layer, block) in model.decoder.blocks.iter().enumerate() {
+        let h = block.attn_ln.apply(&x).unwrap();
+        x = x.try_add(&block.attn.forward(&h, None, Some(&mask)).unwrap()).unwrap();
+
+        let h = block.cross_attn_ln.apply(&x).unwrap();
+        x = x.try_add(&block.cross_attn.forward(&h, Some(features), None).unwrap()).unwrap();
+        let q = block.cross_attn.split_heads(&block.cross_attn.query.forward(&h).unwrap()).unwrap();
+        let k = block.cross_attn.split_heads(&block.cross_attn.key.forward(features).unwrap()).unwrap();
+        for (index, &(_, head)) in alignment_heads.iter().enumerate().filter(|&(_, &(l, _))| l == layer) {
+            let q = q.try_shrink([None, Some((head as isize, head as isize + 1)), None, None]).unwrap();
+            let k = k.try_shrink([None, Some((head as isize, head as isize + 1)), None, None]).unwrap();
+            let scores = q.matmul(&k.try_transpose(-1, -2).unwrap()).unwrap();
+            let scale = Tensor::const_(
+                ConstValue::Float(1.0 / ((model.decoder.n_state / model.decoder.n_head) as f64).sqrt()),
+                scores.uop().dtype().clone(),
+            );
+            selected[index] = Some(scores.try_mul(&scale).unwrap());
+        }
+
+        let h = block.mlp_ln.apply(&x).unwrap();
+        let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().unwrap().gelu_exact().unwrap();
+        let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().unwrap();
+        x = x.try_add(&h).unwrap();
+    }
+
+    let selected: Vec<_> = selected.into_iter().map(Option::unwrap).collect();
+    Tensor::cat(&selected.iter().collect::<Vec<_>>(), 1).unwrap().cast(DType::Float32).unwrap()
+}
+
+#[test]
+fn cached_cross_alignment_matches_audio_feature_reference() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let values: Vec<f32> =
+        (0..2 * dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 17.0) * 0.013).collect();
+    let features = Tensor::from_slice(values).try_reshape([2usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
+    let tokens = Tensor::from_slice([1i32, 2, 3, 4, 4, 3, 2, 1]).try_reshape([2usize, 4]).unwrap();
+    let heads = [(1, 1), (0, 0)];
+
+    let mut reference = eager_audio_feature_alignment_reference(&model, &tokens, &features, &heads);
+    let (cross_k, cross_v) = model.project_cross_kv(&features).unwrap();
+    let mut cached = model.align_with_cross_kv(&tokens, &cross_k, &cross_v, &heads).unwrap();
+    reference.realize().unwrap();
+    cached.realize().unwrap();
+    let reference = reference.as_vec::<f32>().unwrap();
+    let cached = cached.as_vec::<f32>().unwrap();
+    let max_delta = reference.iter().zip(&cached).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    assert!(max_delta < 1e-5, "cached-cross alignment drifted by {max_delta}");
+}
+
+#[test]
+#[ignore = "heavy: prepares cross projection, prefill, and alignment graphs through the CPU backend"]
+fn recognition_cross_kv_seeds_prefill_and_alignment_device_locally() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let cache_shape = [1, dims.n_audio_ctx, dims.n_text_layer * dims.n_text_head, 4];
+    let mut config = svod_tensor::PrepareConfig::from_env();
+    config.device_local_outputs = true;
+
+    let mut cross = WhisperCrossKvJit::new(model.clone());
+    cross.prepare_with_config(InputSpec::f32(&[1, dims.n_audio_ctx, dims.n_text_state]), &config).unwrap();
+    cross.execute().unwrap();
+
+    let mut prefill = WhisperPrefillJit::new(model.clone());
+    prefill
+        .prepare(
+            InputSpec::i32(&[1, 3]),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+        )
+        .unwrap();
+    let alignment_model = WhisperAlignmentModel::new(model, vec![(0, 0), (1, 1)]);
+    let mut alignment = WhisperAlignmentJit::new(alignment_model);
+    alignment
+        .prepare(
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::f32(&cache_shape).device_local(),
+            InputSpec::i32(&[1, 3]),
+        )
+        .unwrap();
+
+    let cross_k = cross.cross_k().unwrap();
+    let cross_v = cross.cross_v().unwrap();
+    prefill.prepared_cross_k_mut().unwrap().copy_region_from(0, cross_k, 0, cross_k.size()).unwrap();
+    prefill.prepared_cross_v_mut().unwrap().copy_region_from(0, cross_v, 0, cross_v.size()).unwrap();
+    alignment.cross_k_mut().unwrap().copy_region_from(0, cross_k, 0, cross_k.size()).unwrap();
+    alignment.cross_v_mut().unwrap().copy_region_from(0, cross_v, 0, cross_v.size()).unwrap();
+    prefill.tokens_mut().unwrap().copyin(bytemuck::cast_slice(&[1i32, 2, 3])).unwrap();
+    alignment.tokens_mut().unwrap().copyin(bytemuck::cast_slice(&[1i32, 2, 3])).unwrap();
+    prefill.execute().unwrap();
+    alignment.execute().unwrap();
+
+    assert_eq!(prefill.logits().unwrap().size(), 3 * dims.n_vocab * std::mem::size_of::<f32>());
+    assert_eq!(alignment.output().unwrap().size(), 2 * 3 * dims.n_audio_ctx * std::mem::size_of::<f32>());
 }
 
 #[test]

--- a/model/src/test/unit/whisper/model.rs
+++ b/model/src/test/unit/whisper/model.rs
@@ -191,6 +191,68 @@ fn prepared_cross_kv_prefill_matches_direct_decoder() {
 }
 
 #[test]
+fn cached_steps_match_teacher_forced_full_prefix() {
+    let dims = small_decoder_dims();
+    let model = Whisper::empty(dims.clone());
+    let d_head = dims.n_text_state / dims.n_text_head;
+    let layer_heads = dims.n_text_layer * dims.n_text_head;
+    let cache_elements = dims.n_text_ctx * layer_heads * d_head;
+    let audio_values: Vec<f32> =
+        (0..dims.n_audio_ctx * dims.n_text_state).map(|index| (index as f32 - 17.0) * 0.021).collect();
+    let audio = Tensor::from_slice(audio_values).try_reshape([1usize, dims.n_audio_ctx, dims.n_text_state]).unwrap();
+    let (cross_k, cross_v) = model.project_cross_kv(&audio).unwrap();
+    let mut prefix = vec![1i32, 7, 3];
+    let prefix_tensor = Tensor::from_slice(&prefix).try_reshape([1usize, prefix.len()]).unwrap();
+    let (_, mut prefill_k, mut prefill_v) = model.decode_prefill(&prefix_tensor, &cross_k, &cross_v, 0).unwrap();
+    Tensor::realize_batch([&mut prefill_k, &mut prefill_v]).unwrap();
+
+    let mut cache_k = vec![0.0f32; cache_elements];
+    let mut cache_v = vec![0.0f32; cache_elements];
+    let prefill_elements = prefix.len() * layer_heads * d_head;
+    cache_k[..prefill_elements].copy_from_slice(&prefill_k.as_vec::<f32>().unwrap());
+    cache_v[..prefill_elements].copy_from_slice(&prefill_v.as_vec::<f32>().unwrap());
+    assert_eq!(cache_k.len() * std::mem::size_of::<f32>(), dims.n_text_ctx * layer_heads * d_head * 4);
+    assert_eq!(cross_k.uop().dtype(), DType::Float32);
+    assert_eq!(prefill_k.uop().dtype(), DType::Float32);
+
+    for next_token in [5i32, 11] {
+        let pos = prefix.len();
+        let token = Tensor::from_slice([next_token]).try_reshape([1usize, 1]).unwrap();
+        let pos_emb = model
+            .decoder
+            .positional_embedding
+            .try_shrink([Some((pos as isize, pos as isize + 1)), None])
+            .unwrap()
+            .try_unsqueeze(0)
+            .unwrap();
+        let self_k = Tensor::from_slice(&cache_k).try_reshape([1usize, dims.n_text_ctx, layer_heads, d_head]).unwrap();
+        let self_v = Tensor::from_slice(&cache_v).try_reshape([1usize, dims.n_text_ctx, layer_heads, d_head]).unwrap();
+        let mut mask_values = vec![0.0f32; dims.n_text_ctx + 1];
+        mask_values[pos..dims.n_text_ctx].fill(f32::NEG_INFINITY);
+        let mask = Tensor::from_slice(&mask_values).try_reshape([1usize, 1, 1, dims.n_text_ctx + 1]).unwrap();
+        assert_eq!(mask_values.len() * std::mem::size_of::<f32>(), (dims.n_text_ctx + 1) * 4);
+
+        let (mut step_logits, mut new_k, mut new_v) =
+            model.decode_step(&token, &pos_emb, &self_k, &self_v, &cross_k, &cross_v, &mask).unwrap();
+        prefix.push(next_token);
+        let full_tokens = Tensor::from_slice(&prefix).try_reshape([1usize, prefix.len()]).unwrap();
+        let mut teacher = model.decode_with_cross_kv(&full_tokens, &cross_k, &cross_v).unwrap();
+        Tensor::realize_batch([&mut step_logits, &mut new_k, &mut new_v, &mut teacher]).unwrap();
+
+        let step = step_logits.as_vec::<f32>().unwrap();
+        let teacher = teacher.as_vec::<f32>().unwrap();
+        let teacher_last = &teacher[(prefix.len() - 1) * dims.n_vocab..prefix.len() * dims.n_vocab];
+        let max_delta = step.iter().zip(teacher_last).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+        assert!(max_delta < 1e-5, "cached step at position {pos} drifted from teacher forcing by {max_delta}");
+
+        let cache_offset = pos * layer_heads * d_head;
+        let cache_end = cache_offset + layer_heads * d_head;
+        cache_k[cache_offset..cache_end].copy_from_slice(&new_k.as_vec::<f32>().unwrap());
+        cache_v[cache_offset..cache_end].copy_from_slice(&new_v.as_vec::<f32>().unwrap());
+    }
+}
+
+#[test]
 fn one_token_language_logits_match_full_context_sot_logits() {
     let dims = small_decoder_dims();
     let model = Whisper::empty(dims.clone());

--- a/model/src/test/unit/whisper/parity.rs
+++ b/model/src/test/unit/whisper/parity.rs
@@ -49,7 +49,8 @@ fn encoder_output_matches_pytorch() {
     let weights = resolve_file("model.safetensors");
     let golden_path = resolve_file("golden.safetensors");
 
-    let dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    let mut dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    dims.dtype = DType::Float32;
     let sd = state::load_safetensors(&weights).expect("load weights");
     // Strip "model." prefix if present (HF safetensors)
     let sd: StateDict = sd
@@ -88,7 +89,8 @@ fn decoder_logits_match_pytorch() {
     let weights = resolve_file("model.safetensors");
     let golden_path = resolve_file("golden.safetensors");
 
-    let dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    let mut dims = ModelDimensions::for_size(WhisperSize::Tiny);
+    dims.dtype = DType::Float32;
     let sd = state::load_safetensors(&weights).expect("load weights");
     let sd: StateDict = sd
         .iter()

--- a/model/src/test/unit/whisper/segments.rs
+++ b/model/src/test/unit/whisper/segments.rs
@@ -1,0 +1,61 @@
+use crate::whisper::{WhisperTokenizer, split_into_segments};
+
+fn tokenizer() -> WhisperTokenizer {
+    WhisperTokenizer::from_hub(true, 99).unwrap()
+}
+
+#[test]
+fn unfinished_timestamp_tail_is_not_emitted() {
+    let tokenizer = tokenizer();
+    let timestamp = tokenizer.timestamp_begin();
+    let mut tokens = vec![timestamp];
+    tokens.extend(tokenizer.encode(" hello"));
+    tokens.extend([timestamp + 50, timestamp + 50]);
+    tokens.extend(tokenizer.encode(" unfinished"));
+
+    let segments = split_into_segments(&tokens, &tokenizer, 30.0);
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].text, "hello");
+    assert_eq!(segments[0].start, 0.0);
+    assert_eq!(segments[0].end, 1.0);
+}
+
+#[test]
+fn segment_without_timestamps_spans_real_window() {
+    let tokenizer = tokenizer();
+    let tokens = tokenizer.encode(" hello");
+    let segments = split_into_segments(&tokens, &tokenizer, 2.5);
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].start, 0.0);
+    assert_eq!(segments[0].end, 2.5);
+}
+
+#[test]
+fn last_timestamp_limits_unpaired_segment() {
+    let tokenizer = tokenizer();
+    let timestamp = tokenizer.timestamp_begin();
+    let mut tokens = vec![timestamp];
+    tokens.extend(tokenizer.encode(" hello"));
+    tokens.push(timestamp + 75);
+    tokens.extend(tokenizer.encode(" tail"));
+
+    let segments = split_into_segments(&tokens, &tokenizer, 4.0);
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].end, 1.5);
+}
+
+#[test]
+fn timestamp_segments_are_clipped_to_real_audio_extent() {
+    let tokenizer = tokenizer();
+    let timestamp = tokenizer.timestamp_begin();
+    let mut tokens = vec![timestamp + 50];
+    tokens.extend(tokenizer.encode(" hello"));
+    tokens.extend([timestamp + 500, timestamp + 500]);
+    tokens.extend(tokenizer.encode(" beyond"));
+    tokens.push(timestamp + 600);
+
+    let segments = split_into_segments(&tokens, &tokenizer, 2.5);
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].start, 1.0);
+    assert_eq!(segments[0].end, 2.5);
+}

--- a/model/src/test/unit/whisper/tokenizer.rs
+++ b/model/src/test/unit/whisper/tokenizer.rs
@@ -1,4 +1,14 @@
+use svod_arch::pipelines::audio::words_to_text;
+
 use crate::whisper::WhisperTokenizer;
+use crate::whisper::aligner::words_from_path;
+
+fn aligned_words(text: &str, language: &str) -> Vec<svod_arch::rnnt::Word> {
+    let tokenizer = WhisperTokenizer::from_hub(true, 99).unwrap();
+    let tokens = tokenizer.encode(text);
+    let path: Vec<_> = (0..=tokens.len()).collect();
+    words_from_path(&path, &path, &tokens, &vec![1.0; tokens.len()], Some(language), &tokenizer)
+}
 
 #[test]
 fn word_split_preserves_text_and_tokens() {
@@ -40,4 +50,33 @@ fn punctuation_is_kept_separate_for_timing_attachment() {
     let tokens = tokenizer.encode(" hello!");
     let (words, _) = tokenizer.split_to_word_tokens_for_language(&tokens, Some("en"));
     assert_eq!(words, [" hello", "!"]);
+}
+
+#[test]
+fn aligned_fragments_preserve_tokenizer_spacing() {
+    for (text, language, expected) in [
+        (" 23-м доме", "ru", "23-м доме"),
+        (" когда-то", "ru", "когда-то"),
+        (" температура -5", "ru", "температура -5"),
+        (" Hello, world!", "en", "Hello, world!"),
+        ("你好！", "zh", "你好！"),
+    ] {
+        let words = aligned_words(text, language);
+        assert_eq!(words_to_text(&words), expected, "failed to render {text:?}");
+        assert_eq!(words.iter().map(|word| word.text.as_str()).collect::<String>().trim(), expected);
+    }
+}
+
+#[test]
+fn aligned_hyphen_suffix_keeps_join_left_fragment() {
+    let words = aligned_words(" 23-м доме", "ru");
+    assert_eq!(words.iter().map(|word| word.text.as_str()).collect::<Vec<_>>(), [" 23", "-м", " доме"]);
+}
+
+#[test]
+fn aligned_fragments_drop_blanks_and_trim_only_outer_boundary() {
+    assert!(aligned_words("   ", "en").is_empty());
+    let words = aligned_words("  hello  world  ", "en");
+    assert_eq!(words_to_text(&words), "hello  world");
+    assert!(words.first().unwrap().text.starts_with(' '));
 }

--- a/model/src/test/unit/whisper/tokenizer.rs
+++ b/model/src/test/unit/whisper/tokenizer.rs
@@ -1,0 +1,43 @@
+use crate::whisper::WhisperTokenizer;
+
+#[test]
+fn word_split_preserves_text_and_tokens() {
+    let tokenizer = WhisperTokenizer::from_hub(true, 99).unwrap();
+    let tokens = tokenizer.encode(" hello world!");
+    let (words, word_tokens) = tokenizer.split_to_word_tokens_for_language(&tokens, Some("en"));
+    assert_eq!(words.concat(), " hello world!");
+    assert_eq!(word_tokens.concat(), tokens);
+    assert_eq!(words, [" hello", " world", "!"]);
+}
+
+#[test]
+fn no_space_languages_split_on_unicode_boundaries() {
+    let tokenizer = WhisperTokenizer::from_hub(true, 99).unwrap();
+    let tokens = tokenizer.encode("你好世界");
+    let (words, word_tokens) = tokenizer.split_to_word_tokens_for_language(&tokens, Some("zh"));
+    assert_eq!(words.concat(), "你好世界");
+    assert_eq!(word_tokens.concat(), tokens);
+    assert!(words.len() > 1);
+}
+
+#[test]
+fn timestamps_are_word_boundaries() {
+    let tokenizer = WhisperTokenizer::from_hub(true, 99).unwrap();
+    let timestamp = tokenizer.timestamp_begin();
+    let mut tokens = tokenizer.encode(" hello");
+    tokens.push(timestamp + 10);
+    tokens.extend(tokenizer.encode("world"));
+
+    let (words, word_tokens) = tokenizer.split_to_word_tokens_for_language(&tokens, Some("en"));
+    assert_eq!(word_tokens.concat(), tokens);
+    assert_eq!(word_tokens[1], [timestamp + 10]);
+    assert_eq!(words[2], "world");
+}
+
+#[test]
+fn punctuation_is_kept_separate_for_timing_attachment() {
+    let tokenizer = WhisperTokenizer::from_hub(true, 99).unwrap();
+    let tokens = tokenizer.encode(" hello!");
+    let (words, _) = tokenizer.split_to_word_tokens_for_language(&tokens, Some("en"));
+    assert_eq!(words, [" hello", "!"]);
+}

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -147,7 +147,7 @@ impl WhisperAligner {
     }
 }
 
-fn words_from_path(
+pub(crate) fn words_from_path(
     text_indices: &[usize],
     time_indices: &[usize],
     text_tokens: &[u32],
@@ -173,7 +173,7 @@ fn words_from_path(
     timings
         .into_iter()
         .filter(|word| !word.word.trim().is_empty())
-        .map(|word| Word { text: word.word.trim().to_string(), start: word.start, end: word.end })
+        .map(|word| Word { text: word.word, start: word.start, end: word.end })
         .collect()
 }
 

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -11,7 +11,7 @@ use super::dtw::{find_alignment_path_selected, path_to_word_timings};
 use super::error::{DeviceSnafu, JitSnafu, Result};
 use super::jit::{WhisperAlignmentJit, WhisperAlignmentModel};
 use super::model::Whisper;
-use super::profile::{CopyProfile, begin_host_copy, timed_d2d};
+use super::profile::{CopyProfile, GraphProfile, begin_host_copy, timed_d2d};
 use super::tokenizer::WhisperTokenizer;
 use super::transcribe::Word;
 
@@ -42,10 +42,17 @@ pub struct WhisperAlignmentInput<'a> {
     pub audio_samples: usize,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct AlignmentProfile {
-    pub(crate) graph_wall: Duration,
+    pub(crate) graph: GraphProfile,
     pub(crate) cpu_dtw_wall: Duration,
+}
+
+impl AlignmentProfile {
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.graph.merge(other.graph);
+        self.cpu_dtw_wall = self.cpu_dtw_wall.saturating_add(other.cpu_dtw_wall);
+    }
 }
 
 impl WhisperAligner {
@@ -163,13 +170,17 @@ impl WhisperAligner {
         if let (Some(copies), Some(started)) = (copies.as_deref_mut(), token_started) {
             copies.h2d("alignment_tokens", 1, packed_tokens.len() * std::mem::size_of::<i32>(), started.elapsed());
         }
-        let graph_started = Instant::now();
-        self.jit.execute().context(JitSnafu)?;
+        let profiling = copies.is_some();
+        let (graph_wall, kernels) = if profiling {
+            let graph_started = Instant::now();
+            let kernels = self.jit.execute_profiled().context(JitSnafu)?;
+            self.jit.output().context(JitSnafu)?.synchronize().context(DeviceSnafu)?;
+            (graph_started.elapsed(), kernels)
+        } else {
+            self.jit.execute().context(JitSnafu)?;
+            (Duration::ZERO, Vec::new())
+        };
         let output = self.jit.output().context(JitSnafu)?;
-        if copies.is_some() {
-            output.synchronize().context(DeviceSnafu)?;
-        }
-        let graph_wall = graph_started.elapsed();
         let output_started = begin_host_copy(copies.is_some(), output)?;
         let output_bytes = output.as_host_bytes().context(DeviceSnafu)?;
         let qk_stride = self.n_heads * N_TEXT_CTX * N_AUDIO_CTX;
@@ -201,7 +212,11 @@ impl WhisperAligner {
                 words_from_path(&text_indices, &time_indices, &text_tokens, &token_probs, input.language, tokenizer)
             })
             .collect();
-        Ok((words, AlignmentProfile { graph_wall, cpu_dtw_wall: cpu_started.elapsed() }))
+        let mut graph = GraphProfile::default();
+        if profiling {
+            graph.record(graph_wall, kernels);
+        }
+        Ok((words, AlignmentProfile { graph, cpu_dtw_wall: cpu_started.elapsed() }))
     }
 }
 

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -1,0 +1,223 @@
+//! Fixed-shape teacher-forced decoder alignment and host-side DTW.
+
+use snafu::ResultExt;
+
+use crate::jit::InputSpec;
+
+use super::config::{HOP_LENGTH, N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, TOKENS_PER_SECOND, WhisperSize};
+use super::decode::WhisperTask;
+use super::dtw::{find_alignment_path_selected, path_to_word_timings};
+use super::error::{DeviceSnafu, JitSnafu, Result};
+use super::jit::{WhisperAlignmentJit, WhisperAlignmentModel};
+use super::model::Whisper;
+use super::tokenizer::WhisperTokenizer;
+use super::transcribe::Word;
+
+/// Prepared alignment stage. Its graph is fully static and is replayed once
+/// for each finalized recognition result.
+pub struct WhisperAligner {
+    jit: WhisperAlignmentJit,
+    n_heads: usize,
+    batch_size: usize,
+    audio_stride: usize,
+}
+
+/// Host-owned inputs for one lane of a prepared alignment batch.
+pub struct WhisperAlignmentInput<'a> {
+    /// Encoder output in `[N_AUDIO_CTX, n_audio_state]` layout.
+    pub audio_features: &'a [f32],
+    /// Recognition tokens, including timestamp tokens when emitted.
+    pub decoded_tokens: &'a [u32],
+    /// Decoder probability corresponding to each decoded token.
+    pub token_probs: &'a [f32],
+    /// Resolved language code used to reconstruct the decoder prompt.
+    pub language: Option<&'a str>,
+    /// Decoder task used to reconstruct the prompt.
+    pub task: WhisperTask,
+    /// Unpadded source-audio length in samples.
+    pub audio_samples: usize,
+}
+
+impl WhisperAligner {
+    pub fn new(model: Whisper, size: WhisperSize, batch_size: usize) -> Result<Self> {
+        if batch_size == 0 {
+            return Err(super::error::Error::Decode { msg: "alignment batch must be non-zero".to_string() });
+        }
+        let heads = size.alignment_heads().to_vec();
+        let n_state = model.dims.n_text_state;
+        let alignment_model = WhisperAlignmentModel::new(model, heads.clone());
+        let mut jit = WhisperAlignmentJit::new(alignment_model);
+        jit.prepare(InputSpec::f32(&[batch_size, N_AUDIO_CTX, n_state]), InputSpec::i32(&[batch_size, N_TEXT_CTX]))
+            .context(JitSnafu)?;
+        Ok(Self { jit, n_heads: heads.len(), batch_size, audio_stride: N_AUDIO_CTX * n_state })
+    }
+
+    /// Align up to the concrete batch capacity prepared at construction.
+    pub fn align_batch(
+        &mut self,
+        inputs: &[WhisperAlignmentInput<'_>],
+        tokenizer: &WhisperTokenizer,
+    ) -> Result<Vec<Vec<Word>>> {
+        if inputs.len() > self.batch_size {
+            return Err(super::error::Error::Decode {
+                msg: format!("alignment input {} exceeds prepared batch {}", inputs.len(), self.batch_size),
+            });
+        }
+        if inputs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let audio_stride = self.audio_stride;
+        let mut packed_audio = vec![0.0f32; self.batch_size * audio_stride];
+        let mut packed_tokens = vec![tokenizer.eot() as i32; self.batch_size * N_TEXT_CTX];
+        let mut metadata = Vec::with_capacity(inputs.len());
+        for (lane, input) in inputs.iter().enumerate() {
+            packed_audio[lane * audio_stride..lane * audio_stride + input.audio_features.len()]
+                .copy_from_slice(input.audio_features);
+
+            let mut text_tokens: Vec<u32> =
+                input.decoded_tokens.iter().copied().filter(|&token| token < tokenizer.eot()).collect();
+            let mut token_probs = input.token_probs[..input.token_probs.len().min(text_tokens.len())].to_vec();
+            let mut tokens = vec![tokenizer.sot()];
+            if tokenizer.multilingual {
+                let language = input.language.unwrap_or("en");
+                tokens.push(tokenizer.language_token_for(language).unwrap_or_else(|| tokenizer.sot()));
+                tokens.push(match input.task {
+                    WhisperTask::Transcribe => tokenizer.transcribe(),
+                    WhisperTask::Translate => tokenizer.translate(),
+                });
+            }
+            let sot_len = tokens.len();
+            text_tokens.truncate(N_TEXT_CTX - sot_len - 2);
+            token_probs.truncate(text_tokens.len());
+            tokens.push(tokenizer.no_timestamps());
+            tokens.extend_from_slice(&text_tokens);
+            tokens.push(tokenizer.eot());
+            let valid_text = tokens.len();
+            for (index, token) in tokens.into_iter().enumerate() {
+                packed_tokens[lane * N_TEXT_CTX + index] = token as i32;
+            }
+            metadata.push((text_tokens, token_probs, valid_text, sot_len));
+        }
+
+        self.jit
+            .audio_features_mut()
+            .context(JitSnafu)?
+            .as_host_bytes_mut()
+            .context(DeviceSnafu)?
+            .copy_from_slice(bytemuck::cast_slice(&packed_audio));
+        self.jit
+            .tokens_mut()
+            .context(JitSnafu)?
+            .as_host_bytes_mut()
+            .context(DeviceSnafu)?
+            .copy_from_slice(bytemuck::cast_slice(&packed_tokens));
+        self.jit.execute().context(JitSnafu)?;
+        let output = self.jit.output().context(JitSnafu)?;
+        let qk: &[f32] = bytemuck::cast_slice(output.as_host_bytes().context(DeviceSnafu)?);
+        let qk_stride = self.n_heads * N_TEXT_CTX * N_AUDIO_CTX;
+
+        Ok(inputs
+            .iter()
+            .zip(metadata)
+            .enumerate()
+            .map(|(lane, (input, (text_tokens, token_probs, valid_text, sot_len)))| {
+                let lane_qk = &qk[lane * qk_stride..(lane + 1) * qk_stride];
+                let valid_audio = (input.audio_samples / HOP_LENGTH).min(N_FRAMES) / 2;
+                let (text_indices, time_indices) = find_alignment_path_selected(
+                    lane_qk,
+                    self.n_heads,
+                    N_TEXT_CTX,
+                    N_AUDIO_CTX,
+                    valid_text,
+                    valid_audio,
+                    7,
+                    sot_len,
+                );
+                words_from_path(&text_indices, &time_indices, &text_tokens, &token_probs, input.language, tokenizer)
+            })
+            .collect())
+    }
+}
+
+fn words_from_path(
+    text_indices: &[usize],
+    time_indices: &[usize],
+    text_tokens: &[u32],
+    token_probs: &[f32],
+    language: Option<&str>,
+    tokenizer: &WhisperTokenizer,
+) -> Vec<Word> {
+    let (word_strings, word_token_lists) = tokenizer.split_to_word_tokens_for_language(text_tokens, language);
+    let mut word_boundaries = vec![0usize];
+    for tokens in &word_token_lists {
+        word_boundaries.push(word_boundaries.last().copied().unwrap() + tokens.len());
+    }
+    let mut timings = path_to_word_timings(
+        text_indices,
+        time_indices,
+        &word_boundaries,
+        &word_strings,
+        &word_token_lists,
+        token_probs,
+        TOKENS_PER_SECOND,
+    );
+    refine_word_timings(&mut timings);
+    timings
+        .into_iter()
+        .filter(|word| !word.word.trim().is_empty())
+        .map(|word| Word { text: word.word.trim().to_string(), start: word.start, end: word.end })
+        .collect()
+}
+
+fn refine_word_timings(words: &mut [super::dtw::WordTiming]) {
+    let mut durations: Vec<f32> =
+        words.iter().map(|word| word.end - word.start).filter(|&duration| duration > 0.0).collect();
+    durations.sort_by(|a, b| a.total_cmp(b));
+    let median = match durations.len() {
+        0 => 0.0,
+        len if len % 2 == 0 => (durations[len / 2 - 1] + durations[len / 2]) / 2.0,
+        len => durations[len / 2],
+    }
+    .min(0.7);
+    let max_duration = median * 2.0;
+    if max_duration > 0.0 {
+        const SENTENCE_END: &str = ".。!！?？";
+        for index in 1..words.len() {
+            if words[index].end - words[index].start > max_duration {
+                if SENTENCE_END.contains(words[index].word.as_str()) {
+                    words[index].end = words[index].start + max_duration;
+                } else if SENTENCE_END.contains(words[index - 1].word.as_str()) {
+                    words[index].start = words[index].end - max_duration;
+                }
+            }
+        }
+    }
+
+    const PREPEND: &str = "\"'“¿([{-";
+    const APPEND: &str = "\"'.。,，!！?？:：”)]}、";
+    let mut following = words.len().saturating_sub(1);
+    for previous in (0..words.len().saturating_sub(1)).rev() {
+        if words[previous].word.starts_with(' ') && PREPEND.contains(words[previous].word.trim()) {
+            let prefix = std::mem::take(&mut words[previous].word);
+            words[following].word.insert_str(0, &prefix);
+            let mut tokens = std::mem::take(&mut words[previous].tokens);
+            tokens.append(&mut words[following].tokens);
+            words[following].tokens = tokens;
+        } else {
+            following = previous;
+        }
+    }
+
+    let mut previous = 0;
+    for following in 1..words.len() {
+        if !words[previous].word.ends_with(' ') && APPEND.contains(words[following].word.as_str()) {
+            let suffix = std::mem::take(&mut words[following].word);
+            words[previous].word.push_str(&suffix);
+            let tokens = std::mem::take(&mut words[following].tokens);
+            words[previous].tokens.extend(tokens);
+        } else {
+            previous = following;
+        }
+    }
+}

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -22,7 +22,6 @@ pub struct WhisperAligner {
     n_heads: usize,
     batch_size: usize,
     cache_stride: usize,
-    cache_dtype: svod_dtype::DType,
 }
 
 /// Inputs for one lane of a prepared alignment batch.
@@ -65,19 +64,11 @@ impl WhisperAligner {
         let n_state = model.dims.n_text_state;
         let n_layer_heads = model.dims.n_text_layer * model.dims.n_text_head;
         let d_head = n_state / model.dims.n_text_head;
-        let cache_dtype = model.cross_cache_output_dtype()?;
         let alignment_model = WhisperAlignmentModel::new(model, heads.clone());
         let mut jit = WhisperAlignmentJit::new(alignment_model);
-        let cache_spec =
-            InputSpec::new(&[batch_size, N_AUDIO_CTX, n_layer_heads, d_head], cache_dtype.clone()).device_local();
+        let cache_spec = InputSpec::f32(&[batch_size, N_AUDIO_CTX, n_layer_heads, d_head]).device_local();
         jit.prepare(cache_spec.clone(), cache_spec, InputSpec::i32(&[batch_size, N_TEXT_CTX])).context(JitSnafu)?;
-        Ok(Self {
-            jit,
-            n_heads: heads.len(),
-            batch_size,
-            cache_stride: N_AUDIO_CTX * n_layer_heads * d_head,
-            cache_dtype,
-        })
+        Ok(Self { jit, n_heads: heads.len(), batch_size, cache_stride: N_AUDIO_CTX * n_layer_heads * d_head })
     }
 
     /// Align up to the concrete batch capacity prepared at construction.
@@ -104,12 +95,12 @@ impl WhisperAligner {
             return Ok((Vec::new(), AlignmentProfile::default()));
         }
 
-        let cache_bytes = self.cache_stride * self.cache_dtype.bytes();
+        let cache_bytes = self.cache_stride * std::mem::size_of::<f32>();
         let (_, packing_wall) = timed_d2d(copies.is_some(), inputs[0].cross_k, || {
             {
                 let packed_k = self.jit.cross_k_mut().context(JitSnafu)?;
                 for (lane, input) in inputs.iter().enumerate() {
-                    if input.cross_k.dtype() != self.cache_dtype
+                    if input.cross_k.dtype() != svod_dtype::DType::Float32
                         || input.cross_k.size() != cache_bytes
                         || !std::ptr::eq(packed_k.allocator(), input.cross_k.allocator())
                     {
@@ -125,7 +116,7 @@ impl WhisperAligner {
             {
                 let packed_v = self.jit.cross_v_mut().context(JitSnafu)?;
                 for (lane, input) in inputs.iter().enumerate() {
-                    if input.cross_v.dtype() != self.cache_dtype
+                    if input.cross_v.dtype() != svod_dtype::DType::Float32
                         || input.cross_v.size() != cache_bytes
                         || !std::ptr::eq(packed_v.allocator(), input.cross_v.allocator())
                         || !std::ptr::eq(input.cross_k.allocator(), input.cross_v.allocator())

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -22,6 +22,7 @@ pub struct WhisperAligner {
     n_heads: usize,
     batch_size: usize,
     cache_stride: usize,
+    cache_dtype: svod_dtype::DType,
 }
 
 /// Inputs for one lane of a prepared alignment batch.
@@ -64,11 +65,19 @@ impl WhisperAligner {
         let n_state = model.dims.n_text_state;
         let n_layer_heads = model.dims.n_text_layer * model.dims.n_text_head;
         let d_head = n_state / model.dims.n_text_head;
+        let cache_dtype = model.cross_cache_output_dtype()?;
         let alignment_model = WhisperAlignmentModel::new(model, heads.clone());
         let mut jit = WhisperAlignmentJit::new(alignment_model);
-        let cache_spec = InputSpec::f32(&[batch_size, N_AUDIO_CTX, n_layer_heads, d_head]).device_local();
+        let cache_spec =
+            InputSpec::new(&[batch_size, N_AUDIO_CTX, n_layer_heads, d_head], cache_dtype.clone()).device_local();
         jit.prepare(cache_spec.clone(), cache_spec, InputSpec::i32(&[batch_size, N_TEXT_CTX])).context(JitSnafu)?;
-        Ok(Self { jit, n_heads: heads.len(), batch_size, cache_stride: N_AUDIO_CTX * n_layer_heads * d_head })
+        Ok(Self {
+            jit,
+            n_heads: heads.len(),
+            batch_size,
+            cache_stride: N_AUDIO_CTX * n_layer_heads * d_head,
+            cache_dtype,
+        })
     }
 
     /// Align up to the concrete batch capacity prepared at construction.
@@ -95,12 +104,12 @@ impl WhisperAligner {
             return Ok((Vec::new(), AlignmentProfile::default()));
         }
 
-        let cache_bytes = self.cache_stride * std::mem::size_of::<f32>();
+        let cache_bytes = self.cache_stride * self.cache_dtype.bytes();
         let (_, packing_wall) = timed_d2d(copies.is_some(), inputs[0].cross_k, || {
             {
                 let packed_k = self.jit.cross_k_mut().context(JitSnafu)?;
                 for (lane, input) in inputs.iter().enumerate() {
-                    if input.cross_k.dtype() != svod_dtype::DType::Float32
+                    if input.cross_k.dtype() != self.cache_dtype
                         || input.cross_k.size() != cache_bytes
                         || !std::ptr::eq(packed_k.allocator(), input.cross_k.allocator())
                     {
@@ -116,7 +125,7 @@ impl WhisperAligner {
             {
                 let packed_v = self.jit.cross_v_mut().context(JitSnafu)?;
                 for (lane, input) in inputs.iter().enumerate() {
-                    if input.cross_v.dtype() != svod_dtype::DType::Float32
+                    if input.cross_v.dtype() != self.cache_dtype
                         || input.cross_v.size() != cache_bytes
                         || !std::ptr::eq(packed_v.allocator(), input.cross_v.allocator())
                         || !std::ptr::eq(input.cross_k.allocator(), input.cross_v.allocator())

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -19,13 +19,15 @@ pub struct WhisperAligner {
     jit: WhisperAlignmentJit,
     n_heads: usize,
     batch_size: usize,
-    audio_stride: usize,
+    cache_stride: usize,
 }
 
 /// Inputs for one lane of a prepared alignment batch.
 pub struct WhisperAlignmentInput<'a> {
-    /// Device-resident encoder output in `[N_AUDIO_CTX, n_audio_state]` layout.
-    pub audio_features: &'a svod_device::Buffer,
+    /// Device-resident packed cross-attention K cache for one recognition window.
+    pub cross_k: &'a svod_device::Buffer,
+    /// Device-resident packed cross-attention V cache for one recognition window.
+    pub cross_v: &'a svod_device::Buffer,
     /// Recognition tokens, including timestamp tokens when emitted.
     pub decoded_tokens: &'a [u32],
     /// Decoder probability corresponding to each decoded token.
@@ -45,11 +47,13 @@ impl WhisperAligner {
         }
         let heads = size.alignment_heads().to_vec();
         let n_state = model.dims.n_text_state;
+        let n_layer_heads = model.dims.n_text_layer * model.dims.n_text_head;
+        let d_head = n_state / model.dims.n_text_head;
         let alignment_model = WhisperAlignmentModel::new(model, heads.clone());
         let mut jit = WhisperAlignmentJit::new(alignment_model);
-        jit.prepare(InputSpec::f32(&[batch_size, N_AUDIO_CTX, n_state]), InputSpec::i32(&[batch_size, N_TEXT_CTX]))
-            .context(JitSnafu)?;
-        Ok(Self { jit, n_heads: heads.len(), batch_size, audio_stride: N_AUDIO_CTX * n_state })
+        let cache_spec = InputSpec::f32(&[batch_size, N_AUDIO_CTX, n_layer_heads, d_head]).device_local();
+        jit.prepare(cache_spec.clone(), cache_spec, InputSpec::i32(&[batch_size, N_TEXT_CTX])).context(JitSnafu)?;
+        Ok(Self { jit, n_heads: heads.len(), batch_size, cache_stride: N_AUDIO_CTX * n_layer_heads * d_head })
     }
 
     /// Align up to the concrete batch capacity prepared at construction.
@@ -67,21 +71,34 @@ impl WhisperAligner {
             return Ok(Vec::new());
         }
 
-        let audio_stride = self.audio_stride;
-        let audio_bytes = audio_stride * std::mem::size_of::<f32>();
+        let cache_bytes = self.cache_stride * std::mem::size_of::<f32>();
         {
-            let packed_audio = self.jit.audio_features_mut().context(JitSnafu)?;
+            let packed_k = self.jit.cross_k_mut().context(JitSnafu)?;
             for (lane, input) in inputs.iter().enumerate() {
-                if input.audio_features.dtype() != svod_dtype::DType::Float32
-                    || input.audio_features.size() != audio_bytes
+                if input.cross_k.dtype() != svod_dtype::DType::Float32
+                    || input.cross_k.size() != cache_bytes
+                    || !std::ptr::eq(packed_k.allocator(), input.cross_k.allocator())
                 {
                     return Err(super::error::Error::Decode {
-                        msg: "alignment encoder features have invalid dtype or size".to_string(),
+                        msg: "alignment cross K has invalid dtype, size, or allocator".to_string(),
                     });
                 }
-                packed_audio
-                    .copy_region_from(lane * audio_bytes, input.audio_features, 0, audio_bytes)
-                    .context(DeviceSnafu)?;
+                packed_k.copy_region_from(lane * cache_bytes, input.cross_k, 0, cache_bytes).context(DeviceSnafu)?;
+            }
+        }
+        {
+            let packed_v = self.jit.cross_v_mut().context(JitSnafu)?;
+            for (lane, input) in inputs.iter().enumerate() {
+                if input.cross_v.dtype() != svod_dtype::DType::Float32
+                    || input.cross_v.size() != cache_bytes
+                    || !std::ptr::eq(packed_v.allocator(), input.cross_v.allocator())
+                    || !std::ptr::eq(input.cross_k.allocator(), input.cross_v.allocator())
+                {
+                    return Err(super::error::Error::Decode {
+                        msg: "alignment cross V has invalid dtype, size, or allocator".to_string(),
+                    });
+                }
+                packed_v.copy_region_from(lane * cache_bytes, input.cross_v, 0, cache_bytes).context(DeviceSnafu)?;
             }
         }
 

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -1,6 +1,7 @@
 //! Fixed-shape teacher-forced decoder alignment and host-side DTW.
 
 use snafu::ResultExt;
+use std::time::{Duration, Instant};
 
 use crate::jit::InputSpec;
 
@@ -10,6 +11,7 @@ use super::dtw::{find_alignment_path_selected, path_to_word_timings};
 use super::error::{DeviceSnafu, JitSnafu, Result};
 use super::jit::{WhisperAlignmentJit, WhisperAlignmentModel};
 use super::model::Whisper;
+use super::profile::{CopyProfile, begin_host_copy, timed_d2d};
 use super::tokenizer::WhisperTokenizer;
 use super::transcribe::Word;
 
@@ -40,6 +42,12 @@ pub struct WhisperAlignmentInput<'a> {
     pub audio_samples: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct AlignmentProfile {
+    pub(crate) graph_wall: Duration,
+    pub(crate) cpu_dtw_wall: Duration,
+}
+
 impl WhisperAligner {
     pub fn new(model: Whisper, size: WhisperSize, batch_size: usize) -> Result<Self> {
         if batch_size == 0 {
@@ -62,44 +70,63 @@ impl WhisperAligner {
         inputs: &[WhisperAlignmentInput<'_>],
         tokenizer: &WhisperTokenizer,
     ) -> Result<Vec<Vec<Word>>> {
+        self.align_batch_profiled(inputs, tokenizer, None).map(|(words, _)| words)
+    }
+
+    pub(crate) fn align_batch_profiled(
+        &mut self,
+        inputs: &[WhisperAlignmentInput<'_>],
+        tokenizer: &WhisperTokenizer,
+        mut copies: Option<&mut CopyProfile>,
+    ) -> Result<(Vec<Vec<Word>>, AlignmentProfile)> {
         if inputs.len() > self.batch_size {
             return Err(super::error::Error::Decode {
                 msg: format!("alignment input {} exceeds prepared batch {}", inputs.len(), self.batch_size),
             });
         }
         if inputs.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), AlignmentProfile::default()));
         }
 
         let cache_bytes = self.cache_stride * std::mem::size_of::<f32>();
-        {
-            let packed_k = self.jit.cross_k_mut().context(JitSnafu)?;
-            for (lane, input) in inputs.iter().enumerate() {
-                if input.cross_k.dtype() != svod_dtype::DType::Float32
-                    || input.cross_k.size() != cache_bytes
-                    || !std::ptr::eq(packed_k.allocator(), input.cross_k.allocator())
-                {
-                    return Err(super::error::Error::Decode {
-                        msg: "alignment cross K has invalid dtype, size, or allocator".to_string(),
-                    });
+        let (_, packing_wall) = timed_d2d(copies.is_some(), inputs[0].cross_k, || {
+            {
+                let packed_k = self.jit.cross_k_mut().context(JitSnafu)?;
+                for (lane, input) in inputs.iter().enumerate() {
+                    if input.cross_k.dtype() != svod_dtype::DType::Float32
+                        || input.cross_k.size() != cache_bytes
+                        || !std::ptr::eq(packed_k.allocator(), input.cross_k.allocator())
+                    {
+                        return Err(super::error::Error::Decode {
+                            msg: "alignment cross K has invalid dtype, size, or allocator".to_string(),
+                        });
+                    }
+                    packed_k
+                        .copy_region_from(lane * cache_bytes, input.cross_k, 0, cache_bytes)
+                        .context(DeviceSnafu)?;
                 }
-                packed_k.copy_region_from(lane * cache_bytes, input.cross_k, 0, cache_bytes).context(DeviceSnafu)?;
             }
-        }
-        {
-            let packed_v = self.jit.cross_v_mut().context(JitSnafu)?;
-            for (lane, input) in inputs.iter().enumerate() {
-                if input.cross_v.dtype() != svod_dtype::DType::Float32
-                    || input.cross_v.size() != cache_bytes
-                    || !std::ptr::eq(packed_v.allocator(), input.cross_v.allocator())
-                    || !std::ptr::eq(input.cross_k.allocator(), input.cross_v.allocator())
-                {
-                    return Err(super::error::Error::Decode {
-                        msg: "alignment cross V has invalid dtype, size, or allocator".to_string(),
-                    });
+            {
+                let packed_v = self.jit.cross_v_mut().context(JitSnafu)?;
+                for (lane, input) in inputs.iter().enumerate() {
+                    if input.cross_v.dtype() != svod_dtype::DType::Float32
+                        || input.cross_v.size() != cache_bytes
+                        || !std::ptr::eq(packed_v.allocator(), input.cross_v.allocator())
+                        || !std::ptr::eq(input.cross_k.allocator(), input.cross_v.allocator())
+                    {
+                        return Err(super::error::Error::Decode {
+                            msg: "alignment cross V has invalid dtype, size, or allocator".to_string(),
+                        });
+                    }
+                    packed_v
+                        .copy_region_from(lane * cache_bytes, input.cross_v, 0, cache_bytes)
+                        .context(DeviceSnafu)?;
                 }
-                packed_v.copy_region_from(lane * cache_bytes, input.cross_v, 0, cache_bytes).context(DeviceSnafu)?;
             }
+            Ok(())
+        })?;
+        if let Some(copies) = copies.as_deref_mut() {
+            copies.d2d("alignment_packing", inputs.len() * 2, inputs.len() * cache_bytes * 2, packing_wall);
         }
 
         let mut packed_tokens = vec![tokenizer.eot() as i32; self.batch_size * N_TEXT_CTX];
@@ -130,18 +157,31 @@ impl WhisperAligner {
             metadata.push((text_tokens, token_probs, valid_text, sot_len));
         }
 
-        self.jit
-            .tokens_mut()
-            .context(JitSnafu)?
-            .as_host_bytes_mut()
-            .context(DeviceSnafu)?
-            .copy_from_slice(bytemuck::cast_slice(&packed_tokens));
+        let token_buffer = self.jit.tokens_mut().context(JitSnafu)?;
+        let token_started = begin_host_copy(copies.is_some(), token_buffer)?;
+        token_buffer.as_host_bytes_mut().context(DeviceSnafu)?.copy_from_slice(bytemuck::cast_slice(&packed_tokens));
+        if let (Some(copies), Some(started)) = (copies.as_deref_mut(), token_started) {
+            copies.h2d("alignment_tokens", 1, packed_tokens.len() * std::mem::size_of::<i32>(), started.elapsed());
+        }
+        let graph_started = Instant::now();
         self.jit.execute().context(JitSnafu)?;
         let output = self.jit.output().context(JitSnafu)?;
-        let qk: &[f32] = bytemuck::cast_slice(output.as_host_bytes().context(DeviceSnafu)?);
+        if copies.is_some() {
+            output.synchronize().context(DeviceSnafu)?;
+        }
+        let graph_wall = graph_started.elapsed();
+        let output_started = begin_host_copy(copies.is_some(), output)?;
+        let output_bytes = output.as_host_bytes().context(DeviceSnafu)?;
         let qk_stride = self.n_heads * N_TEXT_CTX * N_AUDIO_CTX;
+        let active_qk_bytes = inputs.len() * qk_stride * std::mem::size_of::<f32>();
+        let profiled_qk = output_started.map(|_| bytemuck::cast_slice(&output_bytes[..active_qk_bytes]).to_vec());
+        let qk: &[f32] = profiled_qk.as_deref().unwrap_or_else(|| bytemuck::cast_slice(output_bytes));
+        if let (Some(copies), Some(started)) = (copies, output_started) {
+            copies.d2h("alignment_qk", 1, active_qk_bytes, started.elapsed());
+        }
 
-        Ok(inputs
+        let cpu_started = Instant::now();
+        let words = inputs
             .iter()
             .zip(metadata)
             .enumerate()
@@ -160,7 +200,8 @@ impl WhisperAligner {
                 );
                 words_from_path(&text_indices, &time_indices, &text_tokens, &token_probs, input.language, tokenizer)
             })
-            .collect())
+            .collect();
+        Ok((words, AlignmentProfile { graph_wall, cpu_dtw_wall: cpu_started.elapsed() }))
     }
 }
 

--- a/model/src/whisper/aligner.rs
+++ b/model/src/whisper/aligner.rs
@@ -22,10 +22,10 @@ pub struct WhisperAligner {
     audio_stride: usize,
 }
 
-/// Host-owned inputs for one lane of a prepared alignment batch.
+/// Inputs for one lane of a prepared alignment batch.
 pub struct WhisperAlignmentInput<'a> {
-    /// Encoder output in `[N_AUDIO_CTX, n_audio_state]` layout.
-    pub audio_features: &'a [f32],
+    /// Device-resident encoder output in `[N_AUDIO_CTX, n_audio_state]` layout.
+    pub audio_features: &'a svod_device::Buffer,
     /// Recognition tokens, including timestamp tokens when emitted.
     pub decoded_tokens: &'a [u32],
     /// Decoder probability corresponding to each decoded token.
@@ -68,13 +68,26 @@ impl WhisperAligner {
         }
 
         let audio_stride = self.audio_stride;
-        let mut packed_audio = vec![0.0f32; self.batch_size * audio_stride];
+        let audio_bytes = audio_stride * std::mem::size_of::<f32>();
+        {
+            let packed_audio = self.jit.audio_features_mut().context(JitSnafu)?;
+            for (lane, input) in inputs.iter().enumerate() {
+                if input.audio_features.dtype() != svod_dtype::DType::Float32
+                    || input.audio_features.size() != audio_bytes
+                {
+                    return Err(super::error::Error::Decode {
+                        msg: "alignment encoder features have invalid dtype or size".to_string(),
+                    });
+                }
+                packed_audio
+                    .copy_region_from(lane * audio_bytes, input.audio_features, 0, audio_bytes)
+                    .context(DeviceSnafu)?;
+            }
+        }
+
         let mut packed_tokens = vec![tokenizer.eot() as i32; self.batch_size * N_TEXT_CTX];
         let mut metadata = Vec::with_capacity(inputs.len());
         for (lane, input) in inputs.iter().enumerate() {
-            packed_audio[lane * audio_stride..lane * audio_stride + input.audio_features.len()]
-                .copy_from_slice(input.audio_features);
-
             let mut text_tokens: Vec<u32> =
                 input.decoded_tokens.iter().copied().filter(|&token| token < tokenizer.eot()).collect();
             let mut token_probs = input.token_probs[..input.token_probs.len().min(text_tokens.len())].to_vec();
@@ -100,12 +113,6 @@ impl WhisperAligner {
             metadata.push((text_tokens, token_probs, valid_text, sot_len));
         }
 
-        self.jit
-            .audio_features_mut()
-            .context(JitSnafu)?
-            .as_host_bytes_mut()
-            .context(DeviceSnafu)?
-            .copy_from_slice(bytemuck::cast_slice(&packed_audio));
         self.jit
             .tokens_mut()
             .context(JitSnafu)?

--- a/model/src/whisper/attention.rs
+++ b/model/src/whisper/attention.rs
@@ -17,6 +17,64 @@ use crate::state::{self, HasStateDict, StateDict, prefixed};
 use super::blocks::LinearWeights;
 use super::error::{Result, TensorSnafu};
 
+const MIN_PADDED_FA_SEQUENCE: usize = 1024;
+const MAX_PADDED_FA_OVERHEAD_DIVISOR: usize = 16;
+
+/// Returns the padded sequence length only when padding is both necessary and
+/// sufficiently small for encoder-style self-attention.
+fn padded_fa_sequence_len(causal: bool, q_len: usize, k_len: usize, v_len: usize) -> Option<usize> {
+    let multiple = svod_tk::FLASH_ATTENTION_SEQUENCE_MULTIPLE;
+    if causal || q_len != k_len || q_len != v_len || q_len < MIN_PADDED_FA_SEQUENCE || q_len.is_multiple_of(multiple) {
+        return None;
+    }
+    let padded = q_len.next_multiple_of(multiple);
+    (padded - q_len <= q_len / MAX_PADDED_FA_OVERHEAD_DIVISOR).then_some(padded)
+}
+
+fn padded_flash_attention(q: &Tensor, k: &Tensor, v: &Tensor, causal: bool) -> Result<Option<Tensor>> {
+    let dims = |t: &Tensor| -> Result<Vec<usize>> {
+        t.shape()
+            .context(TensorSnafu)?
+            .iter()
+            .map(|dim| {
+                dim.as_const().ok_or_else(|| super::error::Error::Tensor {
+                    source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
+                        operation: "padded flash-attention".into(),
+                    }),
+                })
+            })
+            .collect()
+    };
+    let (qd, kd, vd) = (dims(q)?, dims(k)?, dims(v)?);
+    let Some(padded_len) = padded_fa_sequence_len(causal, qd[1], kd[1], vd[1]) else {
+        return Ok(None);
+    };
+
+    let tail = (padded_len - qd[1]) as isize;
+    let padding = [(0, 0), (0, tail), (0, 0), (0, 0)];
+    let (q_pad, k_pad, v_pad) = (
+        q.try_pad(&padding).context(TensorSnafu)?,
+        k.try_pad(&padding).context(TensorSnafu)?,
+        v.try_pad(&padding).context(TensorSnafu)?,
+    );
+    // Keep this graph-native: the custom call owns the dependency on the device-local
+    // lengths tensor, including when Tensor::full is still lazy.
+    let key_lens =
+        Tensor::full(&[qd[0]], ConstValue::Int(qd[1] as i64), DType::Int32).context(TensorSnafu)?.to(q.device());
+    let Some(out) = svod_tk::flash_attention_with(
+        &q_pad,
+        &k_pad,
+        &v_pad,
+        svod_tk::FaOpts { causal: false, key_lens: Some(&key_lens) },
+    )
+    .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+    .context(TensorSnafu)?
+    else {
+        return Ok(None);
+    };
+    out.try_shrink([(0, qd[0]), (0, qd[1]), (0, qd[2]), (0, qd[3])]).map(Some).context(TensorSnafu)
+}
+
 #[derive(Clone)]
 pub struct MultiHeadAttention {
     pub query: LinearWeights,
@@ -147,10 +205,14 @@ impl MultiHeadAttention {
             (q_fa.clone(), k_fa.clone(), v_fa.clone())
         };
 
-        match svod_tk::flash_attention_with(&q_f, &k_f, &v_f, svod_tk::FaOpts { causal, key_lens: None })
+        let direct = svod_tk::flash_attention_with(&q_f, &k_f, &v_f, svod_tk::FaOpts { causal, key_lens: None })
             .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
-            .context(TensorSnafu)?
-        {
+            .context(TensorSnafu)?;
+        let fa_out = match direct {
+            some @ Some(_) => some,
+            None => padded_flash_attention(&q_f, &k_f, &v_f, causal)?,
+        };
+        match fa_out {
             Some(out) => {
                 let out = if need_cast { out.cast(dt).context(TensorSnafu)? } else { out };
                 out.try_reshape(&[b, s, svod_ir::SInt::Const(d)]).context(TensorSnafu)
@@ -202,4 +264,71 @@ pub fn causal_mask(seq_len: usize, dtype: DType) -> Result<Tensor> {
     let zero = Tensor::const_(ConstValue::Float(0.0), dtype);
     let float_mask = neg_inf.where_(&upper, &zero).context(TensorSnafu)?;
     float_mask.try_unsqueeze(0).context(TensorSnafu)?.try_unsqueeze(0).context(TensorSnafu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn padded_fa_policy_targets_long_untiled_self_attention() {
+        assert_eq!(padded_fa_sequence_len(false, 1500, 1500, 1500), Some(1536));
+        assert_eq!(padded_fa_sequence_len(false, 1536, 1536, 1536), None);
+        assert_eq!(padded_fa_sequence_len(false, 127, 127, 127), None);
+        assert_eq!(padded_fa_sequence_len(true, 1500, 1500, 1500), None);
+        assert_eq!(padded_fa_sequence_len(false, 1500, 100, 100), None);
+        assert_eq!(padded_fa_sequence_len(false, 1500, 1500, 1499), None);
+        assert_eq!(padded_fa_sequence_len(false, 1409, 1409, 1409), None, "large padding overhead must be rejected");
+    }
+
+    fn encoder_shape_inputs() -> (Tensor, Tensor, Tensor) {
+        let make = || {
+            let mut tensor = Tensor::randn(&[1, 1500, 2, 64]).unwrap().cast(DType::Float16).unwrap();
+            tensor.realize().unwrap();
+            tensor
+        };
+        (make(), make(), make())
+    }
+
+    #[test]
+    #[ignore = "GPU: padded Whisper encoder flash-attention vs unpadded SDPA"]
+    fn padded_encoder_flash_attention_matches_unpadded_sdpa() {
+        let (q, k, v) = encoder_shape_inputs();
+        let mut got = padded_flash_attention(&q, &k, &v, false)
+            .expect("padded flash-attention")
+            .expect("supported AMD flash-attention target")
+            .cast(DType::Float32)
+            .unwrap();
+        assert_eq!(got.shape().unwrap().iter().map(|d| d.as_const().unwrap()).collect::<Vec<_>>(), [1, 1500, 2, 64]);
+        got.realize().unwrap();
+
+        let perm = |t: &Tensor| t.cast(DType::Float32).unwrap().try_permute(&[0, 2, 1, 3]).unwrap();
+        let mut reference = perm(&q)
+            .scaled_dot_product_attention()
+            .key(&perm(&k))
+            .value(&perm(&v))
+            .is_causal(false)
+            .call()
+            .unwrap()
+            .try_permute(&[0, 2, 1, 3])
+            .unwrap();
+        reference.realize().unwrap();
+        let got = got.as_vec::<f32>().unwrap();
+        let expected = reference.as_vec::<f32>().unwrap();
+        let max_abs = got.iter().zip(&expected).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+        assert!(max_abs <= 2e-2, "padded encoder FA exceeds tolerance: {max_abs:e}");
+    }
+
+    #[test]
+    #[ignore = "GPU: inspect padded Whisper encoder execution plan"]
+    fn padded_encoder_plan_contains_flash_attention_entry() {
+        let make = || Tensor::randn(&[1, 1500, 128]).unwrap().cast(DType::Float16).unwrap();
+        let (q, k, v) = (make(), make(), make());
+        let attention = MultiHeadAttention::empty_dtype(128, 2, DType::Float16);
+        let mut out = attention.fa_attention(&q, &k, &v, false).expect("Whisper encoder attention graph");
+        assert_eq!(out.shape().unwrap().iter().map(|d| d.as_const().unwrap()).collect::<Vec<_>>(), [1, 1500, 128]);
+        let plan = out.prepare().unwrap();
+        let names = plan.kernels().map(|kernel| kernel.entry_point.as_str()).collect::<Vec<_>>();
+        assert!(names.contains(&"flash_attention"), "missing handwritten flash_attention entry in {names:?}");
+    }
 }

--- a/model/src/whisper/attention.rs
+++ b/model/src/whisper/attention.rs
@@ -28,11 +28,15 @@ pub struct MultiHeadAttention {
 
 impl MultiHeadAttention {
     pub fn empty(n_state: usize, n_head: usize) -> Self {
+        Self::empty_dtype(n_state, n_head, DType::Float32)
+    }
+
+    pub fn empty_dtype(n_state: usize, n_head: usize, dtype: DType) -> Self {
         Self {
-            query: LinearWeights::empty(n_state, n_state, true),
-            key: LinearWeights::empty(n_state, n_state, false),
-            value: LinearWeights::empty(n_state, n_state, true),
-            out: LinearWeights::empty(n_state, n_state, true),
+            query: LinearWeights::empty_dtype(n_state, n_state, true, dtype.clone()),
+            key: LinearWeights::empty_dtype(n_state, n_state, false, dtype.clone()),
+            value: LinearWeights::empty_dtype(n_state, n_state, true, dtype.clone()),
+            out: LinearWeights::empty_dtype(n_state, n_state, true, dtype),
             n_head,
         }
     }
@@ -215,7 +219,11 @@ impl MultiHeadAttention {
             scores = scores.try_add(m).context(TensorSnafu)?;
         }
 
-        let attn = scores.softmax(-1isize).context(TensorSnafu)?;
+        // Softmax in fp32, then back to q dtype — matches the OpenAI reference
+        // (`model.py:140-142`: `qk.float()` → `F.softmax(...).to(q.dtype)`).
+        let q_dtype = q.uop().dtype().clone();
+        let attn = scores.cast(DType::Float32).context(TensorSnafu)?.softmax(-1isize).context(TensorSnafu)?;
+        let attn = attn.cast(q_dtype).context(TensorSnafu)?;
         let out = attn.matmul(&v).context(TensorSnafu)?; // [B, H, Sq, Dh]
         let out = self.merge_heads(&out)?;
 

--- a/model/src/whisper/attention.rs
+++ b/model/src/whisper/attention.rs
@@ -22,57 +22,13 @@ const MAX_PADDED_FA_OVERHEAD_DIVISOR: usize = 16;
 
 /// Returns the padded sequence length only when padding is both necessary and
 /// sufficiently small for encoder-style self-attention.
-fn padded_fa_sequence_len(causal: bool, q_len: usize, k_len: usize, v_len: usize) -> Option<usize> {
+pub(super) fn padded_fa_sequence_len(causal: bool, q_len: usize, k_len: usize, v_len: usize) -> Option<usize> {
     let multiple = svod_tk::FLASH_ATTENTION_SEQUENCE_MULTIPLE;
     if causal || q_len != k_len || q_len != v_len || q_len < MIN_PADDED_FA_SEQUENCE || q_len.is_multiple_of(multiple) {
         return None;
     }
     let padded = q_len.next_multiple_of(multiple);
     (padded - q_len <= q_len / MAX_PADDED_FA_OVERHEAD_DIVISOR).then_some(padded)
-}
-
-fn padded_flash_attention(q: &Tensor, k: &Tensor, v: &Tensor, causal: bool) -> Result<Option<Tensor>> {
-    let dims = |t: &Tensor| -> Result<Vec<usize>> {
-        t.shape()
-            .context(TensorSnafu)?
-            .iter()
-            .map(|dim| {
-                dim.as_const().ok_or_else(|| super::error::Error::Tensor {
-                    source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
-                        operation: "padded flash-attention".into(),
-                    }),
-                })
-            })
-            .collect()
-    };
-    let (qd, kd, vd) = (dims(q)?, dims(k)?, dims(v)?);
-    let Some(padded_len) = padded_fa_sequence_len(causal, qd[1], kd[1], vd[1]) else {
-        return Ok(None);
-    };
-
-    let tail = (padded_len - qd[1]) as isize;
-    let padding = [(0, 0), (0, tail), (0, 0), (0, 0)];
-    let (q_pad, k_pad, v_pad) = (
-        q.try_pad(&padding).context(TensorSnafu)?,
-        k.try_pad(&padding).context(TensorSnafu)?,
-        v.try_pad(&padding).context(TensorSnafu)?,
-    );
-    // Keep this graph-native: the custom call owns the dependency on the device-local
-    // lengths tensor, including when Tensor::full is still lazy.
-    let key_lens =
-        Tensor::full(&[qd[0]], ConstValue::Int(qd[1] as i64), DType::Int32).context(TensorSnafu)?.to(q.device());
-    let Some(out) = svod_tk::flash_attention_with(
-        &q_pad,
-        &k_pad,
-        &v_pad,
-        svod_tk::FaOpts { causal: false, key_lens: Some(&key_lens) },
-    )
-    .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
-    .context(TensorSnafu)?
-    else {
-        return Ok(None);
-    };
-    out.try_shrink([(0, qd[0]), (0, qd[1]), (0, qd[2]), (0, qd[3])]).map(Some).context(TensorSnafu)
 }
 
 #[derive(Clone)]
@@ -102,12 +58,22 @@ impl MultiHeadAttention {
     /// Forward pass. `xa = None` for self-attention, `Some(enc)` for cross-attention.
     /// `mask` is the causal mask for decoder self-attention (additive float mask).
     pub fn forward(&self, x: &Tensor, xa: Option<&Tensor>, mask: Option<&Tensor>) -> Result<Tensor> {
+        self.forward_with_key_lens(x, xa, mask, None)
+    }
+
+    pub(crate) fn forward_with_key_lens(
+        &self,
+        x: &Tensor,
+        xa: Option<&Tensor>,
+        mask: Option<&Tensor>,
+        key_lens: Option<&Tensor>,
+    ) -> Result<Tensor> {
         let q = self.query.forward(x)?;
         let kv_input = xa.unwrap_or(x);
         let k = self.key.forward(kv_input)?;
         let v = self.value.forward(kv_input)?;
 
-        let out = self.fa_attention(&q, &k, &v, mask.is_some())?;
+        let out = self.fa_attention(&q, &k, &v, mask.is_some(), key_lens)?;
         self.out.forward(&out)
     }
 
@@ -122,7 +88,7 @@ impl MultiHeadAttention {
         let k = self.key.forward(kv_input)?;
         let v = self.value.forward(kv_input)?;
 
-        let out = self.fa_attention(&q, &k, &v, mask.is_some())?;
+        let out = self.fa_attention(&q, &k, &v, mask.is_some(), None)?;
         let out = self.out.forward(&out)?;
         Ok((out, k, v))
     }
@@ -164,7 +130,14 @@ impl MultiHeadAttention {
 
     /// Flash-attention path: Q/K/V in [B, S, D] → split to [B, S, H, Dh] for FA,
     /// fall back to SDPA if FA doesn't apply. `causal` controls the mask.
-    fn fa_attention(&self, q: &Tensor, k: &Tensor, v: &Tensor, causal: bool) -> Result<Tensor> {
+    fn fa_attention(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        causal: bool,
+        key_lens: Option<&Tensor>,
+    ) -> Result<Tensor> {
         let shape = q.shape().context(TensorSnafu)?;
         let b = shape[0].clone();
         let s = shape[1].clone();
@@ -205,14 +178,10 @@ impl MultiHeadAttention {
             (q_fa.clone(), k_fa.clone(), v_fa.clone())
         };
 
-        let direct = svod_tk::flash_attention_with(&q_f, &k_f, &v_f, svod_tk::FaOpts { causal, key_lens: None })
+        let direct = svod_tk::flash_attention_with(&q_f, &k_f, &v_f, svod_tk::FaOpts { causal, key_lens })
             .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
             .context(TensorSnafu)?;
-        let fa_out = match direct {
-            some @ Some(_) => some,
-            None => padded_flash_attention(&q_f, &k_f, &v_f, causal)?,
-        };
-        match fa_out {
+        match direct {
             Some(out) => {
                 let out = if need_cast { out.cast(dt).context(TensorSnafu)? } else { out };
                 out.try_reshape(&[b, s, svod_ir::SInt::Const(d)]).context(TensorSnafu)
@@ -220,11 +189,30 @@ impl MultiHeadAttention {
             None => {
                 // SDPA fallback (needs [B, H, S, Dh])
                 let perm = |t: &Tensor| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu);
+                let mask = match key_lens {
+                    Some(lens) => {
+                        let n = shape[1].as_const().ok_or_else(|| super::error::Error::Tensor {
+                            source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
+                                operation: "key-length attention mask".into(),
+                            }),
+                        })?;
+                        let range = Tensor::arange(n as i64, None, None)
+                            .context(TensorSnafu)?
+                            .try_reshape([1usize, 1, 1, n])
+                            .context(TensorSnafu)?;
+                        let lens = lens
+                            .try_reshape([b.clone(), 1usize.into(), 1usize.into(), 1usize.into()])
+                            .context(TensorSnafu)?;
+                        Some(range.try_ge(&lens).context(TensorSnafu)?)
+                    }
+                    None => None,
+                };
                 let out = perm(&q_fa)?
                     .scaled_dot_product_attention()
                     .key(&perm(&k_fa)?)
                     .value(&perm(&v_fa)?)
                     .is_causal(causal)
+                    .maybe_attn_mask(mask.as_ref())
                     .call()
                     .context(TensorSnafu)?;
                 self.merge_heads(&out)
@@ -294,11 +282,17 @@ mod tests {
     #[ignore = "GPU: padded Whisper encoder flash-attention vs unpadded SDPA"]
     fn padded_encoder_flash_attention_matches_unpadded_sdpa() {
         let (q, k, v) = encoder_shape_inputs();
-        let mut got = padded_flash_attention(&q, &k, &v, false)
-            .expect("padded flash-attention")
-            .expect("supported AMD flash-attention target")
-            .cast(DType::Float32)
-            .unwrap();
+        let padding = [(0, 0), (0, 36), (0, 0), (0, 0)];
+        let (qp, kp, vp) = (q.try_pad(&padding).unwrap(), k.try_pad(&padding).unwrap(), v.try_pad(&padding).unwrap());
+        let key_lens = Tensor::full(&[1], ConstValue::Int(1500), DType::Int32).unwrap().to(q.device());
+        let mut got =
+            svod_tk::flash_attention_with(&qp, &kp, &vp, svod_tk::FaOpts { causal: false, key_lens: Some(&key_lens) })
+                .expect("padded flash-attention")
+                .expect("supported AMD flash-attention target")
+                .try_shrink([(0, 1), (0, 1500), (0, 2), (0, 64)])
+                .unwrap()
+                .cast(DType::Float32)
+                .unwrap();
         assert_eq!(got.shape().unwrap().iter().map(|d| d.as_const().unwrap()).collect::<Vec<_>>(), [1, 1500, 2, 64]);
         got.realize().unwrap();
 
@@ -317,18 +311,5 @@ mod tests {
         let expected = reference.as_vec::<f32>().unwrap();
         let max_abs = got.iter().zip(&expected).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
         assert!(max_abs <= 2e-2, "padded encoder FA exceeds tolerance: {max_abs:e}");
-    }
-
-    #[test]
-    #[ignore = "GPU: inspect padded Whisper encoder execution plan"]
-    fn padded_encoder_plan_contains_flash_attention_entry() {
-        let make = || Tensor::randn(&[1, 1500, 128]).unwrap().cast(DType::Float16).unwrap();
-        let (q, k, v) = (make(), make(), make());
-        let attention = MultiHeadAttention::empty_dtype(128, 2, DType::Float16);
-        let mut out = attention.fa_attention(&q, &k, &v, false).expect("Whisper encoder attention graph");
-        assert_eq!(out.shape().unwrap().iter().map(|d| d.as_const().unwrap()).collect::<Vec<_>>(), [1, 1500, 128]);
-        let plan = out.prepare().unwrap();
-        let names = plan.kernels().map(|kernel| kernel.entry_point.as_str()).collect::<Vec<_>>();
-        assert!(names.contains(&"flash_attention"), "missing handwritten flash_attention entry in {names:?}");
     }
 }

--- a/model/src/whisper/attention.rs
+++ b/model/src/whisper/attention.rs
@@ -69,23 +69,6 @@ impl MultiHeadAttention {
         Ok((out, k, v))
     }
 
-    /// Forward pass returning both the output and the raw QK attention weights
-    /// (pre-softmax, post-scale). Used for DTW alignment. Only meaningful for
-    /// cross-attention; returns `None` for self-attention when `xa.is_none()`.
-    pub fn forward_with_qk(
-        &self,
-        x: &Tensor,
-        xa: Option<&Tensor>,
-        mask: Option<&Tensor>,
-    ) -> Result<(Tensor, Option<Tensor>)> {
-        let q = self.query.forward(x)?;
-        let kv_input = xa.unwrap_or(x);
-        let k = self.key.forward(kv_input)?;
-        let v = self.value.forward(kv_input)?;
-
-        self.qkv_attention_with_qk(&q, &k, &v, mask, xa.is_some())
-    }
-
     pub fn split_heads(&self, t: &Tensor) -> Result<Tensor> {
         // t: [B, S, D] -> [B, S, H, Dh] -> [B, H, S, Dh]
         let shape = t.shape().context(TensorSnafu)?;
@@ -185,51 +168,6 @@ impl MultiHeadAttention {
                 self.merge_heads(&out)
             }
         }
-    }
-
-    /// Manual attention that returns softmaxed attention weights for DTW.
-    fn qkv_attention_with_qk(
-        &self,
-        q: &Tensor,
-        k: &Tensor,
-        v: &Tensor,
-        mask: Option<&Tensor>,
-        is_cross: bool,
-    ) -> Result<(Tensor, Option<Tensor>)> {
-        let q = self.split_heads(q)?; // [B, H, Sq, Dh]
-        let k = self.split_heads(k)?; // [B, H, Sk, Dh]
-        let v = self.split_heads(v)?; // [B, H, Sk, Dh]
-
-        let kt = k.try_transpose(-1, -2).context(TensorSnafu)?; // [B, H, Dh, Sk]
-        let mut scores = q.matmul(&kt).context(TensorSnafu)?; // [B, H, Sq, Sk]
-
-        let dh = {
-            let s = q.shape().context(TensorSnafu)?;
-            s[3].as_const().ok_or_else(|| super::error::Error::Tensor {
-                source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
-                    operation: "qkv_attention dh".into(),
-                }),
-            })? as f64
-        };
-        let scale = 1.0 / dh.sqrt();
-        let scale_t = Tensor::const_(ConstValue::Float(scale), scores.uop().dtype().clone());
-        scores = scores.try_mul(&scale_t).context(TensorSnafu)?;
-
-        if let Some(m) = mask {
-            scores = scores.try_add(m).context(TensorSnafu)?;
-        }
-
-        // Softmax in fp32, then back to q dtype — matches the OpenAI reference
-        // (`model.py:140-142`: `qk.float()` → `F.softmax(...).to(q.dtype)`).
-        let q_dtype = q.uop().dtype().clone();
-        let attn = scores.cast(DType::Float32).context(TensorSnafu)?.softmax(-1isize).context(TensorSnafu)?;
-        let attn = attn.cast(q_dtype).context(TensorSnafu)?;
-        let out = attn.matmul(&v).context(TensorSnafu)?; // [B, H, Sq, Dh]
-        let out = self.merge_heads(&out)?;
-
-        // Return softmaxed attention weights only for cross-attention.
-        let qk_weights = is_cross.then_some(attn);
-        Ok((out, qk_weights))
     }
 }
 

--- a/model/src/whisper/attention.rs
+++ b/model/src/whisper/attention.rs
@@ -178,9 +178,13 @@ impl MultiHeadAttention {
             (q_fa.clone(), k_fa.clone(), v_fa.clone())
         };
 
-        let direct = svod_tk::flash_attention_with(&q_f, &k_f, &v_f, svod_tk::FaOpts { causal, key_lens })
-            .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
-            .context(TensorSnafu)?;
+        let direct = if (d / self.n_head).is_multiple_of(16) {
+            svod_tk::flash_attention_with(&q_f, &k_f, &v_f, svod_tk::FaOpts { causal, key_lens })
+                .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+                .context(TensorSnafu)?
+        } else {
+            None
+        };
         match direct {
             Some(out) => {
                 let out = if need_cast { out.cast(dt).context(TensorSnafu)? } else { out };

--- a/model/src/whisper/blocks.rs
+++ b/model/src/whisper/blocks.rs
@@ -32,8 +32,30 @@ impl LinearWeights {
     }
 
     pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        x.linear().weight(&self.weight).maybe_bias(self.bias.as_ref()).call().context(TensorSnafu)
+        match &self.bias {
+            Some(bias) => linear_with_bias(x, &self.weight, bias),
+            None => x.linear().weight(&self.weight).call().context(TensorSnafu),
+        }
     }
+}
+
+pub(super) fn linear_with_bias(x: &Tensor, weight: &Tensor, bias: &Tensor) -> Result<Tensor> {
+    let output_dtype = x.uop().dtype();
+    let is_low_precision = |dtype: &DType| dtype == &DType::Float16 || dtype == &DType::BFloat16;
+    let low_precision = is_low_precision(&output_dtype) && is_low_precision(&weight.uop().dtype());
+    if !low_precision {
+        return x.linear().weight(weight).bias(bias).call().context(TensorSnafu);
+    }
+
+    x.linear()
+        .weight(weight)
+        .dtype(DType::Float32)
+        .call()
+        .context(TensorSnafu)?
+        .try_add(&bias.cast(DType::Float32).context(TensorSnafu)?)
+        .context(TensorSnafu)?
+        .cast(output_dtype)
+        .context(TensorSnafu)
 }
 
 impl HasStateDict for LinearWeights {
@@ -74,12 +96,22 @@ impl LayerNormWeights {
     }
 
     pub fn apply(&self, x: &Tensor) -> Result<Tensor> {
-        // `Tensor::layernorm` upcasts to fp32 internally for numerical
-        // stability (matching ONNX `stash_type=1`, same as the OpenAI reference's
-        // `x.float()`), then casts the normalized output back to the input dtype.
-        // The affine multiply/add then runs in the input dtype via the IR's
-        // auto-promotion lattice. This mirrors xlm_roberta's LayerNorm, which
-        // relies on the op's internal upcast rather than an explicit branch.
+        let output_dtype = x.uop().dtype();
+        if output_dtype == DType::Float16 || output_dtype == DType::BFloat16 {
+            let x = x.cast(DType::Float32).context(TensorSnafu)?;
+            let weight = self.weight.cast(DType::Float32).context(TensorSnafu)?;
+            let bias = self.bias.cast(DType::Float32).context(TensorSnafu)?;
+            return x
+                .layernorm(-1, self.eps)
+                .context(TensorSnafu)?
+                .try_mul(&weight)
+                .context(TensorSnafu)?
+                .try_add(&bias)
+                .context(TensorSnafu)?
+                .cast(output_dtype)
+                .context(TensorSnafu);
+        }
+
         let normed = x.layernorm(-1, self.eps).context(TensorSnafu)?;
         normed.try_mul(&self.weight).context(TensorSnafu)?.try_add(&self.bias).context(TensorSnafu)
     }
@@ -183,4 +215,73 @@ pub fn sinusoids(length: usize, channels: usize, max_timescale: f64) -> Result<T
     let sin = scaled_time.sin().context(TensorSnafu)?;
     let cos = scaled_time.cos().context(TensorSnafu)?;
     Tensor::cat(&[&sin, &cos], -1).context(TensorSnafu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn realized_f32(tensor: Tensor) -> Vec<f32> {
+        let mut tensor = tensor.cast(DType::Float32).unwrap();
+        tensor.realize().unwrap();
+        tensor.as_vec::<f32>().unwrap()
+    }
+
+    #[test]
+    fn fp16_layernorm_keeps_affine_in_fp32_until_final_cast() {
+        let x = Tensor::from_slice([0.1013f32, -0.2037, 0.3071, 1.913])
+            .try_reshape([1usize, 4])
+            .unwrap()
+            .cast(DType::Float16)
+            .unwrap();
+        let layer = LayerNormWeights {
+            weight: Tensor::from_slice([17.25f32, -31.5, 47.75, -63.0]).cast(DType::Float16).unwrap(),
+            bias: Tensor::from_slice([0.03125f32, -0.0625, 0.09375, -0.125]).cast(DType::Float16).unwrap(),
+            eps: 1e-5,
+        };
+
+        let reference = x
+            .cast(DType::Float32)
+            .unwrap()
+            .layernorm(-1, layer.eps)
+            .unwrap()
+            .try_mul(&layer.weight.cast(DType::Float32).unwrap())
+            .unwrap()
+            .try_add(&layer.bias.cast(DType::Float32).unwrap())
+            .unwrap()
+            .cast(DType::Float16)
+            .unwrap();
+        let legacy = x.layernorm(-1, layer.eps).unwrap().try_mul(&layer.weight).unwrap().try_add(&layer.bias).unwrap();
+        let actual = realized_f32(layer.apply(&x).unwrap());
+        let reference = realized_f32(reference);
+        let legacy = realized_f32(legacy);
+
+        assert_eq!(actual, reference, "LayerNorm must round only after the FP32 affine epilogue");
+        assert_ne!(legacy, reference, "fixture must detect rounding before the affine epilogue");
+    }
+
+    #[test]
+    fn fp16_linear_keeps_bias_epilogue_in_fp32_until_final_cast() {
+        let x = Tensor::from_slice([0.3333f32, -0.1428, 0.0909, 0.0769])
+            .try_reshape([1usize, 4])
+            .unwrap()
+            .cast(DType::Float16)
+            .unwrap();
+        let weight = Tensor::from_slice([3.0f32, -5.0, 7.0, -11.0, -2.0, 4.0, -6.0, 8.0])
+            .try_reshape([2usize, 4])
+            .unwrap()
+            .cast(DType::Float16)
+            .unwrap();
+        let bias = Tensor::from_slice([-2.5f32, 2.0]).cast(DType::Float16).unwrap();
+
+        let matmul_f32 = x.linear().weight(&weight).dtype(DType::Float32).call().unwrap();
+        let reference = matmul_f32.try_add(&bias.cast(DType::Float32).unwrap()).unwrap().cast(DType::Float16).unwrap();
+        let legacy = x.linear().weight(&weight).bias(&bias).call().unwrap();
+        let actual = realized_f32(linear_with_bias(&x, &weight, &bias).unwrap());
+        let reference = realized_f32(reference);
+        let legacy = realized_f32(legacy);
+
+        assert_eq!(actual, reference, "linear bias must be added to the FP32 accumulator");
+        assert_ne!(legacy, reference, "fixture must detect rounding before bias addition");
+    }
 }

--- a/model/src/whisper/blocks.rs
+++ b/model/src/whisper/blocks.rs
@@ -22,8 +22,12 @@ pub struct LinearWeights {
 
 impl LinearWeights {
     pub fn empty(in_features: usize, out_features: usize, has_bias: bool) -> Self {
-        let weight = fan_in_uniform(&[out_features, in_features], in_features, DType::Float32);
-        let bias = has_bias.then(|| fan_in_uniform(&[out_features], in_features, DType::Float32));
+        Self::empty_dtype(in_features, out_features, has_bias, DType::Float32)
+    }
+
+    pub fn empty_dtype(in_features: usize, out_features: usize, has_bias: bool, dtype: DType) -> Self {
+        let weight = fan_in_uniform(&[out_features, in_features], in_features, dtype.clone());
+        let bias = has_bias.then(|| fan_in_uniform(&[out_features], in_features, dtype));
         Self { weight, bias }
     }
 
@@ -62,10 +66,20 @@ pub struct LayerNormWeights {
 
 impl LayerNormWeights {
     pub fn empty(size: usize) -> Self {
-        Self { weight: ones(&[size], DType::Float32), bias: zeros(&[size], DType::Float32), eps: 1e-5 }
+        Self::empty_dtype(size, DType::Float32)
+    }
+
+    pub fn empty_dtype(size: usize, dtype: DType) -> Self {
+        Self { weight: ones(&[size], dtype.clone()), bias: zeros(&[size], dtype), eps: 1e-5 }
     }
 
     pub fn apply(&self, x: &Tensor) -> Result<Tensor> {
+        // `Tensor::layernorm` upcasts to fp32 internally for numerical
+        // stability (matching ONNX `stash_type=1`, same as the OpenAI reference's
+        // `x.float()`), then casts the normalized output back to the input dtype.
+        // The affine multiply/add then runs in the input dtype via the IR's
+        // auto-promotion lattice. This mirrors xlm_roberta's LayerNorm, which
+        // relies on the op's internal upcast rather than an explicit branch.
         let normed = x.layernorm(-1, self.eps).context(TensorSnafu)?;
         normed.try_mul(&self.weight).context(TensorSnafu)?.try_add(&self.bias).context(TensorSnafu)
     }
@@ -97,10 +111,22 @@ pub struct Conv1dWeights {
 
 impl Conv1dWeights {
     pub fn empty(in_ch: usize, out_ch: usize, kernel: usize, stride: usize, padding: usize, has_bias: bool) -> Self {
+        Self::empty_dtype(in_ch, out_ch, kernel, stride, padding, has_bias, DType::Float32)
+    }
+
+    pub fn empty_dtype(
+        in_ch: usize,
+        out_ch: usize,
+        kernel: usize,
+        stride: usize,
+        padding: usize,
+        has_bias: bool,
+        dtype: DType,
+    ) -> Self {
         let fan_in = in_ch * kernel;
         Self {
-            weight: fan_in_uniform(&[out_ch, in_ch, kernel], fan_in, DType::Float32),
-            bias: has_bias.then(|| fan_in_uniform(&[out_ch], fan_in, DType::Float32)),
+            weight: fan_in_uniform(&[out_ch, in_ch, kernel], fan_in, dtype.clone()),
+            bias: has_bias.then(|| fan_in_uniform(&[out_ch], fan_in, dtype)),
             stride,
             padding,
         }

--- a/model/src/whisper/config.rs
+++ b/model/src/whisper/config.rs
@@ -16,6 +16,8 @@ pub const N_TEXT_CTX: usize = 448;
 
 // ─── ModelDimensions (matching whisper/model.py) ─────────────────────────────
 
+use svod_dtype::DType;
+
 #[derive(Clone, Debug)]
 pub struct ModelDimensions {
     pub n_mels: usize,
@@ -28,6 +30,11 @@ pub struct ModelDimensions {
     pub n_text_state: usize,
     pub n_text_head: usize,
     pub n_text_layer: usize,
+    /// Compute dtype for weights and activations. Defaults to Float16
+    /// (matching HuggingFace checkpoint storage); set to Float32 for CPU
+    /// parity tests or hardware without fp16 support. fp8 is viable on
+    /// AMD-GPU paths only (CPU/MLIR treat it as raw i8).
+    pub dtype: DType,
 }
 
 impl ModelDimensions {
@@ -53,6 +60,7 @@ impl ModelDimensions {
                 n_text_state: 384,
                 n_text_head: 6,
                 n_text_layer: 4,
+                dtype: DType::Float16,
             },
             WhisperSize::Tiny => Self {
                 n_mels: 80,
@@ -65,6 +73,7 @@ impl ModelDimensions {
                 n_text_state: 384,
                 n_text_head: 6,
                 n_text_layer: 4,
+                dtype: DType::Float16,
             },
             WhisperSize::BaseEn => Self {
                 n_mels: 80,
@@ -77,6 +86,7 @@ impl ModelDimensions {
                 n_text_state: 512,
                 n_text_head: 8,
                 n_text_layer: 6,
+                dtype: DType::Float16,
             },
             WhisperSize::Base => Self {
                 n_mels: 80,
@@ -89,6 +99,7 @@ impl ModelDimensions {
                 n_text_state: 512,
                 n_text_head: 8,
                 n_text_layer: 6,
+                dtype: DType::Float16,
             },
             WhisperSize::SmallEn => Self {
                 n_mels: 80,
@@ -101,6 +112,7 @@ impl ModelDimensions {
                 n_text_state: 768,
                 n_text_head: 12,
                 n_text_layer: 12,
+                dtype: DType::Float16,
             },
             WhisperSize::Small => Self {
                 n_mels: 80,
@@ -113,6 +125,7 @@ impl ModelDimensions {
                 n_text_state: 768,
                 n_text_head: 12,
                 n_text_layer: 12,
+                dtype: DType::Float16,
             },
             WhisperSize::MediumEn => Self {
                 n_mels: 80,
@@ -125,6 +138,7 @@ impl ModelDimensions {
                 n_text_state: 1024,
                 n_text_head: 16,
                 n_text_layer: 24,
+                dtype: DType::Float16,
             },
             WhisperSize::Medium => Self {
                 n_mels: 80,
@@ -137,6 +151,7 @@ impl ModelDimensions {
                 n_text_state: 1024,
                 n_text_head: 16,
                 n_text_layer: 24,
+                dtype: DType::Float16,
             },
             WhisperSize::LargeV1 | WhisperSize::LargeV2 => Self {
                 n_mels: 80,
@@ -149,6 +164,7 @@ impl ModelDimensions {
                 n_text_state: 1280,
                 n_text_head: 20,
                 n_text_layer: 32,
+                dtype: DType::Float16,
             },
             WhisperSize::LargeV3 => Self {
                 n_mels: 128,
@@ -161,6 +177,7 @@ impl ModelDimensions {
                 n_text_state: 1280,
                 n_text_head: 20,
                 n_text_layer: 32,
+                dtype: DType::Float16,
             },
             WhisperSize::Turbo => Self {
                 n_mels: 128,
@@ -173,6 +190,7 @@ impl ModelDimensions {
                 n_text_state: 1280,
                 n_text_head: 20,
                 n_text_layer: 8,
+                dtype: DType::Float16,
             },
         }
     }

--- a/model/src/whisper/config.rs
+++ b/model/src/whisper/config.rs
@@ -30,10 +30,10 @@ pub struct ModelDimensions {
     pub n_text_state: usize,
     pub n_text_head: usize,
     pub n_text_layer: usize,
-    /// Compute dtype for weights and activations. Defaults to Float16
-    /// (matching HuggingFace checkpoint storage); set to Float32 for CPU
-    /// parity tests or hardware without fp16 support. fp8 is viable on
-    /// AMD-GPU paths only (CPU/MLIR treat it as raw i8).
+    /// Compute dtype for projected weights and activations. Defaults to
+    /// Float16; set to Float32 for CPU parity tests or hardware without fp16
+    /// support. fp8 is viable on AMD-GPU paths only (CPU/MLIR treat it as raw
+    /// i8).
     pub dtype: DType,
 }
 

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -24,28 +24,25 @@ pub struct LanguageDetection {
 
 pub fn detect_language(
     decoder_jit: &mut WhisperDecoderJit,
-    n_text_ctx: usize,
+    _n_text_ctx: usize,
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
 ) -> Result<LanguageDetection> {
-    detect_language_profile(decoder_jit, n_text_ctx, n_vocab, tokenizer, None, None)
+    detect_language_profile(decoder_jit, n_vocab, tokenizer, None, None)
 }
 
 pub(crate) fn detect_language_profile(
     decoder_jit: &mut WhisperDecoderJit,
-    n_text_ctx: usize,
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
     mut copies: Option<&mut CopyProfile>,
     graph_profile: Option<&mut GraphProfile>,
 ) -> Result<LanguageDetection> {
     let sot = tokenizer.sot() as i32;
-    let eot = tokenizer.eot() as i32;
-    let token_buf: Vec<i32> = (0..n_text_ctx).map(|i| if i == 0 { sot } else { eot }).collect();
     let started = begin_host_copy(copies.is_some(), decoder_jit.tokens_mut().context(JitSnafu)?)?;
-    write_uncached(decoder_jit, &token_buf)?;
+    write_uncached(decoder_jit, &[sot])?;
     if let (Some(copies), Some(started)) = (copies.as_deref_mut(), started) {
-        copies.h2d("language_tokens", 1, token_buf.len() * std::mem::size_of::<i32>(), started.elapsed());
+        copies.h2d("language_tokens", 1, std::mem::size_of::<i32>(), started.elapsed());
     }
     if let Some(graph_profile) = graph_profile {
         let graph_started = std::time::Instant::now();
@@ -56,11 +53,10 @@ pub(crate) fn detect_language_profile(
         decoder_jit.execute().context(JitSnafu)?;
     }
     let started = begin_host_copy(copies.is_some(), decoder_jit.output().context(JitSnafu)?)?;
-    let flat = read_uncached(decoder_jit)?;
+    let sot_logits = read_uncached(decoder_jit, n_vocab)?;
     if let (Some(copies), Some(started)) = (copies, started) {
-        copies.d2h("language_logits", 1, flat.len() * std::mem::size_of::<f32>(), started.elapsed());
+        copies.d2h("language_logits", 1, n_vocab * std::mem::size_of::<f32>(), started.elapsed());
     }
-    let sot_logits = &flat[..n_vocab];
 
     let lang_tokens = tokenizer.all_language_tokens();
     let lang_codes = tokenizer.all_language_codes();
@@ -1569,9 +1565,9 @@ fn write_uncached(jit: &mut WhisperDecoderJit, tokens: &[i32]) -> Result<()> {
     write_buf(buf, bytemuck::cast_slice(tokens))
 }
 
-fn read_uncached(jit: &WhisperDecoderJit) -> Result<Vec<f32>> {
+fn read_uncached(jit: &WhisperDecoderJit, n_vocab: usize) -> Result<Vec<f32>> {
     let buf = jit.output().context(JitSnafu)?;
-    read_buf(buf, buf.size() / std::mem::size_of::<f32>())
+    read_buf(buf, n_vocab)
 }
 
 /// Write data directly into the buffer's host-visible mapping.

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -6,6 +6,8 @@ use super::error::{DeviceSnafu, Error, JitSnafu, Result};
 use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
 use super::tokenizer::WhisperTokenizer;
 use snafu::ResultExt;
+use std::cmp::Ordering;
+use std::collections::VecDeque;
 use svod_arch::pipelines::audio::Segment;
 
 // ─── Language detection ─────────────────────────────────────────────────────
@@ -190,6 +192,10 @@ fn valid_temperature(temperature: f32) -> bool {
     temperature.is_finite() && temperature > 0.0
 }
 
+pub(crate) fn remaining_sample_steps(sample_len: usize) -> usize {
+    sample_len.saturating_sub(1)
+}
+
 #[derive(Clone, Debug)]
 pub struct DecodeResult {
     pub tokens: Vec<u32>,
@@ -346,6 +352,11 @@ pub fn greedy_decode_cached(
     let mut sum_logprob = log_softmax(&filtered, next_token as usize);
     let no_speech_prob = ctx.no_speech_prob;
 
+    let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
+    if sample_len == 0 {
+        return finish_decode(&[], &[], tokenizer, 0.0, no_speech_prob, options);
+    }
+
     let mut tokens = Vec::new();
     let mut token_probs = Vec::new();
     if next_token != tokenizer.eot() {
@@ -353,9 +364,9 @@ pub fn greedy_decode_cached(
         token_probs.push(sum_logprob.exp());
     }
 
-    let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
-
-    for step in 0..sample_len {
+    // Prefill produced generated token 1, so only the remaining budget needs
+    // decoder-step dispatches.
+    for step in 0..remaining_sample_steps(sample_len) {
         if next_token == tokenizer.eot() {
             break;
         }
@@ -398,254 +409,551 @@ pub fn greedy_decode_cached(
     finish_decode(&tokens, &token_probs, tokenizer, sum_logprob, no_speech_prob, options)
 }
 
-// ─── Batched (step-locked) greedy decode ────────────────────────────────────
-//
-// The continuous-batching primitive: N lanes each carry independent decode
-// state (one per audio window), and every token step runs as a single batched
-// JIT dispatch across all active lanes. Lanes that hit EOT drop out; the loop
-// ends when no lanes remain. This is the bandwidth-amortizing path — one
-// weight read serves all lanes.
-//
-// `DecodeLane` reuses the same `DecodeCtx` fields (prefill seeds them) and
-// adds the per-step loop state that `greedy_decode_cached` kept as locals.
+// ─── Fixed-slot mixed-strategy scheduler ────────────────────────────────────
 
-/// One independent decode (one audio window's greedy decode attempt).
-///
-/// Built by [`DecodeLane::prefill`] from the `[1,4]` prefill JIT; the KV
-/// caches then live in the lane and are packed into the batched step JIT's
-/// `max_lanes`-sized buffers at the lane's row offset each step.
-pub struct DecodeLane {
-    // Static-per-attempt state (set by prefill, read each step)
-    pub initial_tokens: Vec<u32>,
-    pub sample_begin: usize,
-    pub init_len: usize,
-    pub suppress_tokens: Vec<i32>,
-    pub no_speech_prob: f32,
-    pub pos_embedding: Vec<f32>,
-    pub n_state: usize,
-
-    // KV caches are seeded once into this lane's stable fixed-batch slot. The
-    // cache then grows on-device via SDMA writeback; lanes never compact.
-    pub self_k_cache: Vec<f32>,
-    pub self_v_cache: Vec<f32>,
-    pub cross_k: Vec<f32>,
-    pub cross_v: Vec<f32>,
-    pub seeded_row: Option<usize>,
-
-    // Per-step loop state (mutated each step)
-    pub next_token: u32,
-    pub tokens: Vec<u32>,
-    pub token_probs: Vec<f32>,
-    pub sum_logprob: f32,
-    pub pos: usize, // current position = init_len + step
-    pub done: bool,
+/// Immutable output of token prefill. Fallback attempts reuse this seed rather
+/// than rerunning prefill. Cache vectors are currently host-resident and are
+/// copied into a row only when that row changes request ownership.
+pub(crate) struct DecodeSeed {
+    ctx: DecodeCtx,
 }
 
-impl DecodeLane {
-    /// Run prefill for one window and build the lane state.
-    ///
-    /// `audio_raw` is the encoder output for this window, flat
-    /// `[N_AUDIO_CTX * n_audio_state]` f32 (the slice the existing
-    /// `decode_with_fallback_cached` passes to `init_decode`).
-    pub fn prefill(
-        prefill_jit: &mut WhisperPrefillJit,
-        tokenizer: &WhisperTokenizer,
-        options: &DecodeOptions,
-        n_text_ctx: usize,
-        n_vocab: usize,
-        pos_embedding: &[f32],
-        n_state: usize,
-    ) -> Result<Self> {
-        let ctx = init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)?;
-
-        // First token from prefill logits (mirrors greedy_decode_cached:260-278)
-        let last_logits = &ctx.prefill_logits[(ctx.init_len - 1) * n_vocab..ctx.init_len * n_vocab];
-        let mut filtered = last_logits.to_vec();
-        apply_logit_filters(
-            &mut filtered,
-            tokenizer,
-            options,
-            &ctx.initial_tokens,
-            ctx.sample_begin,
-            0,
-            &ctx.suppress_tokens,
-        );
-        let next_token = pick_token(&filtered, options.strategy.temperature());
-        let sum_logprob = log_softmax(&filtered, next_token as usize);
-
-        let mut tokens = Vec::new();
-        let mut token_probs = Vec::new();
-        if next_token != tokenizer.eot() {
-            tokens.push(next_token);
-            token_probs.push(sum_logprob.exp());
-        }
-
-        Ok(Self {
-            initial_tokens: ctx.initial_tokens,
-            sample_begin: ctx.sample_begin,
-            init_len: ctx.init_len,
-            suppress_tokens: ctx.suppress_tokens,
-            no_speech_prob: ctx.no_speech_prob,
-            pos_embedding: ctx.pos_embedding,
-            n_state: ctx.n_state,
-            self_k_cache: ctx.self_k_cache,
-            self_v_cache: ctx.self_v_cache,
-            cross_k: ctx.cross_k,
-            cross_v: ctx.cross_v,
-            seeded_row: None,
-            next_token,
-            tokens,
-            token_probs,
-            sum_logprob,
-            pos: ctx.init_len, // first step decodes at init_len
-            done: next_token == tokenizer.eot(),
-        })
-    }
-
-    /// Per-position floats in the self cache: `n_layer * n_head * d_head`.
-    fn per_pos_floats(&self) -> usize {
-        self.self_k_cache.len() / self.init_len
-    }
-
-    fn per_pos_bytes(&self) -> usize {
-        self.per_pos_floats() * std::mem::size_of::<f32>()
-    }
-
-    pub fn finish(self, tokenizer: &WhisperTokenizer, options: &DecodeOptions) -> Result<DecodeResult> {
-        finish_decode(&self.tokens, &self.token_probs, tokenizer, self.sum_logprob, self.no_speech_prob, options)
-    }
-}
-
-/// Step-locked batched greedy decode: advances every active lane by one token
-/// per JIT dispatch, until all lanes are `done` or hit `sample_len`.
-///
-/// Each lane occupies a stable row (`lane_idx`) in a concrete fixed-capacity
-/// graph. Inactive rows still execute but their outputs are ignored.
-#[allow(clippy::too_many_arguments)]
-pub fn run_batched_decode(
-    lanes: &mut [DecodeLane],
-    step_jit: &mut WhisperDecoderStepJit,
-    capacity: usize,
+pub(crate) fn prefill_decode_seed(
+    prefill_jit: &mut WhisperPrefillJit,
     tokenizer: &WhisperTokenizer,
     options: &DecodeOptions,
     n_text_ctx: usize,
     n_vocab: usize,
+    pos_embedding: &[f32],
+    n_state: usize,
+) -> Result<DecodeSeed> {
+    Ok(DecodeSeed { ctx: init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)? })
+}
+
+pub(crate) fn strategy_width(strategy: DecodeStrategy) -> usize {
+    match strategy {
+        DecodeStrategy::Beam { size } => size,
+        DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => 1,
+    }
+}
+
+pub(crate) fn attempt_strategies(options: &DecodeOptions) -> Vec<DecodeStrategy> {
+    let mut strategies = vec![options.strategy];
+    if let Some(fallback) = &options.fallback {
+        strategies
+            .extend(fallback.sampling_temperatures.iter().map(|&temperature| DecodeStrategy::Sample { temperature }));
+    }
+    strategies
+}
+
+pub(crate) fn collect_ordered<T>(results: Vec<Option<T>>) -> std::result::Result<Vec<T>, &'static str> {
+    results.into_iter().map(|result| result.ok_or("missing scheduled result")).collect()
+}
+
+/// Small independently-testable allocator enforcing whole-attempt admission.
+#[derive(Debug)]
+pub(crate) struct SlotAllocator {
+    owners: Vec<Option<usize>>,
+}
+
+impl SlotAllocator {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self { owners: vec![None; capacity] }
+    }
+
+    pub(crate) fn reserve(
+        &mut self,
+        owner: usize,
+        width: usize,
+    ) -> std::result::Result<Option<Vec<usize>>, &'static str> {
+        if width == 0 {
+            return Err("attempt width must be non-zero");
+        }
+        if width > self.owners.len() {
+            return Err("decode attempt width exceeds decoder slots");
+        }
+        if self.owners.iter().filter(|slot| slot.is_none()).count() < width {
+            return Ok(None);
+        }
+        let rows: Vec<_> = self
+            .owners
+            .iter()
+            .enumerate()
+            .filter_map(|(row, current)| current.is_none().then_some(row))
+            .take(width)
+            .collect();
+        for &row in &rows {
+            self.owners[row] = Some(owner);
+        }
+        Ok(Some(rows))
+    }
+
+    pub(crate) fn release(&mut self, owner: usize) {
+        for slot in &mut self.owners {
+            if *slot == Some(owner) {
+                *slot = None;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn owners(&self) -> &[Option<usize>] {
+        &self.owners
+    }
+}
+
+struct SingleAttempt {
+    next_token: u32,
+    tokens: Vec<u32>,
+    token_probs: Vec<f32>,
+    sum_logprob: f32,
+}
+
+struct BeamAttempt {
+    active: Vec<BeamHypothesis>,
+    rows: Vec<usize>,
+    finished: Vec<BeamHypothesis>,
+    next_logical_id: usize,
+}
+
+enum AttemptKind {
+    Single(SingleAttempt),
+    Beam(BeamAttempt),
+}
+
+struct ScheduledAttempt {
+    strategy_index: usize,
+    strategy: DecodeStrategy,
+    reserved_rows: Vec<usize>,
+    pos: usize,
+    generated_tokens: usize,
+    kind: AttemptKind,
+}
+
+impl ScheduledAttempt {
+    fn is_done(&self, sample_len: usize, eot: u32) -> bool {
+        match &self.kind {
+            AttemptKind::Single(single) => {
+                sample_len == 0 || single.next_token == eot || single.tokens.len() >= sample_len
+            }
+            AttemptKind::Beam(beam) => {
+                sample_len == 0
+                    || self.generated_tokens >= sample_len
+                    || beam.active.is_empty()
+                    || beam.finished.len() >= self.reserved_rows.len()
+            }
+        }
+    }
+}
+
+fn start_attempt(
+    strategy_index: usize,
+    strategy: DecodeStrategy,
+    rows: Vec<usize>,
+    seed: &DecodeSeed,
+    tokenizer: &WhisperTokenizer,
+    options: &DecodeOptions,
+    n_vocab: usize,
+) -> Result<ScheduledAttempt> {
+    let ctx = &seed.ctx;
+    let last = ctx
+        .prefill_logits
+        .get((ctx.init_len - 1) * n_vocab..ctx.init_len * n_vocab)
+        .ok_or_else(|| decode_err("prefill logits are truncated"))?;
+    let mut filtered = last.to_vec();
+    apply_logit_filters(
+        &mut filtered,
+        tokenizer,
+        options,
+        &ctx.initial_tokens,
+        ctx.sample_begin,
+        0,
+        &ctx.suppress_tokens,
+    );
+    let kind = match strategy {
+        DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => {
+            if options.sample_len == Some(0) {
+                return Ok(ScheduledAttempt {
+                    strategy_index,
+                    strategy,
+                    reserved_rows: rows,
+                    pos: ctx.init_len,
+                    generated_tokens: 0,
+                    kind: AttemptKind::Single(SingleAttempt {
+                        next_token: tokenizer.eot(),
+                        tokens: Vec::new(),
+                        token_probs: Vec::new(),
+                        sum_logprob: 0.0,
+                    }),
+                });
+            }
+            let next_token = pick_token(&filtered, strategy.temperature());
+            let sum_logprob = log_softmax(&filtered, next_token as usize);
+            let (tokens, token_probs) = if next_token == tokenizer.eot() {
+                (Vec::new(), Vec::new())
+            } else {
+                (vec![next_token], vec![sum_logprob.exp()])
+            };
+            AttemptKind::Single(SingleAttempt { next_token, tokens, token_probs, sum_logprob })
+        }
+        DecodeStrategy::Beam { size } => {
+            if options.sample_len == Some(0) {
+                let active = vec![BeamHypothesis {
+                    logical_id: 0,
+                    tokens: ctx.initial_tokens.clone(),
+                    token_probs: Vec::new(),
+                    sum_logprob: 0.0,
+                }];
+                return Ok(ScheduledAttempt {
+                    strategy_index,
+                    strategy,
+                    reserved_rows: rows.clone(),
+                    pos: ctx.init_len,
+                    generated_tokens: 0,
+                    kind: AttemptKind::Beam(BeamAttempt {
+                        active,
+                        rows: vec![rows[0]],
+                        finished: Vec::new(),
+                        next_logical_id: 1,
+                    }),
+                });
+            }
+            let mut ranked: Vec<_> = log_softmax_vec(&filtered).into_iter().enumerate().collect();
+            ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            let mut active = Vec::with_capacity(size);
+            let mut finished = Vec::new();
+            let mut next_logical_id = 0;
+            for (token, logprob) in ranked {
+                if active.len() >= size {
+                    break;
+                }
+                let mut tokens = ctx.initial_tokens.clone();
+                tokens.push(token as u32);
+                let hypothesis = BeamHypothesis {
+                    logical_id: next_logical_id,
+                    tokens,
+                    token_probs: vec![logprob.exp()],
+                    sum_logprob: logprob,
+                };
+                next_logical_id += 1;
+                if token as u32 == tokenizer.eot() {
+                    finished.push(hypothesis);
+                } else {
+                    active.push(hypothesis);
+                }
+            }
+            let active_rows = rows[..active.len()].to_vec();
+            AttemptKind::Beam(BeamAttempt { active, rows: active_rows, finished, next_logical_id })
+        }
+    };
+    Ok(ScheduledAttempt { strategy_index, strategy, reserved_rows: rows, pos: ctx.init_len, generated_tokens: 1, kind })
+}
+
+fn seed_attempt_rows(
+    jit: &mut WhisperDecoderStepJit,
+    rows: &[usize],
+    seed: &DecodeSeed,
+    n_text_ctx: usize,
 ) -> Result<()> {
-    let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
-    let eot = tokenizer.eot();
-    let n_state = lanes.first().map(|l| l.n_state).unwrap_or(0);
-    for lane in lanes.iter_mut() {
-        if lane.tokens.len() >= sample_len || lane.next_token == eot {
-            lane.done = true;
-        }
+    let ctx = &seed.ctx;
+    let per_pos = ctx.per_pos_floats();
+    let self_stride = n_text_ctx.checked_mul(per_pos).ok_or_else(|| decode_err("self cache stride overflow"))?;
+    let cross_stride = N_AUDIO_CTX.checked_mul(per_pos).ok_or_else(|| decode_err("cross cache stride overflow"))?;
+    for &row in rows {
+        copyin_cache_row(jit.self_k_cache_mut().context(JitSnafu)?, row, self_stride, &ctx.self_k_cache)?;
+        copyin_cache_row(jit.self_v_cache_mut().context(JitSnafu)?, row, self_stride, &ctx.self_v_cache)?;
+        copyin_cache_row(jit.cross_k_mut().context(JitSnafu)?, row, cross_stride, &ctx.cross_k)?;
+        copyin_cache_row(jit.cross_v_mut().context(JitSnafu)?, row, cross_stride, &ctx.cross_v)?;
     }
-    let mut owners: Vec<Option<usize>> = vec![None; capacity];
-    let mut next_lane = 0usize;
-
-    loop {
-        for owner in &mut owners {
-            if owner.is_some_and(|lane_index| lanes[lane_index].done) {
-                *owner = None;
-            }
-            if owner.is_none() {
-                while next_lane < lanes.len() && lanes[next_lane].done {
-                    next_lane += 1;
-                }
-                if next_lane < lanes.len() {
-                    *owner = Some(next_lane);
-                    next_lane += 1;
-                }
-            }
-        }
-
-        let active: Vec<(usize, usize)> =
-            owners.iter().enumerate().filter_map(|(slot, &owner)| owner.map(|lane_index| (slot, lane_index))).collect();
-        if active.is_empty() {
-            break;
-        }
-        // Per-position float count and buffer row strides. All lanes share
-        // the same structural dims, so read them from the first active lane.
-        let per_pos_floats = lanes[active[0].1].per_pos_floats();
-        let self_row_stride = n_text_ctx * per_pos_floats; // [max_lanes, N_TEXT_CTX, ...]
-        let cross_row_stride = N_AUDIO_CTX * per_pos_floats; // [max_lanes, N_AUDIO_CTX, ...]
-
-        // Stable slots remove cache relocation when another lane finishes.
-        for &(row, lane_idx) in &active {
-            let lane = &mut lanes[lane_idx];
-            write_token_row(step_jit, row, lane.next_token)?;
-            write_pos_emb_row(step_jit, row, &lane.pos_embedding[lane.pos * n_state..(lane.pos + 1) * n_state])?;
-            write_self_mask_row(step_jit, row, lane.pos, n_text_ctx)?;
-
-            if lane.seeded_row.is_none() {
-                copyin_cache_row(
-                    step_jit.self_k_cache_mut().context(JitSnafu)?,
-                    row,
-                    self_row_stride,
-                    &lane.self_k_cache,
-                )?;
-                copyin_cache_row(
-                    step_jit.self_v_cache_mut().context(JitSnafu)?,
-                    row,
-                    self_row_stride,
-                    &lane.self_v_cache,
-                )?;
-                copyin_cache_row(step_jit.cross_k_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_k)?;
-                copyin_cache_row(step_jit.cross_v_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_v)?;
-            }
-            lane.seeded_row = Some(row);
-        }
-
-        // The same concrete graph executes at every step. This keeps matrix
-        // dimensions static and makes the plan graph-capture eligible.
-        step_jit.execute().context(JitSnafu)?;
-
-        // Per-lane teardown: SDMA-writeback new K/V, read logits, pick token.
-        for &(row, lane_idx) in &active {
-            let lane = &mut lanes[lane_idx];
-
-            // Device-side K/V copy: append this step's new K/V at lane.pos.
-            // Input buffer is [max_lanes, N_TEXT_CTX, ...]; this lane's row
-            // starts at row*N_TEXT_CTX*per_pos_floats*4, position `pos` within
-            // that row. Output buffer is [active_count, 1, ...]; the `row`-th
-            // lane's new K/V is at row*per_pos_floats*4.
-            let per_pos_b = lane.per_pos_bytes();
-            let dst_base = row * self_row_stride * std::mem::size_of::<f32>();
-            let dst_off = dst_base + lane.pos * per_pos_b;
-            let src_off = row * per_pos_b;
-            step_jit.copy_output_to_self_k_cache(1, dst_off, src_off, per_pos_b).context(JitSnafu)?;
-            step_jit.copy_output_to_self_v_cache(2, dst_off, src_off, per_pos_b).context(JitSnafu)?;
-
-            // Read this lane's logits row and pick the next token.
-            let logits = read_logits_row(step_jit, row, n_vocab)?;
-
-            let all_toks: Vec<u32> = lane.initial_tokens.iter().copied().chain(lane.tokens.iter().copied()).collect();
-            let step = lane.pos + 1 - lane.init_len;
-            let mut filtered = logits;
-            apply_logit_filters(
-                &mut filtered,
-                tokenizer,
-                options,
-                &all_toks,
-                lane.sample_begin,
-                step,
-                &lane.suppress_tokens,
-            );
-            lane.next_token = pick_token(&filtered, options.strategy.temperature());
-            let token_logprob = log_softmax(&filtered, lane.next_token as usize);
-            lane.sum_logprob += token_logprob;
-
-            if lane.next_token != eot {
-                lane.tokens.push(lane.next_token);
-                lane.token_probs.push(token_logprob.exp());
-            }
-            lane.pos += 1;
-            if lane.next_token == eot || lane.tokens.len() >= sample_len {
-                lane.done = true;
-            }
-        }
-    }
-
     Ok(())
+}
+
+fn append_row_cache(
+    jit: &mut WhisperDecoderStepJit,
+    row: usize,
+    pos: usize,
+    per_pos_bytes: usize,
+    row_stride_bytes: usize,
+) -> Result<()> {
+    let dst = row
+        .checked_mul(row_stride_bytes)
+        .and_then(|base| pos.checked_mul(per_pos_bytes).and_then(|offset| base.checked_add(offset)))
+        .ok_or_else(|| decode_err("self cache append offset overflow"))?;
+    let src = row.checked_mul(per_pos_bytes).ok_or_else(|| decode_err("step cache output offset overflow"))?;
+    jit.copy_output_to_self_k_cache(1, dst, src, per_pos_bytes).context(JitSnafu)?;
+    jit.copy_output_to_self_v_cache(2, dst, src, per_pos_bytes).context(JitSnafu)
+}
+
+fn clone_cache_prefix(
+    jit: &mut WhisperDecoderStepJit,
+    copies: &[CacheCopy],
+    positions: usize,
+    per_pos_bytes: usize,
+    row_stride_bytes: usize,
+) -> Result<()> {
+    let len = positions.checked_mul(per_pos_bytes).ok_or_else(|| decode_err("cache prefix length overflow"))?;
+    for copy in copies {
+        let src =
+            copy.src_row.checked_mul(row_stride_bytes).ok_or_else(|| decode_err("cache source offset overflow"))?;
+        let dst = copy
+            .dst_row
+            .checked_mul(row_stride_bytes)
+            .ok_or_else(|| decode_err("cache destination offset overflow"))?;
+        jit.self_k_cache_mut().context(JitSnafu)?.copy_within(dst, src, len).context(DeviceSnafu)?;
+        jit.self_v_cache_mut().context(JitSnafu)?.copy_within(dst, src, len).context(DeviceSnafu)?;
+    }
+    Ok(())
+}
+
+fn finish_attempt(
+    attempt: ScheduledAttempt,
+    seed: &DecodeSeed,
+    tokenizer: &WhisperTokenizer,
+    options: &DecodeOptions,
+) -> Result<DecodeResult> {
+    match attempt.kind {
+        AttemptKind::Single(single) => finish_decode(
+            &single.tokens,
+            &single.token_probs,
+            tokenizer,
+            if options.sample_len == Some(0) { 0.0 } else { single.sum_logprob },
+            seed.ctx.no_speech_prob,
+            options,
+        ),
+        AttemptKind::Beam(beam) => {
+            let size = attempt.reserved_rows.len();
+            let best =
+                finalize_beam_hypotheses(beam.active, beam.finished, size, tokenizer.eot(), seed.ctx.sample_begin)
+                    .ok_or_else(|| decode_err("beam produced nothing"))?;
+            let tokens: Vec<_> = best.tokens[seed.ctx.sample_begin..]
+                .iter()
+                .copied()
+                .take_while(|&token| token != tokenizer.eot())
+                .collect();
+            let token_probs = best.token_probs.into_iter().take(tokens.len()).collect::<Vec<_>>();
+            finish_decode(&tokens, &token_probs, tokenizer, best.sum_logprob, seed.ctx.no_speech_prob, options)
+        }
+    }
+}
+
+/// Decode all requests through one concrete `[decoder_slots, ...]` step graph.
+/// Attempts reserve their full width atomically and retain every reserved row,
+/// including inactive beam rows, until quality acceptance or fallback requeue.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_fixed_slot_decode(
+    seeds: &[DecodeSeed],
+    request_options: &[DecodeOptions],
+    step_jit: &mut WhisperDecoderStepJit,
+    capacity: usize,
+    tokenizer: &WhisperTokenizer,
+    n_text_ctx: usize,
+    n_vocab: usize,
+) -> Result<Vec<DecodeResult>> {
+    if seeds.len() != request_options.len() {
+        return Err(decode_err("decode seed/options count mismatch"));
+    }
+    for options in request_options {
+        options.validate().map_err(decode_err)?;
+        for strategy in attempt_strategies(options) {
+            if strategy_width(strategy) > capacity {
+                return Err(decode_err("decode attempt width exceeds decoder slots"));
+            }
+        }
+    }
+
+    let strategies: Vec<_> = request_options.iter().map(attempt_strategies).collect();
+    let mut queue: VecDeque<_> = (0..seeds.len()).map(|request| (request, 0usize)).collect();
+    let mut allocator = SlotAllocator::new(capacity);
+    let mut attempts: Vec<Option<ScheduledAttempt>> = (0..seeds.len()).map(|_| None).collect();
+    let mut results: Vec<Option<DecodeResult>> = (0..seeds.len()).map(|_| None).collect();
+
+    while results.iter().any(Option::is_none) {
+        while let Some(&(request, strategy_index)) = queue.front() {
+            let strategy = strategies[request][strategy_index];
+            let Some(rows) = allocator.reserve(request, strategy_width(strategy)).map_err(decode_err)? else {
+                break;
+            };
+            queue.pop_front();
+            let mut options = request_options[request].clone();
+            options.strategy = strategy;
+            let attempt = start_attempt(strategy_index, strategy, rows, &seeds[request], tokenizer, &options, n_vocab)?;
+            seed_attempt_rows(step_jit, &attempt.reserved_rows, &seeds[request], n_text_ctx)?;
+            attempts[request] = Some(attempt);
+        }
+
+        let active_requests: Vec<_> =
+            attempts.iter().enumerate().filter_map(|(request, attempt)| attempt.as_ref().map(|_| request)).collect();
+        if active_requests.is_empty() {
+            return Err(decode_err("fixed-slot scheduler made no progress"));
+        }
+
+        // Attempts that finish from prefill (EOT or zero budget) need no graph dispatch.
+        let mut dispatch = false;
+        for &request in &active_requests {
+            let attempt = attempts[request].as_ref().expect("active attempt");
+            let sample_len = request_options[request].sample_len.unwrap_or(n_text_ctx / 2);
+            if attempt.is_done(sample_len, tokenizer.eot()) {
+                continue;
+            }
+            let seed = &seeds[request].ctx;
+            match &attempt.kind {
+                AttemptKind::Single(single) => {
+                    let row = attempt.reserved_rows[0];
+                    write_token_row(step_jit, row, single.next_token)?;
+                    write_pos_emb_row(
+                        step_jit,
+                        row,
+                        seed.pos_embedding
+                            .get(attempt.pos * seed.n_state..(attempt.pos + 1) * seed.n_state)
+                            .ok_or_else(|| decode_err("position embedding is out of bounds"))?,
+                    )?;
+                    write_self_mask_row(step_jit, row, attempt.pos, n_text_ctx)?;
+                }
+                AttemptKind::Beam(beam) => {
+                    for (hypothesis, &row) in beam.active.iter().zip(&beam.rows) {
+                        write_token_row(
+                            step_jit,
+                            row,
+                            *hypothesis.tokens.last().ok_or_else(|| decode_err("empty beam"))?,
+                        )?;
+                        write_pos_emb_row(
+                            step_jit,
+                            row,
+                            seed.pos_embedding
+                                .get(attempt.pos * seed.n_state..(attempt.pos + 1) * seed.n_state)
+                                .ok_or_else(|| decode_err("position embedding is out of bounds"))?,
+                        )?;
+                        write_self_mask_row(step_jit, row, attempt.pos, n_text_ctx)?;
+                    }
+                }
+            }
+            dispatch = true;
+        }
+
+        if dispatch {
+            step_jit.execute().context(JitSnafu)?;
+            for &request in &active_requests {
+                let attempt = attempts[request].as_mut().expect("active attempt");
+                let sample_len = request_options[request].sample_len.unwrap_or(n_text_ctx / 2);
+                if attempt.is_done(sample_len, tokenizer.eot()) {
+                    continue;
+                }
+                let seed = &seeds[request].ctx;
+                let per_pos_bytes = seed.per_pos_bytes();
+                let row_stride_bytes = n_text_ctx
+                    .checked_mul(per_pos_bytes)
+                    .ok_or_else(|| decode_err("self cache row stride overflow"))?;
+                let mut options = request_options[request].clone();
+                options.strategy = attempt.strategy;
+                match &mut attempt.kind {
+                    AttemptKind::Single(single) => {
+                        let row = attempt.reserved_rows[0];
+                        append_row_cache(step_jit, row, attempt.pos, per_pos_bytes, row_stride_bytes)?;
+                        let mut logits = read_logits_row(step_jit, row, n_vocab)?;
+                        let all_tokens: Vec<_> =
+                            seed.initial_tokens.iter().copied().chain(single.tokens.iter().copied()).collect();
+                        apply_logit_filters(
+                            &mut logits,
+                            tokenizer,
+                            &options,
+                            &all_tokens,
+                            seed.sample_begin,
+                            attempt.pos + 1 - seed.init_len,
+                            &seed.suppress_tokens,
+                        );
+                        single.next_token = pick_token(&logits, attempt.strategy.temperature());
+                        let logprob = log_softmax(&logits, single.next_token as usize);
+                        single.sum_logprob += logprob;
+                        if single.next_token != tokenizer.eot() {
+                            single.tokens.push(single.next_token);
+                            single.token_probs.push(logprob.exp());
+                        }
+                    }
+                    AttemptKind::Beam(beam) => {
+                        for &row in &beam.rows {
+                            append_row_cache(step_jit, row, attempt.pos, per_pos_bytes, row_stride_bytes)?;
+                        }
+                        let size = attempt.reserved_rows.len();
+                        let mut candidates = Vec::new();
+                        for (parent_index, (hypothesis, &row)) in beam.active.iter().zip(&beam.rows).enumerate() {
+                            let mut logits = read_logits_row(step_jit, row, n_vocab)?;
+                            apply_logit_filters(
+                                &mut logits,
+                                tokenizer,
+                                &options,
+                                &hypothesis.tokens,
+                                seed.sample_begin,
+                                attempt.pos + 1 - seed.init_len,
+                                &seed.suppress_tokens,
+                            );
+                            let mut ranked: Vec<_> = log_softmax_vec(&logits).into_iter().enumerate().collect();
+                            ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                            for (token, logprob) in ranked.into_iter().take(size + 1) {
+                                candidates.push(BeamCandidate {
+                                    parent_index,
+                                    parent_logical_id: hypothesis.logical_id,
+                                    parent_row: row,
+                                    token_id: token as u32,
+                                    token_logprob: logprob,
+                                    sum_logprob: hypothesis.sum_logprob + logprob,
+                                });
+                            }
+                        }
+                        let (active, newly_finished, survivors) = select_beam_candidates(
+                            &beam.active,
+                            candidates,
+                            size,
+                            tokenizer.eot(),
+                            size - beam.finished.len(),
+                            &mut beam.next_logical_id,
+                        );
+                        beam.finished.extend(newly_finished);
+                        let assignment = plan_beam_rows(&attempt.reserved_rows, &survivors).map_err(decode_err)?;
+                        clone_cache_prefix(
+                            step_jit,
+                            &assignment.copies,
+                            attempt.pos + 1,
+                            per_pos_bytes,
+                            row_stride_bytes,
+                        )?;
+                        beam.active = active;
+                        beam.rows = assignment.rows;
+                    }
+                }
+                attempt.pos += 1;
+                attempt.generated_tokens += 1;
+            }
+        }
+
+        for request in active_requests {
+            let sample_len = request_options[request].sample_len.unwrap_or(n_text_ctx / 2);
+            let done = attempts[request]
+                .as_ref()
+                .is_some_and(|attempt| attempt.is_done(sample_len, tokenizer.eot()) || attempt.pos >= n_text_ctx);
+            if !done {
+                continue;
+            }
+            let attempt = attempts[request].take().expect("completed attempt");
+            let strategy_index = attempt.strategy_index;
+            let mut options = request_options[request].clone();
+            options.strategy = attempt.strategy;
+            options.fallback = None;
+            let result = finish_attempt(attempt, &seeds[request], tokenizer, &options)?;
+            allocator.release(request);
+            let retry = strategies[request].get(strategy_index + 1).is_some()
+                && request_options[request]
+                    .fallback
+                    .as_ref()
+                    .is_some_and(|fallback| check_fallback(&result, fallback, &request_options[request]));
+            if retry {
+                queue.push_back((request, strategy_index + 1));
+            } else {
+                results[request] = Some(result);
+            }
+        }
+    }
+
+    collect_ordered(results).map_err(decode_err)
 }
 
 // ─── Batched JIT buffer row helpers ─────────────────────────────────────────
@@ -657,10 +965,11 @@ fn write_token_row(jit: &mut WhisperDecoderStepJit, row: usize, token: u32) -> R
     let buf = jit.token_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     // token is [max_lanes, 1] i32; row stride = 4 bytes
-    let off = row * std::mem::size_of::<i32>();
+    let off = row.checked_mul(std::mem::size_of::<i32>()).ok_or_else(|| decode_err("token row offset overflow"))?;
     let tok = [token as i32];
     let bytes: &[u8] = bytemuck::cast_slice(&tok);
-    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    let target = dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("token row is out of bounds"))?;
+    target.copy_from_slice(bytes);
     Ok(())
 }
 
@@ -668,9 +977,12 @@ fn write_pos_emb_row(jit: &mut WhisperDecoderStepJit, row: usize, emb: &[f32]) -
     let buf = jit.pos_emb_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     // pos_emb is [max_lanes, 1, n_state] f32
-    let off = row * emb.len() * std::mem::size_of::<f32>();
+    let row_bytes =
+        emb.len().checked_mul(std::mem::size_of::<f32>()).ok_or_else(|| decode_err("position row stride overflow"))?;
+    let off = row.checked_mul(row_bytes).ok_or_else(|| decode_err("position row offset overflow"))?;
     let bytes: &[u8] = bytemuck::cast_slice(emb);
-    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    let target = dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("position row is out of bounds"))?;
+    target.copy_from_slice(bytes);
     Ok(())
 }
 
@@ -678,15 +990,20 @@ fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, 
     let buf = jit.self_mask_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     // mask is [max_lanes, 1, 1, n_text_ctx + 1]; row stride = (n_text_ctx+1)*4
-    let stride = (n_text_ctx + 1) * std::mem::size_of::<f32>();
-    let off = row * stride;
+    let stride = n_text_ctx
+        .checked_add(1)
+        .and_then(|positions| positions.checked_mul(std::mem::size_of::<f32>()))
+        .ok_or_else(|| decode_err("mask row stride overflow"))?;
+    let off = row.checked_mul(stride).ok_or_else(|| decode_err("mask row offset overflow"))?;
     // [0..pos) = 0.0 (attend), [pos..n_text_ctx) = -inf (mask), [n_text_ctx] = 0.0
     let mut mask = vec![0f32; n_text_ctx + 1];
-    for v in &mut mask[pos..n_text_ctx] {
+    let masked = mask.get_mut(pos..n_text_ctx).ok_or_else(|| decode_err("decoder position exceeds text context"))?;
+    for v in masked {
         *v = f32::NEG_INFINITY;
     }
     let bytes: &[u8] = bytemuck::cast_slice(&mask);
-    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    let target = dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("mask row is out of bounds"))?;
+    target.copy_from_slice(bytes);
     Ok(())
 }
 
@@ -697,8 +1014,15 @@ fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, 
 /// cache after prefill). Used for one-time seeding; the cache then grows
 /// on-device via SDMA append.
 fn copyin_cache_row(buf: &mut svod_device::Buffer, row: usize, row_stride_floats: usize, data: &[f32]) -> Result<()> {
-    let off = row * row_stride_floats * std::mem::size_of::<f32>();
+    let row_bytes = row_stride_floats
+        .checked_mul(std::mem::size_of::<f32>())
+        .ok_or_else(|| decode_err("cache row stride overflow"))?;
+    let off = row.checked_mul(row_bytes).ok_or_else(|| decode_err("cache row offset overflow"))?;
     let bytes: &[u8] = bytemuck::cast_slice(data);
+    let end = off.checked_add(bytes.len()).ok_or_else(|| decode_err("cache seed end overflow"))?;
+    if end > buf.size() || bytes.len() > row_bytes {
+        return Err(decode_err("cache seed row is out of bounds"));
+    }
     buf.copyin_at(off, bytes).context(DeviceSnafu)
 }
 
@@ -706,18 +1030,167 @@ fn copyin_cache_row(buf: &mut svod_device::Buffer, row: usize, row_stride_floats
 fn read_logits_row(jit: &mut WhisperDecoderStepJit, row: usize, n_vocab: usize) -> Result<Vec<f32>> {
     let buf = jit.logits().context(JitSnafu)?;
     let src = buf.as_host_bytes().context(DeviceSnafu)?;
-    let row_floats = n_vocab;
-    let off = row * row_floats * std::mem::size_of::<f32>();
-    let end = off + row_floats * std::mem::size_of::<f32>();
-    Ok(bytemuck::cast_slice(&src[off..end]).to_vec())
+    let row_bytes = n_vocab.checked_mul(std::mem::size_of::<f32>()).ok_or_else(|| decode_err("logits row overflow"))?;
+    let off = row.checked_mul(row_bytes).ok_or_else(|| decode_err("logits offset overflow"))?;
+    let end = off.checked_add(row_bytes).ok_or_else(|| decode_err("logits end overflow"))?;
+    let logits = src.get(off..end).ok_or_else(|| decode_err("logits row is out of bounds"))?;
+    Ok(bytemuck::cast_slice(logits).to_vec())
 }
 
 // ─── Cached beam search ─────────────────────────────────────────────────────
 
-struct Beam {
-    tokens: Vec<u32>,
-    token_probs: Vec<f32>,
-    sum_logprob: f32,
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct BeamHypothesis {
+    /// Stable search identity. Decoder rows are deliberately not part of it.
+    pub(crate) logical_id: usize,
+    pub(crate) tokens: Vec<u32>,
+    pub(crate) token_probs: Vec<f32>,
+    pub(crate) sum_logprob: f32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct BeamCandidate {
+    pub(crate) parent_index: usize,
+    pub(crate) parent_logical_id: usize,
+    pub(crate) parent_row: usize,
+    pub(crate) token_id: u32,
+    pub(crate) token_logprob: f32,
+    pub(crate) sum_logprob: f32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BeamSurvivor {
+    pub(crate) logical_id: usize,
+    pub(crate) parent_row: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CacheCopy {
+    pub(crate) src_row: usize,
+    pub(crate) dst_row: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RowAssignment {
+    /// Destination row for each survivor, in survivor (logical rank) order.
+    pub(crate) rows: Vec<usize>,
+    pub(crate) copies: Vec<CacheCopy>,
+}
+
+/// Assign fixed decoder rows without scratch storage or copy cycles.
+///
+/// The first selected child of each parent retains that parent's row. Further
+/// children use only reserved rows whose old hypotheses are no longer live.
+pub(crate) fn plan_beam_rows(
+    reserved_rows: &[usize],
+    survivors: &[BeamSurvivor],
+) -> std::result::Result<RowAssignment, &'static str> {
+    let mut unique_reserved = reserved_rows.to_vec();
+    unique_reserved.sort_unstable();
+    unique_reserved.dedup();
+    if unique_reserved.len() != reserved_rows.len() {
+        return Err("reserved beam rows must be unique");
+    }
+    if survivors.len() > reserved_rows.len() {
+        return Err("more survivors than reserved beam rows");
+    }
+    if survivors.iter().any(|survivor| !unique_reserved.contains(&survivor.parent_row)) {
+        return Err("survivor parent row is not reserved");
+    }
+
+    let mut live_parent_rows = Vec::new();
+    for survivor in survivors {
+        if !live_parent_rows.contains(&survivor.parent_row) {
+            live_parent_rows.push(survivor.parent_row);
+        }
+    }
+    let mut dead_rows = reserved_rows.iter().copied().filter(|row| !live_parent_rows.contains(row));
+    let mut retained = Vec::new();
+    let mut rows = Vec::with_capacity(survivors.len());
+    let mut copies = Vec::new();
+    for survivor in survivors {
+        if !retained.contains(&survivor.parent_row) {
+            retained.push(survivor.parent_row);
+            rows.push(survivor.parent_row);
+        } else {
+            let dst_row = dead_rows.next().ok_or("insufficient inactive rows for duplicate beam children")?;
+            rows.push(dst_row);
+            copies.push(CacheCopy { src_row: survivor.parent_row, dst_row });
+        }
+    }
+    Ok(RowAssignment { rows, copies })
+}
+
+fn candidate_order(a: &BeamCandidate, b: &BeamCandidate) -> Ordering {
+    b.sum_logprob
+        .total_cmp(&a.sum_logprob)
+        .then_with(|| a.parent_logical_id.cmp(&b.parent_logical_id))
+        .then_with(|| a.token_id.cmp(&b.token_id))
+        .then_with(|| a.parent_index.cmp(&b.parent_index))
+}
+
+/// Deterministically rank candidates and split completed from active children.
+pub(crate) fn select_beam_candidates(
+    parents: &[BeamHypothesis],
+    mut candidates: Vec<BeamCandidate>,
+    beam_size: usize,
+    eot: u32,
+    finished_capacity: usize,
+    next_logical_id: &mut usize,
+) -> (Vec<BeamHypothesis>, Vec<BeamHypothesis>, Vec<BeamSurvivor>) {
+    candidates.sort_by(candidate_order);
+    let mut active = Vec::with_capacity(beam_size);
+    let mut finished = Vec::new();
+    let mut survivors = Vec::with_capacity(beam_size);
+    for candidate in candidates {
+        if active.len() >= beam_size {
+            break;
+        }
+        let Some(parent) = parents.get(candidate.parent_index) else {
+            continue;
+        };
+        let logical_id = *next_logical_id;
+        *next_logical_id += 1;
+        let mut child = parent.clone();
+        child.logical_id = logical_id;
+        child.tokens.push(candidate.token_id);
+        child.token_probs.push(candidate.token_logprob.exp());
+        child.sum_logprob = candidate.sum_logprob;
+        if candidate.token_id == eot {
+            if finished.len() < finished_capacity {
+                finished.push(child);
+            }
+        } else {
+            active.push(child);
+            survivors.push(BeamSurvivor { logical_id, parent_row: candidate.parent_row });
+        }
+    }
+    (active, finished, survivors)
+}
+
+/// Backfill unfinished hypotheses with EOT and choose the normalized best.
+pub(crate) fn finalize_beam_hypotheses(
+    active: Vec<BeamHypothesis>,
+    mut finished: Vec<BeamHypothesis>,
+    beam_size: usize,
+    eot: u32,
+    sample_begin: usize,
+) -> Option<BeamHypothesis> {
+    for mut hypothesis in active {
+        if finished.len() >= beam_size {
+            break;
+        }
+        if hypothesis.tokens.last().is_none_or(|&token| token != eot) {
+            hypothesis.tokens.push(eot);
+        }
+        finished.push(hypothesis);
+    }
+    finished.sort_by(|a, b| {
+        let a_score = a.sum_logprob / a.tokens.len().saturating_sub(sample_begin + 1).max(1) as f32;
+        let b_score = b.sum_logprob / b.tokens.len().saturating_sub(sample_begin + 1).max(1) as f32;
+        b_score.total_cmp(&a_score).then_with(|| a.logical_id.cmp(&b.logical_id))
+    });
+    finished.into_iter().next()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -753,27 +1226,51 @@ pub fn beam_decode_cached(
     let prefill_logprobs = log_softmax_vec(&filtered);
 
     let mut indexed: Vec<(usize, f32)> = prefill_logprobs.into_iter().enumerate().collect();
-    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    indexed.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     let mut beams = Vec::new();
     let mut finished = Vec::new();
+    let mut next_logical_id = 0;
+    if sample_len == 0 {
+        beams.push(BeamHypothesis {
+            logical_id: next_logical_id,
+            tokens: ctx.initial_tokens.clone(),
+            token_probs: Vec::new(),
+            sum_logprob: 0.0,
+        });
+        next_logical_id += 1;
+    }
     for (tok_id, lp) in &indexed {
+        if sample_len == 0 {
+            break;
+        }
         if beams.len() >= beam_size {
             break;
         }
         let mut toks = ctx.initial_tokens.clone();
         toks.push(*tok_id as u32);
         if *tok_id as u32 == eot {
-            finished.push(Beam { tokens: toks, token_probs: vec![lp.exp()], sum_logprob: *lp });
+            finished.push(BeamHypothesis {
+                logical_id: next_logical_id,
+                tokens: toks,
+                token_probs: vec![lp.exp()],
+                sum_logprob: *lp,
+            });
         } else {
-            beams.push(Beam { tokens: toks, token_probs: vec![lp.exp()], sum_logprob: *lp });
+            beams.push(BeamHypothesis {
+                logical_id: next_logical_id,
+                tokens: toks,
+                token_probs: vec![lp.exp()],
+                sum_logprob: *lp,
+            });
         }
+        next_logical_id += 1;
     }
 
     let per_beam_floats = ctx.per_beam_floats(n_text_ctx);
     let sample_begin = ctx.sample_begin;
 
-    for step in 0..sample_len {
+    for step in 0..remaining_sample_steps(sample_len) {
         if beams.is_empty() || finished.len() >= beam_size {
             break;
         }
@@ -796,13 +1293,12 @@ pub fn beam_decode_cached(
         let all_logits = &ctx.logits_buf;
 
         // Generate + rank candidates
-        let mut candidates: Vec<(usize, usize, f32, f32)> = Vec::new();
+        let mut candidates = Vec::new();
         for (bi, beam) in beams.iter().enumerate() {
             let start = bi * n_vocab;
-            if start >= all_logits.len() {
-                continue;
-            }
-            let beam_logits = &all_logits[start..(start + n_vocab).min(all_logits.len())];
+            let Some(beam_logits) = all_logits.get(start..start + n_vocab) else {
+                return Err(decode_err("beam logits row is truncated"));
+            };
             let mut filtered = beam_logits.to_vec();
             apply_logit_filters(
                 &mut filtered,
@@ -815,36 +1311,29 @@ pub fn beam_decode_cached(
             );
             let logprobs = log_softmax_vec(&filtered);
             let mut idx: Vec<(usize, f32)> = logprobs.iter().copied().enumerate().collect();
-            idx.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            idx.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             for (tok_id, lp) in idx.into_iter().take(beam_size + 1) {
-                candidates.push((bi, tok_id, lp, beam.sum_logprob + lp));
+                candidates.push(BeamCandidate {
+                    parent_index: bi,
+                    parent_logical_id: beam.logical_id,
+                    parent_row: bi,
+                    token_id: tok_id as u32,
+                    token_logprob: lp,
+                    sum_logprob: beam.sum_logprob + lp,
+                });
             }
         }
-        candidates.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(std::cmp::Ordering::Equal));
 
-        // Select survivors
-        let mut new_beams = Vec::with_capacity(beam_size);
-        let mut parent_map = Vec::with_capacity(beam_size);
-        for (parent_idx, tok_id, token_lp, sum_lp) in candidates {
-            if new_beams.len() >= beam_size {
-                break;
-            }
-            let mut toks = beams[parent_idx].tokens.clone();
-            let mut token_probs = beams[parent_idx].token_probs.clone();
-            toks.push(tok_id as u32);
-            token_probs.push(token_lp.exp());
-            if tok_id as u32 == eot {
-                if finished.len() < beam_size {
-                    finished.push(Beam { tokens: toks, token_probs, sum_logprob: sum_lp });
-                }
-            } else {
-                new_beams.push(Beam { tokens: toks, token_probs, sum_logprob: sum_lp });
-                parent_map.push(parent_idx);
-            }
-            if new_beams.len() >= beam_size {
-                break;
-            }
-        }
+        let (new_beams, newly_finished, survivors) = select_beam_candidates(
+            &beams,
+            candidates,
+            beam_size,
+            eot,
+            beam_size - finished.len(),
+            &mut next_logical_id,
+        );
+        finished.extend(newly_finished);
+        let parent_map: Vec<usize> = survivors.iter().map(|survivor| survivor.parent_row).collect();
 
         // Reorder cache by parent_map (host-side, copies ENTIRE cache incl new K/V)
         if !parent_map.is_empty() {
@@ -855,36 +1344,12 @@ pub fn beam_decode_cached(
         beams = new_beams;
 
         if beams.iter().all(|b| b.tokens.len() >= n_text_ctx) {
-            for b in beams.drain(..) {
-                let mut t = b.tokens;
-                if *t.last().unwrap() != eot {
-                    t.push(eot);
-                }
-                finished.push(Beam { tokens: t, token_probs: b.token_probs, sum_logprob: b.sum_logprob });
-            }
             break;
         }
     }
 
-    // Backfill + rank
-    for b in beams {
-        if finished.len() >= beam_size {
-            break;
-        }
-        let mut t = b.tokens;
-        if *t.last().unwrap() != eot {
-            t.push(eot);
-        }
-        finished.push(Beam { tokens: t, token_probs: b.token_probs, sum_logprob: b.sum_logprob });
-    }
-
-    finished.sort_by(|a, b| {
-        let la = a.sum_logprob / a.tokens.len().saturating_sub(ctx.sample_begin + 1).max(1) as f32;
-        let lb = b.sum_logprob / b.tokens.len().saturating_sub(ctx.sample_begin + 1).max(1) as f32;
-        lb.partial_cmp(&la).unwrap_or(std::cmp::Ordering::Equal)
-    });
-
-    let best = finished.into_iter().next().ok_or_else(|| decode_err("beam produced nothing"))?;
+    let best = finalize_beam_hypotheses(beams, finished, beam_size, eot, ctx.sample_begin)
+        .ok_or_else(|| decode_err("beam produced nothing"))?;
     let output_tokens: Vec<u32> = best.tokens[ctx.sample_begin..].iter().copied().take_while(|&t| t != eot).collect();
     let token_probs = best.token_probs.into_iter().take(output_tokens.len()).collect();
     let text = tokenizer.decode(&output_tokens);
@@ -962,7 +1427,7 @@ impl DecodeCtx {
     fn write_beam_inputs(
         &self,
         step_jit: &mut WhisperDecoderStepJit,
-        beams: &[Beam],
+        beams: &[BeamHypothesis],
         beam_size: usize,
         pos: usize,
         n_text_ctx: usize,

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -263,6 +263,13 @@ pub(crate) struct DecodeSeed {
     cross_positions: usize,
 }
 
+impl DecodeSeed {
+    /// Discard the attempt-local self cache and retain the immutable cross cache.
+    pub(crate) fn into_cross_kv(self) -> (Buffer, Buffer) {
+        (self.cross_k, self.cross_v)
+    }
+}
+
 pub(crate) fn prefill_decode_seed(
     prefill_jit: &mut WhisperPrefillJit,
     tokenizer: &WhisperTokenizer,

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -2,6 +2,7 @@
 
 use super::error::{DeviceSnafu, Error, JitSnafu, Result};
 use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
+use super::profile::{CopyProfile, begin_host_copy, timed_d2d};
 use super::tokenizer::WhisperTokenizer;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -27,12 +28,30 @@ pub fn detect_language(
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
 ) -> Result<LanguageDetection> {
+    detect_language_profile(decoder_jit, n_text_ctx, n_vocab, tokenizer, None)
+}
+
+pub(crate) fn detect_language_profile(
+    decoder_jit: &mut WhisperDecoderJit,
+    n_text_ctx: usize,
+    n_vocab: usize,
+    tokenizer: &WhisperTokenizer,
+    mut copies: Option<&mut CopyProfile>,
+) -> Result<LanguageDetection> {
     let sot = tokenizer.sot() as i32;
     let eot = tokenizer.eot() as i32;
     let token_buf: Vec<i32> = (0..n_text_ctx).map(|i| if i == 0 { sot } else { eot }).collect();
+    let started = begin_host_copy(copies.is_some(), decoder_jit.tokens_mut().context(JitSnafu)?)?;
     write_uncached(decoder_jit, &token_buf)?;
+    if let (Some(copies), Some(started)) = (copies.as_deref_mut(), started) {
+        copies.h2d("language_tokens", 1, token_buf.len() * std::mem::size_of::<i32>(), started.elapsed());
+    }
     decoder_jit.execute().context(JitSnafu)?;
+    let started = begin_host_copy(copies.is_some(), decoder_jit.output().context(JitSnafu)?)?;
     let flat = read_uncached(decoder_jit)?;
+    if let (Some(copies), Some(started)) = (copies, started) {
+        copies.d2h("language_logits", 1, flat.len() * std::mem::size_of::<f32>(), started.elapsed());
+    }
     let sot_logits = &flat[..n_vocab];
 
     let lang_tokens = tokenizer.all_language_tokens();
@@ -270,6 +289,7 @@ impl DecodeSeed {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn prefill_decode_seed(
     prefill_jit: &mut WhisperPrefillJit,
     tokenizer: &WhisperTokenizer,
@@ -278,12 +298,30 @@ pub(crate) fn prefill_decode_seed(
     n_vocab: usize,
     pos_embedding: &[f32],
     n_state: usize,
+    mut copies: Option<&mut CopyProfile>,
 ) -> Result<DecodeSeed> {
-    let metadata = execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state)?;
-    let self_k = clone_device_cache(prefill_jit.self_k().context(JitSnafu)?)?;
-    let self_v = clone_device_cache(prefill_jit.self_v().context(JitSnafu)?)?;
-    let cross_k = clone_device_cache(prefill_jit.prepared_cross_k_mut().context(JitSnafu)?)?;
-    let cross_v = clone_device_cache(prefill_jit.prepared_cross_v_mut().context(JitSnafu)?)?;
+    let metadata =
+        execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state, copies.as_deref_mut())?;
+    let self_k_src = prefill_jit.self_k().context(JitSnafu)?.clone();
+    let self_v_src = prefill_jit.self_v().context(JitSnafu)?.clone();
+    let cross_k_src = prefill_jit.prepared_cross_k_mut().context(JitSnafu)?.clone();
+    let cross_v_src = prefill_jit.prepared_cross_v_mut().context(JitSnafu)?.clone();
+    let bytes = self_k_src
+        .size()
+        .saturating_add(self_v_src.size())
+        .saturating_add(cross_k_src.size())
+        .saturating_add(cross_v_src.size());
+    let ((self_k, self_v, cross_k, cross_v), wall) = timed_d2d(copies.is_some(), &self_k_src, || {
+        Ok((
+            clone_device_cache(&self_k_src)?,
+            clone_device_cache(&self_v_src)?,
+            clone_device_cache(&cross_k_src)?,
+            clone_device_cache(&cross_v_src)?,
+        ))
+    })?;
+    if let Some(copies) = copies {
+        copies.d2d("seed_snapshots", 4, bytes, wall);
+    }
     let seed = build_decode_seed(metadata, self_k, self_v, cross_k, cross_v)?;
     if seed.self_positions > n_text_ctx {
         return Err(decode_err("prefill self cache exceeds text context"));
@@ -384,6 +422,7 @@ pub(crate) struct DecodeScheduleStats {
     pub(crate) cache_clone_bytes: usize,
     pub(crate) attempts: usize,
     pub(crate) fallback_attempts: usize,
+    pub(crate) copies: CopyProfile,
 }
 
 impl DecodeScheduleStats {
@@ -396,7 +435,20 @@ impl DecodeScheduleStats {
         self.cache_clone_bytes += other.cache_clone_bytes;
         self.attempts += other.attempts;
         self.fallback_attempts += other.fallback_attempts;
+        self.copies.merge(other.copies);
     }
+}
+
+pub(crate) fn scheduler_seed_copy_accounting(rows: usize, self_bytes: usize, cross_bytes: usize) -> (usize, usize) {
+    (rows.saturating_mul(4), rows.saturating_mul(self_bytes.saturating_add(cross_bytes)).saturating_mul(2))
+}
+
+pub(crate) fn cache_append_copy_accounting(rows: usize, per_pos_bytes: usize) -> (usize, usize) {
+    (rows.saturating_mul(2), rows.saturating_mul(per_pos_bytes).saturating_mul(2))
+}
+
+pub(crate) fn beam_clone_copy_accounting(copies: usize, positions: usize, per_pos_bytes: usize) -> (usize, usize) {
+    (copies.saturating_mul(2), copies.saturating_mul(positions).saturating_mul(per_pos_bytes).saturating_mul(2))
 }
 
 /// Small independently-testable allocator enforcing whole-attempt admission.
@@ -716,6 +768,7 @@ pub(crate) fn run_fixed_slot_decode(
     n_text_ctx: usize,
     n_vocab: usize,
     profile: bool,
+    profile_kernels: bool,
 ) -> Result<(Vec<DecodeResult>, DecodeScheduleStats, Vec<svod_runtime::KernelProfile>)> {
     if seeds.len() != request_options.len() {
         return Err(decode_err("decode seed/options count mismatch"));
@@ -758,7 +811,17 @@ pub(crate) fn run_fixed_slot_decode(
                 n_vocab,
                 &mut rngs[request],
             )?;
-            seed_attempt_rows(step_jit, &attempt.reserved_rows, &seeds[request], n_text_ctx)?;
+            let (ops, bytes) = scheduler_seed_copy_accounting(
+                attempt.reserved_rows.len(),
+                seeds[request].self_cache_bytes,
+                seeds[request].cross_cache_bytes,
+            );
+            let (_, wall) = timed_d2d(profile, &seeds[request].self_k_cache, || {
+                seed_attempt_rows(step_jit, &attempt.reserved_rows, &seeds[request], n_text_ctx)
+            })?;
+            if profile {
+                stats.copies.d2d("scheduler_seeding", ops, bytes, wall);
+            }
             attempts[request] = Some(attempt);
             stats.attempts += 1;
             stats.fallback_attempts += usize::from(strategy_index > 0);
@@ -772,6 +835,9 @@ pub(crate) fn run_fixed_slot_decode(
 
         // Attempts that finish from prefill (EOT or zero budget) need no graph dispatch.
         let mut dispatch = false;
+        let control_started = begin_host_copy(profile, step_jit.token_mut().context(JitSnafu)?)?;
+        let mut control_ops = 0usize;
+        let mut control_bytes = 0usize;
         for &request in &active_requests {
             let attempt = attempts[request].as_ref().expect("active attempt");
             let sample_len = request_options[request].sample_len.unwrap_or(n_text_ctx / 2);
@@ -791,6 +857,12 @@ pub(crate) fn run_fixed_slot_decode(
                             .ok_or_else(|| decode_err("position embedding is out of bounds"))?,
                     )?;
                     write_self_mask_row(step_jit, row, attempt.pos, n_text_ctx)?;
+                    control_ops = control_ops.saturating_add(3);
+                    control_bytes = control_bytes.saturating_add(
+                        std::mem::size_of::<i32>()
+                            + seed.n_state * std::mem::size_of::<f32>()
+                            + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
+                    );
                 }
                 AttemptKind::Beam(beam) => {
                     for (hypothesis, &row) in beam.active.iter().zip(&beam.rows) {
@@ -807,6 +879,12 @@ pub(crate) fn run_fixed_slot_decode(
                                 .ok_or_else(|| decode_err("position embedding is out of bounds"))?,
                         )?;
                         write_self_mask_row(step_jit, row, attempt.pos, n_text_ctx)?;
+                        control_ops = control_ops.saturating_add(3);
+                        control_bytes = control_bytes.saturating_add(
+                            std::mem::size_of::<i32>()
+                                + seed.n_state * std::mem::size_of::<f32>()
+                                + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
+                        );
                     }
                 }
             }
@@ -814,6 +892,9 @@ pub(crate) fn run_fixed_slot_decode(
         }
 
         if dispatch {
+            if let Some(started) = control_started {
+                stats.copies.h2d("decoder_controls", control_ops, control_bytes, started.elapsed());
+            }
             stats.dispatches += 1;
             stats.capacity_row_steps += capacity;
             stats.reserved_row_steps += allocator.reserved();
@@ -824,7 +905,7 @@ pub(crate) fn run_fixed_slot_decode(
                     AttemptKind::Beam(beam) => beam.active.len(),
                 })
                 .sum::<usize>();
-            if profile && profiled_kernels.is_empty() {
+            if profile_kernels && profiled_kernels.is_empty() {
                 profiled_kernels = step_jit.execute_profiled().context(JitSnafu)?;
             } else {
                 step_jit.execute().context(JitSnafu)?;
@@ -846,8 +927,24 @@ pub(crate) fn run_fixed_slot_decode(
                 match &mut attempt.kind {
                     AttemptKind::Single(single) => {
                         let row = attempt.reserved_rows[0];
-                        append_row_cache(step_jit, row, attempt.pos, per_pos_bytes, row_stride_bytes)?;
+                        let fence = step_jit.new_self_k().context(JitSnafu)?.clone();
+                        let (_, wall) = timed_d2d(profile, &fence, || {
+                            append_row_cache(step_jit, row, attempt.pos, per_pos_bytes, row_stride_bytes)
+                        })?;
+                        if profile {
+                            let (ops, bytes) = cache_append_copy_accounting(1, per_pos_bytes);
+                            stats.copies.d2d("cache_append", ops, bytes, wall);
+                        }
+                        let started = begin_host_copy(profile, step_jit.logits().context(JitSnafu)?)?;
                         let mut logits = read_logits_row(step_jit, row, n_vocab)?;
+                        if let Some(started) = started {
+                            stats.copies.d2h(
+                                "decoder_logits",
+                                1,
+                                n_vocab * std::mem::size_of::<f32>(),
+                                started.elapsed(),
+                            );
+                        }
                         let all_tokens: Vec<_> =
                             seed.initial_tokens.iter().copied().chain(single.tokens.iter().copied()).collect();
                         apply_logit_filters(
@@ -869,13 +966,31 @@ pub(crate) fn run_fixed_slot_decode(
                         }
                     }
                     AttemptKind::Beam(beam) => {
-                        for &row in &beam.rows {
-                            append_row_cache(step_jit, row, attempt.pos, per_pos_bytes, row_stride_bytes)?;
+                        let append_rows = beam.rows.clone();
+                        let fence = step_jit.new_self_k().context(JitSnafu)?.clone();
+                        let (_, wall) = timed_d2d(profile, &fence, || {
+                            for &row in &append_rows {
+                                append_row_cache(step_jit, row, attempt.pos, per_pos_bytes, row_stride_bytes)?;
+                            }
+                            Ok(())
+                        })?;
+                        if profile {
+                            let (ops, bytes) = cache_append_copy_accounting(append_rows.len(), per_pos_bytes);
+                            stats.copies.d2d("cache_append", ops, bytes, wall);
                         }
                         let size = attempt.reserved_rows.len();
                         let mut candidates = Vec::new();
                         for (parent_index, (hypothesis, &row)) in beam.active.iter().zip(&beam.rows).enumerate() {
+                            let started = begin_host_copy(profile, step_jit.logits().context(JitSnafu)?)?;
                             let mut logits = read_logits_row(step_jit, row, n_vocab)?;
+                            if let Some(started) = started {
+                                stats.copies.d2h(
+                                    "decoder_logits",
+                                    1,
+                                    n_vocab * std::mem::size_of::<f32>(),
+                                    started.elapsed(),
+                                );
+                            }
                             apply_logit_filters(
                                 &mut logits,
                                 tokenizer,
@@ -908,15 +1023,23 @@ pub(crate) fn run_fixed_slot_decode(
                         );
                         beam.finished.extend(newly_finished);
                         let assignment = plan_beam_rows(&attempt.reserved_rows, &survivors).map_err(decode_err)?;
-                        clone_cache_prefix(
-                            step_jit,
-                            &assignment.copies,
-                            attempt.pos + 1,
-                            per_pos_bytes,
-                            row_stride_bytes,
-                        )?;
+                        let fence = step_jit.self_k_cache_mut().context(JitSnafu)?.clone();
+                        let (_, wall) = timed_d2d(profile, &fence, || {
+                            clone_cache_prefix(
+                                step_jit,
+                                &assignment.copies,
+                                attempt.pos + 1,
+                                per_pos_bytes,
+                                row_stride_bytes,
+                            )
+                        })?;
                         stats.cache_clone_ops += assignment.copies.len();
-                        stats.cache_clone_bytes += assignment.copies.len() * (attempt.pos + 1) * per_pos_bytes * 2;
+                        let (clone_ops, clone_bytes) =
+                            beam_clone_copy_accounting(assignment.copies.len(), attempt.pos + 1, per_pos_bytes);
+                        stats.cache_clone_bytes = stats.cache_clone_bytes.saturating_add(clone_bytes);
+                        if profile {
+                            stats.copies.d2d("beam_clone", clone_ops, clone_bytes, wall);
+                        }
                         beam.active = active;
                         beam.rows = assignment.rows;
                     }
@@ -1209,6 +1332,7 @@ fn execute_prefill(
     n_vocab: usize,
     pos_embedding: &[f32],
     n_state: usize,
+    mut copies: Option<&mut CopyProfile>,
 ) -> Result<PrefillMetadata> {
     // Build initial tokens
     let mut initial_tokens = vec![tokenizer.sot()];
@@ -1229,17 +1353,26 @@ fn execute_prefill(
     {
         let token_data: Vec<i32> = initial_tokens.iter().map(|&t| t as i32).collect();
         let buf = prefill_jit.tokens_mut().context(JitSnafu)?;
-        write_buf(buf, bytemuck::cast_slice(&token_data))?;
+        let started = begin_host_copy(copies.is_some(), buf)?;
+        let data = bytemuck::cast_slice(&token_data);
+        write_buf(buf, data)?;
+        if let (Some(copies), Some(started)) = (copies.as_deref_mut(), started) {
+            copies.h2d("prefill_tokens", 1, data.len(), started.elapsed());
+        }
     }
 
     // Execute prefill JIT (plan manages all buffers, no realize)
     prefill_jit.execute().context(JitSnafu)?;
 
     // Read logits from output 0
+    let started = begin_host_copy(copies.is_some(), prefill_jit.logits().context(JitSnafu)?)?;
     let prefill_logits = {
         let buf = prefill_jit.logits().context(JitSnafu)?;
         read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
     };
+    if let (Some(copies), Some(started)) = (copies, started) {
+        copies.d2h("prefill_logits", 1, prefill_logits.len() * std::mem::size_of::<f32>(), started.elapsed());
+    }
     let no_speech_prob = tokenizer
         .no_speech()
         .map(|ns| softmax_prob(&prefill_logits[..n_vocab.min(prefill_logits.len())], ns as usize))

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -2,11 +2,11 @@
 //! and language detection — matching `whisper.decoding`.
 
 use super::config::N_AUDIO_CTX;
-use super::error::{DeviceSnafu, Error, JitSnafu, Result, TensorSnafu};
-use super::jit::{WhisperDecoderJit, WhisperDecoderStepBatchedJit, WhisperDecoderStepJit, WhisperPrefillJit};
-use super::model::Whisper;
+use super::error::{DeviceSnafu, Error, JitSnafu, Result};
+use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
 use super::tokenizer::WhisperTokenizer;
 use snafu::ResultExt;
+use svod_arch::pipelines::audio::Segment;
 
 // ─── Language detection ─────────────────────────────────────────────────────
 
@@ -56,31 +56,59 @@ pub fn detect_language(
 
 // ─── Decode options & result ────────────────────────────────────────────────
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WhisperTask {
+    Transcribe,
+    Translate,
+}
+
+impl std::str::FromStr for WhisperTask {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "transcribe" => Ok(Self::Transcribe),
+            "translate" => Ok(Self::Translate),
+            _ => Err("expected `transcribe` or `translate`"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct DecodeOptions {
-    pub task: String,
+    /// Whether to transcribe source speech or translate it to English.
+    pub task: WhisperTask,
+    /// Source language code, or `None` for automatic detection.
     pub language: Option<String>,
+    /// Initial sampling temperature.
     pub temperature: f32,
+    /// Maximum generated token count; defaults to half the text context.
     pub sample_len: Option<usize>,
-    pub without_timestamps: bool,
+    /// Suppress blank/space as the first generated token.
     pub suppress_blank: bool,
+    /// Token IDs to suppress; `-1` expands to Whisper's non-speech set.
     pub suppress_tokens: Option<Vec<i32>>,
+    /// Latest timestamp permitted at the beginning of a window, in seconds.
     pub max_initial_timestamp: Option<f32>,
+    /// Beam width, or `None` for greedy/sampling decode.
     pub beam_size: Option<usize>,
+    /// Temperature increment used by fallback; zero disables fallback.
     pub temperature_inc: f32,
+    /// Retry when text compression exceeds this threshold.
     pub compression_ratio_threshold: Option<f32>,
+    /// Retry low-confidence decodes below this average log-probability.
     pub logprob_threshold: Option<f32>,
+    /// Skip likely silence when no-speech probability exceeds this threshold.
     pub no_speech_threshold: Option<f32>,
 }
 
 impl Default for DecodeOptions {
     fn default() -> Self {
         Self {
-            task: "transcribe".into(),
+            task: WhisperTask::Transcribe,
             language: None,
             temperature: 0.0,
             sample_len: None,
-            without_timestamps: false,
             suppress_blank: true,
             suppress_tokens: Some(vec![-1]),
             max_initial_timestamp: Some(1.0),
@@ -96,6 +124,7 @@ impl Default for DecodeOptions {
 #[derive(Clone, Debug)]
 pub struct DecodeResult {
     pub tokens: Vec<u32>,
+    pub token_probs: Vec<f32>,
     pub text: String,
     pub avg_logprob: f32,
     pub no_speech_prob: f32,
@@ -104,28 +133,22 @@ pub struct DecodeResult {
     pub language: Option<String>,
 }
 
-/// Greedy decode with cross-attention weight extraction for DTW alignment.
-pub fn greedy_decode_with_alignment(
-    model: &Whisper,
-    audio_features: &svod_tensor::Tensor,
-    tokenizer: &WhisperTokenizer,
-    _options: &DecodeOptions,
-    text_tokens: &[u32],
-) -> Result<(Vec<svod_tensor::Tensor>, usize)> {
-    let mut tokens = tokenizer.sot_sequence();
-    tokens.push(tokenizer.no_timestamps());
-    tokens.extend_from_slice(text_tokens);
-    tokens.push(tokenizer.eot());
+impl DecodeResult {
+    pub fn should_skip(&self, options: &DecodeOptions) -> bool {
+        let Some(no_speech_threshold) = options.no_speech_threshold else {
+            return false;
+        };
+        if self.no_speech_prob <= no_speech_threshold {
+            return false;
+        }
+        options.logprob_threshold.is_none_or(|threshold| self.avg_logprob <= threshold)
+    }
 
-    let token_tensor = svod_tensor::Tensor::from_slice(tokens.iter().map(|&t| t as i32).collect::<Vec<_>>())
-        .try_reshape([1usize, tokens.len()])
-        .context(TensorSnafu)?
-        .cast(svod_dtype::DType::Int32)
-        .context(TensorSnafu)?;
-
-    let (_, qk_weights) = model.decode_with_alignment(&token_tensor, audio_features, 0)?;
-    let sot_len = tokenizer.sot_sequence().len() + 1;
-    Ok((qk_weights, sot_len))
+    pub fn clear_speech(&mut self) {
+        self.tokens.clear();
+        self.token_probs.clear();
+        self.text.clear();
+    }
 }
 
 // ─── Decode with temperature fallback (cached) ──────────────────────────────
@@ -139,11 +162,10 @@ pub fn decode_with_fallback_cached(
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
     options: &DecodeOptions,
-    audio_raw: &[f32],
     pos_embedding: &[f32],
     n_state: usize,
 ) -> Result<DecodeResult> {
-    let resolved_lang = resolve_language(options, audio_raw, decoder_jit, n_text_ctx, n_vocab, tokenizer)?;
+    let resolved_lang = resolve_language(options, decoder_jit, n_text_ctx, n_vocab, tokenizer)?;
 
     let temperatures = build_temperature_schedule(options);
     let mut best: Option<DecodeResult> = None;
@@ -193,19 +215,16 @@ pub fn decode_with_fallback_cached(
 
 fn resolve_language(
     options: &DecodeOptions,
-    audio_raw: &[f32],
     decoder_jit: &mut WhisperDecoderJit,
     n_text_ctx: usize,
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
 ) -> Result<Option<String>> {
+    if !tokenizer.multilingual {
+        return Ok(Some("en".to_string()));
+    }
     if options.language.is_some() {
         return Ok(options.language.clone());
-    }
-    // Load audio features into uncached decoder JIT for language detection
-    {
-        let buf = decoder_jit.audio_features_mut().context(JitSnafu)?;
-        write_buf(buf, bytemuck::cast_slice(audio_raw))?;
     }
     let detection = detect_language(decoder_jit, n_text_ctx, n_vocab, tokenizer)?;
     Ok(Some(detection.language))
@@ -274,8 +293,10 @@ pub fn greedy_decode_cached(
     let no_speech_prob = ctx.no_speech_prob;
 
     let mut tokens = Vec::new();
+    let mut token_probs = Vec::new();
     if next_token != tokenizer.eot() {
         tokens.push(next_token);
+        token_probs.push(sum_logprob.exp());
     }
 
     let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
@@ -308,17 +329,19 @@ pub fn greedy_decode_cached(
         );
 
         next_token = pick_token(&filtered, options.temperature);
-        sum_logprob += log_softmax(&filtered, next_token as usize);
+        let token_logprob = log_softmax(&filtered, next_token as usize);
+        sum_logprob += token_logprob;
 
         if next_token != tokenizer.eot() {
             tokens.push(next_token);
+            token_probs.push(token_logprob.exp());
         }
         if tokens.len() >= sample_len {
             break;
         }
     }
 
-    finish_decode(&tokens, tokenizer, sum_logprob, no_speech_prob, options)
+    finish_decode(&tokens, &token_probs, tokenizer, sum_logprob, no_speech_prob, options)
 }
 
 // ─── Batched (step-locked) greedy decode ────────────────────────────────────
@@ -347,11 +370,8 @@ pub struct DecodeLane {
     pub pos_embedding: Vec<f32>,
     pub n_state: usize,
 
-    // KV caches — seeded once into the batched step JIT's device-local buffer
-    // at this lane's row. After seeding, the cache lives on-device and grows
-    // one position per step via SDMA writeback (`copy_output_to_self_k_cache`);
-    // the host never rewrites it. `seeded_row` is the row the cache currently
-    // occupies in the [max_lanes, ...] buffer (changes on lane compaction).
+    // KV caches are seeded once into this lane's stable fixed-batch slot. The
+    // cache then grows on-device via SDMA writeback; lanes never compact.
     pub self_k_cache: Vec<f32>,
     pub self_v_cache: Vec<f32>,
     pub cross_k: Vec<f32>,
@@ -361,6 +381,7 @@ pub struct DecodeLane {
     // Per-step loop state (mutated each step)
     pub next_token: u32,
     pub tokens: Vec<u32>,
+    pub token_probs: Vec<f32>,
     pub sum_logprob: f32,
     pub pos: usize, // current position = init_len + step
     pub done: bool,
@@ -399,8 +420,10 @@ impl DecodeLane {
         let sum_logprob = log_softmax(&filtered, next_token as usize);
 
         let mut tokens = Vec::new();
+        let mut token_probs = Vec::new();
         if next_token != tokenizer.eot() {
             tokens.push(next_token);
+            token_probs.push(sum_logprob.exp());
         }
 
         Ok(Self {
@@ -418,6 +441,7 @@ impl DecodeLane {
             seeded_row: None,
             next_token,
             tokens,
+            token_probs,
             sum_logprob,
             pos: ctx.init_len, // first step decodes at init_len
             done: next_token == tokenizer.eot(),
@@ -434,20 +458,20 @@ impl DecodeLane {
     }
 
     pub fn finish(self, tokenizer: &WhisperTokenizer, options: &DecodeOptions) -> Result<DecodeResult> {
-        finish_decode(&self.tokens, tokenizer, self.sum_logprob, self.no_speech_prob, options)
+        finish_decode(&self.tokens, &self.token_probs, tokenizer, self.sum_logprob, self.no_speech_prob, options)
     }
 }
 
 /// Step-locked batched greedy decode: advances every active lane by one token
 /// per JIT dispatch, until all lanes are `done` or hit `sample_len`.
 ///
-/// Each lane occupies a fixed row (`lane_idx`) in the batched step JIT's
-/// buffers; inactive lanes are skipped. The plan is rebound to the active
-/// count each dispatch via `execute_with_vars(&[("b", active)])`.
+/// Each lane occupies a stable row (`lane_idx`) in a concrete fixed-capacity
+/// graph. Inactive rows still execute but their outputs are ignored.
 #[allow(clippy::too_many_arguments)]
 pub fn run_batched_decode(
     lanes: &mut [DecodeLane],
-    step_jit: &mut WhisperDecoderStepBatchedJit,
+    step_jit: &mut WhisperDecoderStepJit,
+    capacity: usize,
     tokenizer: &WhisperTokenizer,
     options: &DecodeOptions,
     n_text_ctx: usize,
@@ -456,82 +480,73 @@ pub fn run_batched_decode(
     let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
     let eot = tokenizer.eot();
     let n_state = lanes.first().map(|l| l.n_state).unwrap_or(0);
+    for lane in lanes.iter_mut() {
+        if lane.tokens.len() >= sample_len || lane.next_token == eot {
+            lane.done = true;
+        }
+    }
+    let mut owners: Vec<Option<usize>> = vec![None; capacity];
+    let mut next_lane = 0usize;
 
     loop {
-        // Collect the active (not-done, not-at-sample_len) lanes by index.
-        let active: Vec<usize> = lanes
-            .iter()
-            .enumerate()
-            .filter(|(_, l)| !l.done && l.tokens.len() < sample_len && l.next_token != eot)
-            .map(|(i, _)| i)
-            .collect();
+        for owner in &mut owners {
+            if owner.is_some_and(|lane_index| lanes[lane_index].done) {
+                *owner = None;
+            }
+            if owner.is_none() {
+                while next_lane < lanes.len() && lanes[next_lane].done {
+                    next_lane += 1;
+                }
+                if next_lane < lanes.len() {
+                    *owner = Some(next_lane);
+                    next_lane += 1;
+                }
+            }
+        }
+
+        let active: Vec<(usize, usize)> =
+            owners.iter().enumerate().filter_map(|(slot, &owner)| owner.map(|lane_index| (slot, lane_index))).collect();
         if active.is_empty() {
             break;
         }
-        let active_count = active.len();
-
         // Per-position float count and buffer row strides. All lanes share
         // the same structural dims, so read them from the first active lane.
-        let per_pos_floats = lanes[active[0]].per_pos_floats();
+        let per_pos_floats = lanes[active[0].1].per_pos_floats();
         let self_row_stride = n_text_ctx * per_pos_floats; // [max_lanes, N_TEXT_CTX, ...]
         let cross_row_stride = N_AUDIO_CTX * per_pos_floats; // [max_lanes, N_AUDIO_CTX, ...]
 
-        // Pack each active lane's inputs into the batched JIT at its row.
-        // Rows are contiguous: active lane `j` (j=0..active_count) maps to
-        // row `j` in the [active_count, ...] dispatch.
-        //
-        // KV caches are device-local: the first time a lane occupies a row
-        // (and whenever compaction moves it to a new row), the seed cache
-        // (read from prefill) is copied in once via `copyin`. Thereafter the
-        // cache grows on-device via SDMA append (teardown below) — the host
-        // never rewrites it. This is the bandwidth win: one seed per lane,
-        // not a full-cache rewrite per step.
-        for (row, &lane_idx) in active.iter().enumerate() {
+        // Stable slots remove cache relocation when another lane finishes.
+        for &(row, lane_idx) in &active {
             let lane = &mut lanes[lane_idx];
             write_token_row(step_jit, row, lane.next_token)?;
             write_pos_emb_row(step_jit, row, &lane.pos_embedding[lane.pos * n_state..(lane.pos + 1) * n_state])?;
             write_self_mask_row(step_jit, row, lane.pos, n_text_ctx)?;
 
-            // Seed caches into this row only when the lane's row changed.
-            //
-            // Two cases:
-            // - First activation (`seeded_row == None`): seed from the host Vec
-            //   (the prefill prefix). The cache then grows on-device via SDMA.
-            // - Compaction (`seeded_row == Some(old_row)`): the earlier lane
-            //   dropped out, shifting this lane down to `row`. Copy the GROWN
-            //   cache device-to-device from `old_row` to `row` — NOT from the
-            //   host Vec, which only holds the stale prefill prefix and would
-            //   clobber positions [init_len, pos) written by prior SDMA appends.
-            match lane.seeded_row {
-                None => {
-                    copyin_cache_row(step_jit.self_k_cache_mut().context(JitSnafu)?, row, self_row_stride, &lane.self_k_cache)?;
-                    copyin_cache_row(step_jit.self_v_cache_mut().context(JitSnafu)?, row, self_row_stride, &lane.self_v_cache)?;
-                    copyin_cache_row(step_jit.cross_k_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_k)?;
-                    copyin_cache_row(step_jit.cross_v_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_v)?;
-                }
-                Some(old_row) if old_row != row => {
-                    let grown_bytes = lane.pos * lane.per_pos_bytes();
-                    let new_self_off = row * self_row_stride * std::mem::size_of::<f32>();
-                    let old_self_off = old_row * self_row_stride * std::mem::size_of::<f32>();
-                    copy_cache_row_device(step_jit.self_k_cache_mut().context(JitSnafu)?, new_self_off, old_self_off, grown_bytes)?;
-                    copy_cache_row_device(step_jit.self_v_cache_mut().context(JitSnafu)?, new_self_off, old_self_off, grown_bytes)?;
-                    // Cross cache is static after prefill — copy the full row.
-                    let cross_bytes = N_AUDIO_CTX * lane.per_pos_bytes();
-                    let new_cross_off = row * cross_row_stride * std::mem::size_of::<f32>();
-                    let old_cross_off = old_row * cross_row_stride * std::mem::size_of::<f32>();
-                    copy_cache_row_device(step_jit.cross_k_mut().context(JitSnafu)?, new_cross_off, old_cross_off, cross_bytes)?;
-                    copy_cache_row_device(step_jit.cross_v_mut().context(JitSnafu)?, new_cross_off, old_cross_off, cross_bytes)?;
-                }
-                _ => {}
+            if lane.seeded_row.is_none() {
+                copyin_cache_row(
+                    step_jit.self_k_cache_mut().context(JitSnafu)?,
+                    row,
+                    self_row_stride,
+                    &lane.self_k_cache,
+                )?;
+                copyin_cache_row(
+                    step_jit.self_v_cache_mut().context(JitSnafu)?,
+                    row,
+                    self_row_stride,
+                    &lane.self_v_cache,
+                )?;
+                copyin_cache_row(step_jit.cross_k_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_k)?;
+                copyin_cache_row(step_jit.cross_v_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_v)?;
             }
             lane.seeded_row = Some(row);
         }
 
-        // One dispatch for all active lanes, rebound to the live count.
-        step_jit.execute_with_vars(&[("b", active_count as i64)]).context(JitSnafu)?;
+        // The same concrete graph executes at every step. This keeps matrix
+        // dimensions static and makes the plan graph-capture eligible.
+        step_jit.execute().context(JitSnafu)?;
 
         // Per-lane teardown: SDMA-writeback new K/V, read logits, pick token.
-        for (row, &lane_idx) in active.iter().enumerate() {
+        for &(row, lane_idx) in &active {
             let lane = &mut lanes[lane_idx];
 
             // Device-side K/V copy: append this step's new K/V at lane.pos.
@@ -543,15 +558,12 @@ pub fn run_batched_decode(
             let dst_base = row * self_row_stride * std::mem::size_of::<f32>();
             let dst_off = dst_base + lane.pos * per_pos_b;
             let src_off = row * per_pos_b;
-            step_jit
-                .copy_output_to_self_k_cache(1, dst_off, src_off, per_pos_b)
-                .context(JitSnafu)?;
-            step_jit
-                .copy_output_to_self_v_cache(2, dst_off, src_off, per_pos_b)
-                .context(JitSnafu)?;
+            step_jit.copy_output_to_self_k_cache(1, dst_off, src_off, per_pos_b).context(JitSnafu)?;
+            step_jit.copy_output_to_self_v_cache(2, dst_off, src_off, per_pos_b).context(JitSnafu)?;
 
             // Read this lane's logits row and pick the next token.
             let logits = read_logits_row(step_jit, row, n_vocab)?;
+
             let all_toks: Vec<u32> = lane.initial_tokens.iter().copied().chain(lane.tokens.iter().copied()).collect();
             let step = lane.pos + 1 - lane.init_len;
             let mut filtered = logits;
@@ -565,10 +577,12 @@ pub fn run_batched_decode(
                 &lane.suppress_tokens,
             );
             lane.next_token = pick_token(&filtered, options.temperature);
-            lane.sum_logprob += log_softmax(&filtered, lane.next_token as usize);
+            let token_logprob = log_softmax(&filtered, lane.next_token as usize);
+            lane.sum_logprob += token_logprob;
 
             if lane.next_token != eot {
                 lane.tokens.push(lane.next_token);
+                lane.token_probs.push(token_logprob.exp());
             }
             lane.pos += 1;
             if lane.next_token == eot || lane.tokens.len() >= sample_len {
@@ -585,7 +599,7 @@ pub fn run_batched_decode(
 // The batched step JIT owns max_lanes-sized buffers; each lane writes/reads
 // its row. These wrap the per-row slicing so the main loop stays readable.
 
-fn write_token_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, token: u32) -> Result<()> {
+fn write_token_row(jit: &mut WhisperDecoderStepJit, row: usize, token: u32) -> Result<()> {
     let buf = jit.token_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     // token is [max_lanes, 1] i32; row stride = 4 bytes
@@ -596,7 +610,7 @@ fn write_token_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, token: u3
     Ok(())
 }
 
-fn write_pos_emb_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, emb: &[f32]) -> Result<()> {
+fn write_pos_emb_row(jit: &mut WhisperDecoderStepJit, row: usize, emb: &[f32]) -> Result<()> {
     let buf = jit.pos_emb_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     // pos_emb is [max_lanes, 1, n_state] f32
@@ -606,7 +620,7 @@ fn write_pos_emb_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, emb: &[
     Ok(())
 }
 
-fn write_self_mask_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, pos: usize, n_text_ctx: usize) -> Result<()> {
+fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, n_text_ctx: usize) -> Result<()> {
     let buf = jit.self_mask_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     // mask is [max_lanes, 1, 1, n_text_ctx + 1]; row stride = (n_text_ctx+1)*4
@@ -628,33 +642,14 @@ fn write_self_mask_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, pos: 
 /// `data` may be shorter (e.g. only `init_len` positions populated for the self
 /// cache after prefill). Used for one-time seeding; the cache then grows
 /// on-device via SDMA append.
-fn copyin_cache_row(
-    buf: &mut svod_device::Buffer,
-    row: usize,
-    row_stride_floats: usize,
-    data: &[f32],
-) -> Result<()> {
+fn copyin_cache_row(buf: &mut svod_device::Buffer, row: usize, row_stride_floats: usize, data: &[f32]) -> Result<()> {
     let off = row * row_stride_floats * std::mem::size_of::<f32>();
     let bytes: &[u8] = bytemuck::cast_slice(data);
     buf.copyin_at(off, bytes).context(DeviceSnafu)
 }
 
-/// On-device cache row relocation for lane compaction. When an earlier lane
-/// drops out, later lanes shift down — their grown caches move with them via
-/// `Buffer::copy_within` (SDMA, no host round-trip). Used instead of re-seeding
-/// from the stale host Vec, which only holds the prefill prefix and would
-/// clobber positions [init_len, pos) grown by prior SDMA appends.
-fn copy_cache_row_device(
-    buf: &mut svod_device::Buffer,
-    new_off: usize,
-    old_off: usize,
-    len: usize,
-) -> Result<()> {
-    buf.copy_within(new_off, old_off, len).context(DeviceSnafu)
-}
-
 /// Read one lane's logits row `[n_vocab]` from the batched JIT output.
-fn read_logits_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, n_vocab: usize) -> Result<Vec<f32>> {
+fn read_logits_row(jit: &mut WhisperDecoderStepJit, row: usize, n_vocab: usize) -> Result<Vec<f32>> {
     let buf = jit.logits().context(JitSnafu)?;
     let src = buf.as_host_bytes().context(DeviceSnafu)?;
     let row_floats = n_vocab;
@@ -667,6 +662,7 @@ fn read_logits_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, n_vocab: 
 
 struct Beam {
     tokens: Vec<u32>,
+    token_probs: Vec<f32>,
     sum_logprob: f32,
 }
 
@@ -714,9 +710,9 @@ pub fn beam_decode_cached(
         let mut toks = ctx.initial_tokens.clone();
         toks.push(*tok_id as u32);
         if *tok_id as u32 == eot {
-            finished.push(Beam { tokens: toks, sum_logprob: *lp });
+            finished.push(Beam { tokens: toks, token_probs: vec![lp.exp()], sum_logprob: *lp });
         } else {
-            beams.push(Beam { tokens: toks, sum_logprob: *lp });
+            beams.push(Beam { tokens: toks, token_probs: vec![lp.exp()], sum_logprob: *lp });
         }
     }
 
@@ -746,7 +742,7 @@ pub fn beam_decode_cached(
         let all_logits = &ctx.logits_buf;
 
         // Generate + rank candidates
-        let mut candidates: Vec<(usize, usize, f32)> = Vec::new();
+        let mut candidates: Vec<(usize, usize, f32, f32)> = Vec::new();
         for (bi, beam) in beams.iter().enumerate() {
             let start = bi * n_vocab;
             if start >= all_logits.len() {
@@ -767,26 +763,28 @@ pub fn beam_decode_cached(
             let mut idx: Vec<(usize, f32)> = logprobs.iter().copied().enumerate().collect();
             idx.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
             for (tok_id, lp) in idx.into_iter().take(beam_size + 1) {
-                candidates.push((bi, tok_id, beam.sum_logprob + lp));
+                candidates.push((bi, tok_id, lp, beam.sum_logprob + lp));
             }
         }
-        candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(std::cmp::Ordering::Equal));
 
         // Select survivors
         let mut new_beams = Vec::with_capacity(beam_size);
         let mut parent_map = Vec::with_capacity(beam_size);
-        for (parent_idx, tok_id, sum_lp) in candidates {
+        for (parent_idx, tok_id, token_lp, sum_lp) in candidates {
             if new_beams.len() >= beam_size {
                 break;
             }
             let mut toks = beams[parent_idx].tokens.clone();
+            let mut token_probs = beams[parent_idx].token_probs.clone();
             toks.push(tok_id as u32);
+            token_probs.push(token_lp.exp());
             if tok_id as u32 == eot {
                 if finished.len() < beam_size {
-                    finished.push(Beam { tokens: toks, sum_logprob: sum_lp });
+                    finished.push(Beam { tokens: toks, token_probs, sum_logprob: sum_lp });
                 }
             } else {
-                new_beams.push(Beam { tokens: toks, sum_logprob: sum_lp });
+                new_beams.push(Beam { tokens: toks, token_probs, sum_logprob: sum_lp });
                 parent_map.push(parent_idx);
             }
             if new_beams.len() >= beam_size {
@@ -808,7 +806,7 @@ pub fn beam_decode_cached(
                 if *t.last().unwrap() != eot {
                     t.push(eot);
                 }
-                finished.push(Beam { tokens: t, sum_logprob: b.sum_logprob });
+                finished.push(Beam { tokens: t, token_probs: b.token_probs, sum_logprob: b.sum_logprob });
             }
             break;
         }
@@ -823,7 +821,7 @@ pub fn beam_decode_cached(
         if *t.last().unwrap() != eot {
             t.push(eot);
         }
-        finished.push(Beam { tokens: t, sum_logprob: b.sum_logprob });
+        finished.push(Beam { tokens: t, token_probs: b.token_probs, sum_logprob: b.sum_logprob });
     }
 
     finished.sort_by(|a, b| {
@@ -834,11 +832,13 @@ pub fn beam_decode_cached(
 
     let best = finished.into_iter().next().ok_or_else(|| decode_err("beam produced nothing"))?;
     let output_tokens: Vec<u32> = best.tokens[ctx.sample_begin..].iter().copied().take_while(|&t| t != eot).collect();
+    let token_probs = best.token_probs.into_iter().take(output_tokens.len()).collect();
     let text = tokenizer.decode(&output_tokens);
     let avg_logprob = best.sum_logprob / (output_tokens.len() + 1) as f32;
     let compression_ratio = compression_ratio_text(&text);
     Ok(DecodeResult {
         tokens: output_tokens,
+        token_probs,
         text,
         avg_logprob,
         no_speech_prob: ctx.no_speech_prob,
@@ -887,8 +887,18 @@ impl DecodeCtx {
         let layer_heads_dh = self.self_k_cache.len() / self.init_len;
         let self_stride = n_text_ctx * layer_heads_dh;
         let cross_stride = n_audio_ctx * layer_heads_dh;
-        copyin_replicated_cache(step_jit.self_k_cache_mut().context(JitSnafu)?, &self.self_k_cache, beam_size, self_stride)?;
-        copyin_replicated_cache(step_jit.self_v_cache_mut().context(JitSnafu)?, &self.self_v_cache, beam_size, self_stride)?;
+        copyin_replicated_cache(
+            step_jit.self_k_cache_mut().context(JitSnafu)?,
+            &self.self_k_cache,
+            beam_size,
+            self_stride,
+        )?;
+        copyin_replicated_cache(
+            step_jit.self_v_cache_mut().context(JitSnafu)?,
+            &self.self_v_cache,
+            beam_size,
+            self_stride,
+        )?;
         copyin_replicated_cache(step_jit.cross_k_mut().context(JitSnafu)?, &self.cross_k, beam_size, cross_stride)?;
         copyin_replicated_cache(step_jit.cross_v_mut().context(JitSnafu)?, &self.cross_v, beam_size, cross_stride)?;
         Ok(())
@@ -1000,12 +1010,15 @@ fn init_decode(
     n_state: usize,
 ) -> Result<DecodeCtx> {
     // Build initial tokens
-    let lang = options.language.as_ref().ok_or_else(|| decode_err("language required"))?;
-    let lang_tok = tokenizer.language_token_for(lang).unwrap_or_else(|| tokenizer.sot());
-    let task_tok = if options.task == "transcribe" { tokenizer.transcribe() } else { tokenizer.translate() };
-    let mut initial_tokens = vec![tokenizer.sot(), lang_tok, task_tok];
-    if options.without_timestamps {
-        initial_tokens.push(tokenizer.no_timestamps());
+    let mut initial_tokens = vec![tokenizer.sot()];
+    if tokenizer.multilingual {
+        let lang = options.language.as_ref().ok_or_else(|| decode_err("language required"))?;
+        let lang_tok = tokenizer.language_token_for(lang).unwrap_or_else(|| tokenizer.sot());
+        let task_tok = match options.task {
+            WhisperTask::Transcribe => tokenizer.transcribe(),
+            WhisperTask::Translate => tokenizer.translate(),
+        };
+        initial_tokens.extend([lang_tok, task_tok]);
     }
     let sample_begin = initial_tokens.len();
     let init_len = initial_tokens.len();
@@ -1044,8 +1057,16 @@ fn init_decode(
     // total = seq * n_layer * n_head * d_head. So layer_heads_dh = total / seq.
     let self_k_cache = read_output(prefill_jit, WhisperPrefillJit::self_k)?;
     let self_v_cache = read_output(prefill_jit, WhisperPrefillJit::self_v)?;
-    let cross_k = read_output(prefill_jit, WhisperPrefillJit::cross_k)?;
-    let cross_v = read_output(prefill_jit, WhisperPrefillJit::cross_v)?;
+    // Cross K/V were projected once before fallback decoding and remain in
+    // prefill's device-local inputs. Read them only to seed the step graph.
+    let cross_k = {
+        let buf = prefill_jit.prepared_cross_k_mut().context(JitSnafu)?;
+        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
+    };
+    let cross_v = {
+        let buf = prefill_jit.prepared_cross_v_mut().context(JitSnafu)?;
+        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
+    };
 
     let _ = n_text_ctx;
 
@@ -1069,8 +1090,105 @@ fn init_decode(
 
 // ─── Result helpers ─────────────────────────────────────────────────────────
 
+/// Split a decoded token stream into timestamp-bounded segments.
+///
+/// The decoder emits paired timestamp tokens (`<|t0|> text <|t1|> text <|t2|>...`)
+/// during timestamp-enabled recognition. This function finds
+/// consecutive timestamp-token pairs — the boundary between segments — and
+/// returns one [`Segment`] per slice, with window-relative start/end times
+/// decoded from the timestamp token values.
+///
+/// Ported from the OpenAI reference (`transcribe.py:339-367`). When no
+/// consecutive timestamp pairs are found, returns a single segment spanning
+/// the whole token stream.
+pub fn split_into_segments(
+    tokens: &[u32],
+    tokenizer: &WhisperTokenizer,
+    window_duration: f32,
+) -> Vec<svod_arch::pipelines::audio::Segment> {
+    let ts_begin = tokenizer.timestamp_begin();
+    let is_ts = |t: u32| t >= ts_begin;
+
+    // Find indices where two adjacent tokens are both timestamps — these are
+    // segment boundaries (the closing ts of one segment + the opening ts of the
+    // next, shared).
+    let mut boundaries: Vec<usize> = Vec::new();
+    for i in 1..tokens.len() {
+        if is_ts(tokens[i - 1]) && is_ts(tokens[i]) {
+            boundaries.push(i);
+        }
+    }
+
+    let mut segments = Vec::new();
+    let terminal_timestamp = tokens.last().is_some_and(|&token| is_ts(token))
+        && tokens.get(tokens.len().saturating_sub(2)).is_none_or(|&token| !is_ts(token));
+
+    if boundaries.is_empty() {
+        // Whisper treats this as one window-relative segment. If any timestamp
+        // was emitted, its last value limits the segment duration.
+        let start = 0.0;
+        let end = tokens
+            .iter()
+            .rev()
+            .find(|&&token| is_ts(token))
+            .filter(|&&token| token != ts_begin)
+            .map(|&token| token_to_seconds(token, ts_begin))
+            .unwrap_or(window_duration)
+            .clamp(0.0, window_duration.max(0.0));
+        let text = tokenizer.decode(tokens);
+        let text = text.trim();
+        if !text.is_empty() && end > start {
+            segments.push(Segment { text: text.to_string(), start, end });
+        }
+        return segments;
+    }
+
+    let mut last_slice = 0;
+    for &boundary in &boundaries {
+        if boundary > last_slice {
+            segments.push(segment_from_tokens(&tokens[last_slice..boundary], tokenizer, ts_begin, window_duration));
+        }
+        last_slice = boundary;
+    }
+
+    // An unfinished tail is excluded; it will be decoded again from the last
+    // completed timestamp boundary by long-form host orchestration.
+    if terminal_timestamp && tokens.len() > last_slice {
+        segments.push(segment_from_tokens(&tokens[last_slice..], tokenizer, ts_begin, window_duration));
+    }
+
+    // Filter empty segments (can happen when consecutive timestamps have no text between them).
+    segments.retain(|s| !s.text.is_empty() && s.end > s.start);
+    segments
+}
+
+/// Decode one timestamp-bounded slice into a [`Segment`].
+fn segment_from_tokens(slice: &[u32], tokenizer: &WhisperTokenizer, ts_begin: u32, window_duration: f32) -> Segment {
+    let extent = window_duration.max(0.0);
+    let start = slice
+        .first()
+        .filter(|&&t| t >= ts_begin)
+        .map(|&t| token_to_seconds(t, ts_begin))
+        .unwrap_or(0.0)
+        .clamp(0.0, extent);
+    let end = slice
+        .last()
+        .filter(|&&t| t >= ts_begin)
+        .map(|&t| token_to_seconds(t, ts_begin))
+        .unwrap_or(start)
+        .clamp(start, extent);
+    let text = tokenizer.decode(slice).trim().to_string();
+    Segment { text, start, end }
+}
+
+/// Convert a timestamp token id to seconds: `(id - timestamp_begin) / TOKENS_PER_SECOND`.
+fn token_to_seconds(token: u32, ts_begin: u32) -> f32 {
+    (token - ts_begin) as f32 / super::config::TOKENS_PER_SECOND
+}
+
 fn finish_decode(
     tokens: &[u32],
+    token_probs: &[f32],
     tokenizer: &WhisperTokenizer,
     sum_logprob: f32,
     no_speech_prob: f32,
@@ -1081,6 +1199,7 @@ fn finish_decode(
     let compression_ratio = compression_ratio_text(&text);
     Ok(DecodeResult {
         tokens: tokens.to_vec(),
+        token_probs: token_probs.to_vec(),
         text,
         avg_logprob,
         no_speech_prob,
@@ -1167,11 +1286,7 @@ fn copyin_replicated_cache(
     buf.copyin_at(0, bytemuck::cast_slice(&packed)).context(DeviceSnafu)
 }
 
-fn reorder_cache_host(
-    buf: &mut svod_device::Buffer,
-    parent_map: &[usize],
-    per_beam_floats: usize,
-) -> Result<()> {
+fn reorder_cache_host(buf: &mut svod_device::Buffer, parent_map: &[usize], per_beam_floats: usize) -> Result<()> {
     let total = per_beam_floats * parent_map.len();
     // Device-local cache: read out via copyout_prefix, reorder on host, write
     // back via copyin_at. This is the beam-reorder path (runs once per step
@@ -1251,16 +1366,7 @@ fn apply_logit_filters(
     {
         logits[ns as usize] = f32::NEG_INFINITY;
     }
-    if !options.without_timestamps {
-        apply_timestamp_rules(logits, tokenizer, tokens, sample_begin, options);
-    } else {
-        let ts_begin = tokenizer.timestamp_begin() as usize;
-        if ts_begin < logits.len() {
-            for t in &mut logits[ts_begin..] {
-                *t = f32::NEG_INFINITY;
-            }
-        }
-    }
+    apply_timestamp_rules(logits, tokenizer, tokens, sample_begin, options);
 }
 
 fn apply_timestamp_rules(
@@ -1380,15 +1486,23 @@ fn compression_ratio_text(text: &str) -> f32 {
     raw.len() as f32 / clen as f32
 }
 
+/// Multinomial sampling from logits at temperature T. Matches the OpenAI
+/// reference's `Categorical(logits=logits/T).sample()` (`decoding.py:283`),
+/// which PyTorch implements as a numerically stable softmax (max-subtract
+/// before exp) followed by inverse-CDF sampling.
 fn sample_from_logits(logits: &[f32], temperature: f32) -> u32 {
-    let scaled: Vec<f32> = logits.iter().map(|&l| (l / temperature).exp()).collect();
-    let sum: f32 = scaled.iter().sum();
+    // Max-subtract for numerical stability: exp(x - m) avoids overflow on
+    // large positive logits. The max is a no-op for the sampling distribution
+    // (it's a constant shift that cancels in normalization).
+    let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max) / temperature;
+    let probs: Vec<f32> = logits.iter().map(|&l| ((l / temperature) - max_val).exp()).collect();
+    let sum: f32 = probs.iter().copied().sum();
     let mut r = rand::random::<f32>() * sum;
-    for (i, &p) in scaled.iter().enumerate() {
+    for (i, &p) in probs.iter().enumerate() {
         r -= p;
         if r <= 0.0 {
             return i as u32;
         }
     }
-    (scaled.len() - 1) as u32
+    (probs.len() - 1) as u32
 }

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -343,13 +343,14 @@ pub(crate) fn prefill_decode_seed(
 }
 
 fn clone_device_cache(src: &Buffer) -> Result<Buffer> {
-    if src.dtype() != DType::Float32 || !src.size().is_multiple_of(std::mem::size_of::<f32>()) {
-        return Err(decode_err("prefill cache must contain aligned float32 data"));
+    let element_bytes = src.dtype().bytes();
+    if element_bytes == 0 || !src.size().is_multiple_of(element_bytes) {
+        return Err(decode_err("prefill cache is not element-aligned"));
     }
     let mut clone = Buffer::allocate(
         src.allocator_arc(),
-        DType::Float32,
-        vec![src.size() / std::mem::size_of::<f32>()],
+        src.dtype().clone(),
+        vec![src.size() / element_bytes],
         BufferSpec { cpu_access: false, ..BufferSpec::default() },
     )
     .context(DeviceSnafu)?;
@@ -370,6 +371,12 @@ fn build_decode_seed(
     if cross_k.size() == 0 || cross_k.size() != cross_v.size() {
         return Err(decode_err("invalid prefill cross-cache geometry"));
     }
+    if self_k.dtype() != self_v.dtype() || cross_k.dtype() != cross_v.dtype() {
+        return Err(decode_err("prefill K/V cache dtypes disagree"));
+    }
+    if self_k.dtype() != cross_k.dtype() {
+        return Err(decode_err("prefill self and cross cache dtypes disagree"));
+    }
     for cache in [&self_v, &cross_k, &cross_v] {
         if !std::ptr::eq(self_k.allocator(), cache.allocator()) {
             return Err(decode_err("prefill caches use different allocators"));
@@ -380,8 +387,8 @@ fn build_decode_seed(
         .checked_div(metadata.init_len)
         .filter(|&bytes| bytes != 0 && bytes.checked_mul(metadata.init_len) == Some(self_k.size()))
         .ok_or_else(|| decode_err("self cache is not position-aligned"))?;
-    if per_pos_bytes % std::mem::size_of::<f32>() != 0 {
-        return Err(decode_err("self cache position is not float32-aligned"));
+    if per_pos_bytes % self_k.dtype().bytes() != 0 {
+        return Err(decode_err("self cache position is not element-aligned"));
     }
     let cross_positions = cross_k
         .size()
@@ -707,6 +714,17 @@ fn append_row_cache(
     per_pos_bytes: usize,
     row_stride_bytes: usize,
 ) -> Result<()> {
+    let output_k_dtype = jit.new_self_k().context(JitSnafu)?.dtype().clone();
+    let output_v_dtype = jit.new_self_v().context(JitSnafu)?.dtype().clone();
+    let cache_k_dtype = jit.self_k_cache_mut().context(JitSnafu)?.dtype().clone();
+    let cache_v_dtype = jit.self_v_cache_mut().context(JitSnafu)?.dtype().clone();
+    if output_k_dtype != output_v_dtype || output_k_dtype != cache_k_dtype || output_v_dtype != cache_v_dtype {
+        return Err(decode_err("step K/V outputs and cache destination dtypes disagree"));
+    }
+    let element_bytes = output_k_dtype.bytes();
+    if !per_pos_bytes.is_multiple_of(element_bytes) || !row_stride_bytes.is_multiple_of(element_bytes) {
+        return Err(decode_err("self cache append is not element-aligned"));
+    }
     let dst = row
         .checked_mul(row_stride_bytes)
         .and_then(|base| pos.checked_mul(per_pos_bytes).and_then(|offset| base.checked_add(offset)))
@@ -873,7 +891,7 @@ pub(crate) fn run_fixed_slot_decode(
                     control_bytes = control_bytes.saturating_add(
                         std::mem::size_of::<i32>()
                             + seed.n_state * std::mem::size_of::<f32>()
-                            + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
+                            + (n_text_ctx + 1) * DType::Bool.bytes(),
                     );
                 }
                 AttemptKind::Beam(beam) => {
@@ -895,7 +913,7 @@ pub(crate) fn run_fixed_slot_decode(
                         control_bytes = control_bytes.saturating_add(
                             std::mem::size_of::<i32>()
                                 + seed.n_state * std::mem::size_of::<f32>()
-                                + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
+                                + (n_text_ctx + 1) * DType::Bool.bytes(),
                         );
                     }
                 }
@@ -1128,28 +1146,36 @@ fn write_pos_emb_row(jit: &mut WhisperDecoderStepJit, row: usize, emb: &[f32]) -
 fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, n_text_ctx: usize) -> Result<()> {
     let buf = jit.self_mask_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-    // mask is [max_lanes, 1, 1, n_text_ctx + 1]; row stride = (n_text_ctx+1)*4
+    if buf.dtype() != DType::Bool {
+        return Err(decode_err("decoder self mask must be bool"));
+    }
+    // True masks cached positions [pos..n_text_ctx); the appended current
+    // position at n_text_ctx remains visible, exactly matching the old mask.
+    let bool_bytes = DType::Bool.bytes();
+    if bool_bytes != 1 {
+        return Err(decode_err("decoder bool mask host encoding must be one byte"));
+    }
     let stride = n_text_ctx
         .checked_add(1)
-        .and_then(|positions| positions.checked_mul(std::mem::size_of::<f32>()))
+        .and_then(|positions| positions.checked_mul(bool_bytes))
         .ok_or_else(|| decode_err("mask row stride overflow"))?;
     let off = row.checked_mul(stride).ok_or_else(|| decode_err("mask row offset overflow"))?;
-    // [0..pos) = 0.0 (attend), [pos..n_text_ctx) = -inf (mask), [n_text_ctx] = 0.0
-    let mut mask = vec![0f32; n_text_ctx + 1];
+    let mut mask = vec![0u8; n_text_ctx + 1];
     let masked = mask.get_mut(pos..n_text_ctx).ok_or_else(|| decode_err("decoder position exceeds text context"))?;
-    for v in masked {
-        *v = f32::NEG_INFINITY;
-    }
-    let bytes: &[u8] = bytemuck::cast_slice(&mask);
-    let target = dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("mask row is out of bounds"))?;
-    target.copy_from_slice(bytes);
+    masked.fill(1);
+    let target = dst.get_mut(off..off + mask.len()).ok_or_else(|| decode_err("mask row is out of bounds"))?;
+    target.copy_from_slice(&mask);
     Ok(())
 }
 
 /// Seed one physical cache row from an immutable device-local snapshot.
 fn copy_device_cache_row(buf: &mut Buffer, row: usize, row_stride_bytes: usize, data: &Buffer) -> Result<()> {
-    if buf.dtype() != DType::Float32 || data.dtype() != DType::Float32 {
-        return Err(decode_err("cache seed buffers must be float32"));
+    if buf.dtype() != data.dtype() {
+        return Err(decode_err("cache seed source and destination dtypes disagree"));
+    }
+    let element_bytes = data.dtype().bytes();
+    if !row_stride_bytes.is_multiple_of(element_bytes) || !data.size().is_multiple_of(element_bytes) {
+        return Err(decode_err("cache seed copy is not element-aligned"));
     }
     if !std::ptr::eq(buf.allocator(), data.allocator()) {
         return Err(decode_err("cache seed and decoder row use different allocators"));
@@ -1797,9 +1823,9 @@ mod scheduler_seed_tests {
     use std::sync::Arc;
     use svod_device::CpuAllocator;
 
-    fn cache(allocator: Arc<CpuAllocator>, values: &[f32]) -> Buffer {
+    fn cache(allocator: Arc<CpuAllocator>, values: &[u16]) -> Buffer {
         let mut buffer =
-            Buffer::allocate(allocator, DType::Float32, vec![values.len()], BufferSpec::default()).unwrap();
+            Buffer::allocate(allocator, DType::Float16, vec![values.len()], BufferSpec::default()).unwrap();
         buffer.copyin(bytemuck::cast_slice(values)).unwrap();
         buffer
     }
@@ -1807,8 +1833,8 @@ mod scheduler_seed_tests {
     #[test]
     fn scheduler_seed_owns_device_buffers_and_seeds_multiple_rows() {
         let allocator = Arc::new(CpuAllocator);
-        let self_values = [1.0f32, 2.0, 3.0, 4.0];
-        let cross_values = [5.0f32, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let self_values = [0x3c00u16, 0x4000, 0x4200, 0x4400];
+        let cross_values = [0x4500u16, 0x4600, 0x4700, 0x4800, 0x4880, 0x4900];
         let self_k_source = cache(allocator.clone(), &self_values);
         let self_v_source = cache(allocator.clone(), &self_values);
         let cross_k_source = cache(allocator.clone(), &cross_values);
@@ -1834,7 +1860,7 @@ mod scheduler_seed_tests {
         .unwrap();
 
         assert_eq!(seed.metadata.initial_tokens, [1, 2]);
-        assert_eq!(seed.per_pos_bytes, 2 * std::mem::size_of::<f32>());
+        assert_eq!(seed.per_pos_bytes, 2 * DType::Float16.bytes());
         assert_eq!(seed.self_cache_bytes, std::mem::size_of_val(&self_values));
         assert_eq!(seed.cross_cache_bytes, std::mem::size_of_val(&cross_values));
         assert_eq!((seed.self_positions, seed.cross_positions), (2, 3));
@@ -1846,8 +1872,8 @@ mod scheduler_seed_tests {
         let self_stride = 4 * seed.per_pos_bytes;
         let mut self_rows = Buffer::allocate(
             allocator.clone(),
-            DType::Float32,
-            vec![2 * self_stride / std::mem::size_of::<f32>()],
+            DType::Float16,
+            vec![2 * self_stride / DType::Float16.bytes()],
             BufferSpec::default(),
         )
         .unwrap();
@@ -1860,8 +1886,8 @@ mod scheduler_seed_tests {
 
         let mut cross_rows = Buffer::allocate(
             allocator,
-            DType::Float32,
-            vec![2 * seed.cross_cache_bytes / std::mem::size_of::<f32>()],
+            DType::Float16,
+            vec![2 * seed.cross_cache_bytes / DType::Float16.bytes()],
             BufferSpec::default(),
         )
         .unwrap();

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -1,8 +1,9 @@
 //! KV-cached Whisper decoder: greedy, beam search, temperature fallback,
 //! and language detection — matching `whisper.decoding`.
 
+use super::config::N_AUDIO_CTX;
 use super::error::{DeviceSnafu, Error, JitSnafu, Result, TensorSnafu};
-use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
+use super::jit::{WhisperDecoderJit, WhisperDecoderStepBatchedJit, WhisperDecoderStepJit, WhisperPrefillJit};
 use super::model::Whisper;
 use super::tokenizer::WhisperTokenizer;
 use snafu::ResultExt;
@@ -318,6 +319,294 @@ pub fn greedy_decode_cached(
     }
 
     finish_decode(&tokens, tokenizer, sum_logprob, no_speech_prob, options)
+}
+
+// ─── Batched (step-locked) greedy decode ────────────────────────────────────
+//
+// The continuous-batching primitive: N lanes each carry independent decode
+// state (one per audio window), and every token step runs as a single batched
+// JIT dispatch across all active lanes. Lanes that hit EOT drop out; the loop
+// ends when no lanes remain. This is the bandwidth-amortizing path — one
+// weight read serves all lanes.
+//
+// `DecodeLane` reuses the same `DecodeCtx` fields (prefill seeds them) and
+// adds the per-step loop state that `greedy_decode_cached` kept as locals.
+
+/// One independent decode (one audio window's greedy decode attempt).
+///
+/// Built by [`DecodeLane::prefill`] from the `[1,4]` prefill JIT; the KV
+/// caches then live in the lane and are packed into the batched step JIT's
+/// `max_lanes`-sized buffers at the lane's row offset each step.
+pub struct DecodeLane {
+    // Static-per-attempt state (set by prefill, read each step)
+    pub initial_tokens: Vec<u32>,
+    pub sample_begin: usize,
+    pub init_len: usize,
+    pub suppress_tokens: Vec<i32>,
+    pub no_speech_prob: f32,
+    pub pos_embedding: Vec<f32>,
+    pub n_state: usize,
+
+    // KV caches — packed into the batched step JIT at this lane's row.
+    // self_k/v grow as tokens decode (one position appended per step via
+    // SDMA writeback); cross_k/v are fixed after prefill.
+    pub self_k_cache: Vec<f32>,
+    pub self_v_cache: Vec<f32>,
+    pub cross_k: Vec<f32>,
+    pub cross_v: Vec<f32>,
+
+    // Per-step loop state (mutated each step)
+    pub next_token: u32,
+    pub tokens: Vec<u32>,
+    pub sum_logprob: f32,
+    pub pos: usize, // current position = init_len + step
+    pub done: bool,
+}
+
+impl DecodeLane {
+    /// Run prefill for one window and build the lane state.
+    ///
+    /// `audio_raw` is the encoder output for this window, flat
+    /// `[N_AUDIO_CTX * n_audio_state]` f32 (the slice the existing
+    /// `decode_with_fallback_cached` passes to `init_decode`).
+    pub fn prefill(
+        prefill_jit: &mut WhisperPrefillJit,
+        tokenizer: &WhisperTokenizer,
+        options: &DecodeOptions,
+        n_text_ctx: usize,
+        n_vocab: usize,
+        pos_embedding: &[f32],
+        n_state: usize,
+    ) -> Result<Self> {
+        let ctx = init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)?;
+
+        // First token from prefill logits (mirrors greedy_decode_cached:260-278)
+        let last_logits = &ctx.prefill_logits[(ctx.init_len - 1) * n_vocab..ctx.init_len * n_vocab];
+        let mut filtered = last_logits.to_vec();
+        apply_logit_filters(
+            &mut filtered,
+            tokenizer,
+            options,
+            &ctx.initial_tokens,
+            ctx.sample_begin,
+            0,
+            &ctx.suppress_tokens,
+        );
+        let next_token = pick_token(&filtered, options.temperature);
+        let sum_logprob = log_softmax(&filtered, next_token as usize);
+
+        let mut tokens = Vec::new();
+        if next_token != tokenizer.eot() {
+            tokens.push(next_token);
+        }
+
+        Ok(Self {
+            initial_tokens: ctx.initial_tokens,
+            sample_begin: ctx.sample_begin,
+            init_len: ctx.init_len,
+            suppress_tokens: ctx.suppress_tokens,
+            no_speech_prob: ctx.no_speech_prob,
+            pos_embedding: ctx.pos_embedding,
+            n_state: ctx.n_state,
+            self_k_cache: ctx.self_k_cache,
+            self_v_cache: ctx.self_v_cache,
+            cross_k: ctx.cross_k,
+            cross_v: ctx.cross_v,
+            next_token,
+            tokens,
+            sum_logprob,
+            pos: ctx.init_len, // first step decodes at init_len
+            done: next_token == tokenizer.eot(),
+        })
+    }
+
+    /// Per-position floats in the self cache: `n_layer * n_head * d_head`.
+    fn per_pos_floats(&self) -> usize {
+        self.self_k_cache.len() / self.init_len
+    }
+
+    fn per_pos_bytes(&self) -> usize {
+        self.per_pos_floats() * std::mem::size_of::<f32>()
+    }
+
+    pub fn finish(self, tokenizer: &WhisperTokenizer, options: &DecodeOptions) -> Result<DecodeResult> {
+        finish_decode(&self.tokens, tokenizer, self.sum_logprob, self.no_speech_prob, options)
+    }
+}
+
+/// Step-locked batched greedy decode: advances every active lane by one token
+/// per JIT dispatch, until all lanes are `done` or hit `sample_len`.
+///
+/// Each lane occupies a fixed row (`lane_idx`) in the batched step JIT's
+/// buffers; inactive lanes are skipped. The plan is rebound to the active
+/// count each dispatch via `execute_with_vars(&[("b", active)])`.
+#[allow(clippy::too_many_arguments)]
+pub fn run_batched_decode(
+    lanes: &mut [DecodeLane],
+    step_jit: &mut WhisperDecoderStepBatchedJit,
+    tokenizer: &WhisperTokenizer,
+    options: &DecodeOptions,
+    n_text_ctx: usize,
+    n_vocab: usize,
+) -> Result<()> {
+    let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
+    let eot = tokenizer.eot();
+    let n_state = lanes.first().map(|l| l.n_state).unwrap_or(0);
+
+    loop {
+        // Collect the active (not-done, not-at-sample_len) lanes by index.
+        let active: Vec<usize> = lanes
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| !l.done && l.tokens.len() < sample_len && l.next_token != eot)
+            .map(|(i, _)| i)
+            .collect();
+        if active.is_empty() {
+            break;
+        }
+        let active_count = active.len();
+
+        // Per-position float count and buffer row strides. All lanes share
+        // the same structural dims, so read them from the first active lane.
+        let per_pos_floats = lanes[active[0]].per_pos_floats();
+        let self_row_stride = n_text_ctx * per_pos_floats; // [max_lanes, N_TEXT_CTX, ...]
+        let cross_row_stride = N_AUDIO_CTX * per_pos_floats; // [max_lanes, N_AUDIO_CTX, ...]
+
+        // Pack each active lane's inputs into the batched JIT at its row.
+        // Rows are contiguous: active lane `j` (j=0..active_count) maps to
+        // row `j` in the [active_count, ...] dispatch.
+        for (row, &lane_idx) in active.iter().enumerate() {
+            let lane = &lanes[lane_idx];
+            write_token_row(step_jit, row, lane.next_token)?;
+            write_pos_emb_row(step_jit, row, &lane.pos_embedding[lane.pos * n_state..(lane.pos + 1) * n_state])?;
+            write_self_mask_row(step_jit, row, lane.pos, n_text_ctx)?;
+            write_cache_row(step_jit.self_k_cache_mut(), row, self_row_stride, &lane.self_k_cache)?;
+            write_cache_row(step_jit.self_v_cache_mut(), row, self_row_stride, &lane.self_v_cache)?;
+            write_cache_row(step_jit.cross_k_mut(), row, cross_row_stride, &lane.cross_k)?;
+            write_cache_row(step_jit.cross_v_mut(), row, cross_row_stride, &lane.cross_v)?;
+        }
+
+        // One dispatch for all active lanes, rebound to the live count.
+        step_jit.execute_with_vars(&[("b", active_count as i64)]).context(JitSnafu)?;
+
+        // Per-lane teardown: SDMA-writeback new K/V, read logits, pick token.
+        for (row, &lane_idx) in active.iter().enumerate() {
+            let lane = &mut lanes[lane_idx];
+
+            // Device-side K/V copy: append this step's new K/V at lane.pos.
+            // Input buffer is [max_lanes, N_TEXT_CTX, ...]; this lane's row
+            // starts at row*N_TEXT_CTX*per_pos_floats*4, position `pos` within
+            // that row. Output buffer is [active_count, 1, ...]; the `row`-th
+            // lane's new K/V is at row*per_pos_floats*4.
+            let per_pos_b = lane.per_pos_bytes();
+            let dst_base = row * self_row_stride * std::mem::size_of::<f32>();
+            let dst_off = dst_base + lane.pos * per_pos_b;
+            let src_off = row * per_pos_b;
+            step_jit
+                .copy_output_to_self_k_cache(1, dst_off, src_off, per_pos_b)
+                .context(JitSnafu)?;
+            step_jit
+                .copy_output_to_self_v_cache(2, dst_off, src_off, per_pos_b)
+                .context(JitSnafu)?;
+
+            // Read this lane's logits row and pick the next token.
+            let logits = read_logits_row(step_jit, row, n_vocab)?;
+            let all_toks: Vec<u32> = lane.initial_tokens.iter().copied().chain(lane.tokens.iter().copied()).collect();
+            let step = lane.pos + 1 - lane.init_len;
+            let mut filtered = logits;
+            apply_logit_filters(
+                &mut filtered,
+                tokenizer,
+                options,
+                &all_toks,
+                lane.sample_begin,
+                step,
+                &lane.suppress_tokens,
+            );
+            lane.next_token = pick_token(&filtered, options.temperature);
+            lane.sum_logprob += log_softmax(&filtered, lane.next_token as usize);
+
+            if lane.next_token != eot {
+                lane.tokens.push(lane.next_token);
+            }
+            lane.pos += 1;
+            if lane.next_token == eot || lane.tokens.len() >= sample_len {
+                lane.done = true;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ─── Batched JIT buffer row helpers ─────────────────────────────────────────
+//
+// The batched step JIT owns max_lanes-sized buffers; each lane writes/reads
+// its row. These wrap the per-row slicing so the main loop stays readable.
+
+fn write_token_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, token: u32) -> Result<()> {
+    let buf = jit.token_mut().context(JitSnafu)?;
+    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
+    // token is [max_lanes, 1] i32; row stride = 4 bytes
+    let off = row * std::mem::size_of::<i32>();
+    let tok = [token as i32];
+    let bytes: &[u8] = bytemuck::cast_slice(&tok);
+    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    Ok(())
+}
+
+fn write_pos_emb_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, emb: &[f32]) -> Result<()> {
+    let buf = jit.pos_emb_mut().context(JitSnafu)?;
+    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
+    // pos_emb is [max_lanes, 1, n_state] f32
+    let off = row * emb.len() * std::mem::size_of::<f32>();
+    let bytes: &[u8] = bytemuck::cast_slice(emb);
+    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    Ok(())
+}
+
+fn write_self_mask_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, pos: usize, n_text_ctx: usize) -> Result<()> {
+    let buf = jit.self_mask_mut().context(JitSnafu)?;
+    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
+    // mask is [max_lanes, 1, 1, n_text_ctx + 1]; row stride = (n_text_ctx+1)*4
+    let stride = (n_text_ctx + 1) * std::mem::size_of::<f32>();
+    let off = row * stride;
+    // [0..pos) = 0.0 (attend), [pos..n_text_ctx) = -inf (mask), [n_text_ctx] = 0.0
+    let mut mask = vec![0f32; n_text_ctx + 1];
+    for v in &mut mask[pos..n_text_ctx] {
+        *v = f32::NEG_INFINITY;
+    }
+    let bytes: &[u8] = bytemuck::cast_slice(&mask);
+    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    Ok(())
+}
+
+/// Write a full cache buffer (self or cross) into one row of the batched JIT.
+/// `row_stride_floats` is the buffer's per-row capacity (N_TEXT_CTX or
+/// N_AUDIO_CTX positions × per_pos_floats); `data` may be shorter (e.g. only
+/// `init_len` positions populated for the self cache after prefill).
+fn write_cache_row(
+    buf_result: crate::jit::Result<&mut svod_device::Buffer>,
+    row: usize,
+    row_stride_floats: usize,
+    data: &[f32],
+) -> Result<()> {
+    let buf = buf_result.context(JitSnafu)?;
+    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
+    let off = row * row_stride_floats * std::mem::size_of::<f32>();
+    let bytes: &[u8] = bytemuck::cast_slice(data);
+    dst[off..off + bytes.len()].copy_from_slice(bytes);
+    Ok(())
+}
+
+/// Read one lane's logits row `[n_vocab]` from the batched JIT output.
+fn read_logits_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, n_vocab: usize) -> Result<Vec<f32>> {
+    let buf = jit.logits().context(JitSnafu)?;
+    let src = buf.as_host_bytes().context(DeviceSnafu)?;
+    let row_floats = n_vocab;
+    let off = row * row_floats * std::mem::size_of::<f32>();
+    let end = off + row_floats * std::mem::size_of::<f32>();
+    Ok(bytemuck::cast_slice(&src[off..end]).to_vec())
 }
 
 // ─── Cached beam search ─────────────────────────────────────────────────────

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -2,7 +2,7 @@
 
 use super::error::{DeviceSnafu, Error, JitSnafu, Result};
 use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
-use super::profile::{CopyProfile, begin_host_copy, timed_d2d};
+use super::profile::{CopyProfile, GraphProfile, begin_host_copy, timed_d2d};
 use super::tokenizer::WhisperTokenizer;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -28,7 +28,7 @@ pub fn detect_language(
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
 ) -> Result<LanguageDetection> {
-    detect_language_profile(decoder_jit, n_text_ctx, n_vocab, tokenizer, None)
+    detect_language_profile(decoder_jit, n_text_ctx, n_vocab, tokenizer, None, None)
 }
 
 pub(crate) fn detect_language_profile(
@@ -37,6 +37,7 @@ pub(crate) fn detect_language_profile(
     n_vocab: usize,
     tokenizer: &WhisperTokenizer,
     mut copies: Option<&mut CopyProfile>,
+    graph_profile: Option<&mut GraphProfile>,
 ) -> Result<LanguageDetection> {
     let sot = tokenizer.sot() as i32;
     let eot = tokenizer.eot() as i32;
@@ -46,7 +47,14 @@ pub(crate) fn detect_language_profile(
     if let (Some(copies), Some(started)) = (copies.as_deref_mut(), started) {
         copies.h2d("language_tokens", 1, token_buf.len() * std::mem::size_of::<i32>(), started.elapsed());
     }
-    decoder_jit.execute().context(JitSnafu)?;
+    if let Some(graph_profile) = graph_profile {
+        let graph_started = std::time::Instant::now();
+        let kernels = decoder_jit.execute_profiled().context(JitSnafu)?;
+        decoder_jit.output().context(JitSnafu)?.synchronize().context(DeviceSnafu)?;
+        graph_profile.record(graph_started.elapsed(), kernels);
+    } else {
+        decoder_jit.execute().context(JitSnafu)?;
+    }
     let started = begin_host_copy(copies.is_some(), decoder_jit.output().context(JitSnafu)?)?;
     let flat = read_uncached(decoder_jit)?;
     if let (Some(copies), Some(started)) = (copies, started) {
@@ -299,9 +307,18 @@ pub(crate) fn prefill_decode_seed(
     pos_embedding: &[f32],
     n_state: usize,
     mut copies: Option<&mut CopyProfile>,
+    graph_profile: Option<&mut GraphProfile>,
 ) -> Result<DecodeSeed> {
-    let metadata =
-        execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state, copies.as_deref_mut())?;
+    let metadata = execute_prefill(
+        prefill_jit,
+        tokenizer,
+        options,
+        n_vocab,
+        pos_embedding,
+        n_state,
+        copies.as_deref_mut(),
+        graph_profile,
+    )?;
     let self_k_src = prefill_jit.self_k().context(JitSnafu)?.clone();
     let self_v_src = prefill_jit.self_v().context(JitSnafu)?.clone();
     let cross_k_src = prefill_jit.prepared_cross_k_mut().context(JitSnafu)?.clone();
@@ -768,8 +785,7 @@ pub(crate) fn run_fixed_slot_decode(
     n_text_ctx: usize,
     n_vocab: usize,
     profile: bool,
-    profile_kernels: bool,
-) -> Result<(Vec<DecodeResult>, DecodeScheduleStats, Vec<svod_runtime::KernelProfile>)> {
+) -> Result<(Vec<DecodeResult>, DecodeScheduleStats, GraphProfile)> {
     if seeds.len() != request_options.len() {
         return Err(decode_err("decode seed/options count mismatch"));
     }
@@ -788,7 +804,7 @@ pub(crate) fn run_fixed_slot_decode(
     let mut attempts: Vec<Option<ScheduledAttempt>> = (0..seeds.len()).map(|_| None).collect();
     let mut results: Vec<Option<DecodeResult>> = (0..seeds.len()).map(|_| None).collect();
     let mut stats = DecodeScheduleStats::default();
-    let mut profiled_kernels = Vec::new();
+    let mut graph_profile = GraphProfile::default();
     let mut rngs: Vec<_> =
         request_options.iter().enumerate().map(|(request, options)| sampling_rng(options, request)).collect();
 
@@ -905,8 +921,11 @@ pub(crate) fn run_fixed_slot_decode(
                     AttemptKind::Beam(beam) => beam.active.len(),
                 })
                 .sum::<usize>();
-            if profile_kernels && profiled_kernels.is_empty() {
-                profiled_kernels = step_jit.execute_profiled().context(JitSnafu)?;
+            if profile {
+                let graph_started = std::time::Instant::now();
+                let kernels = step_jit.execute_profiled().context(JitSnafu)?;
+                step_jit.logits().context(JitSnafu)?.synchronize().context(DeviceSnafu)?;
+                graph_profile.record(graph_started.elapsed(), kernels);
             } else {
                 step_jit.execute().context(JitSnafu)?;
             }
@@ -1077,7 +1096,7 @@ pub(crate) fn run_fixed_slot_decode(
         }
     }
 
-    Ok((collect_ordered(results).map_err(decode_err)?, stats, profiled_kernels))
+    Ok((collect_ordered(results).map_err(decode_err)?, stats, graph_profile))
 }
 
 // ─── Batched JIT buffer row helpers ─────────────────────────────────────────
@@ -1325,6 +1344,7 @@ struct PrefillMetadata {
     n_state: usize,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_prefill(
     prefill_jit: &mut WhisperPrefillJit,
     tokenizer: &WhisperTokenizer,
@@ -1333,6 +1353,7 @@ fn execute_prefill(
     pos_embedding: &[f32],
     n_state: usize,
     mut copies: Option<&mut CopyProfile>,
+    graph_profile: Option<&mut GraphProfile>,
 ) -> Result<PrefillMetadata> {
     // Build initial tokens
     let mut initial_tokens = vec![tokenizer.sot()];
@@ -1362,7 +1383,14 @@ fn execute_prefill(
     }
 
     // Execute prefill JIT (plan manages all buffers, no realize)
-    prefill_jit.execute().context(JitSnafu)?;
+    if let Some(graph_profile) = graph_profile {
+        let graph_started = std::time::Instant::now();
+        let kernels = prefill_jit.execute_profiled().context(JitSnafu)?;
+        prefill_jit.logits().context(JitSnafu)?.synchronize().context(DeviceSnafu)?;
+        graph_profile.record(graph_started.elapsed(), kernels);
+    } else {
+        prefill_jit.execute().context(JitSnafu)?;
+    }
 
     // Read logits from output 0
     let started = begin_host_copy(copies.is_some(), prefill_jit.logits().context(JitSnafu)?)?;

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -74,14 +74,57 @@ impl std::str::FromStr for WhisperTask {
     }
 }
 
-#[derive(Clone)]
+/// Search algorithm for the first decode attempt.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DecodeStrategy {
+    /// Deterministic token-by-token argmax.
+    Greedy,
+    /// Beam search with a concrete number of decoder rows.
+    Beam { size: usize },
+    /// Multinomial sampling at a positive temperature.
+    Sample { temperature: f32 },
+}
+
+impl DecodeStrategy {
+    fn temperature(self) -> f32 {
+        match self {
+            Self::Greedy | Self::Beam { .. } => 0.0,
+            Self::Sample { temperature } => temperature,
+        }
+    }
+}
+
+/// Quality-gated sampling attempts after the primary decode is rejected.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FallbackPolicy {
+    /// Positive sampling temperatures tried in order.
+    pub sampling_temperatures: Vec<f32>,
+    /// Retry when text compression exceeds this threshold.
+    pub compression_ratio_threshold: Option<f32>,
+    /// Retry below this average log-probability.
+    pub logprob_threshold: Option<f32>,
+}
+
+impl Default for FallbackPolicy {
+    fn default() -> Self {
+        Self {
+            sampling_temperatures: vec![0.2, 0.4, 0.6, 0.8, 1.0],
+            compression_ratio_threshold: Some(2.4),
+            logprob_threshold: Some(-1.0),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct DecodeOptions {
     /// Whether to transcribe source speech or translate it to English.
     pub task: WhisperTask,
     /// Source language code, or `None` for automatic detection.
     pub language: Option<String>,
-    /// Initial sampling temperature.
-    pub temperature: f32,
+    /// Search algorithm for the first decode attempt.
+    pub strategy: DecodeStrategy,
+    /// Optional quality-gated sampling retries.
+    pub fallback: Option<FallbackPolicy>,
     /// Maximum generated token count; defaults to half the text context.
     pub sample_len: Option<usize>,
     /// Suppress blank/space as the first generated token.
@@ -90,14 +133,6 @@ pub struct DecodeOptions {
     pub suppress_tokens: Option<Vec<i32>>,
     /// Latest timestamp permitted at the beginning of a window, in seconds.
     pub max_initial_timestamp: Option<f32>,
-    /// Beam width, or `None` for greedy/sampling decode.
-    pub beam_size: Option<usize>,
-    /// Temperature increment used by fallback; zero disables fallback.
-    pub temperature_inc: f32,
-    /// Retry when text compression exceeds this threshold.
-    pub compression_ratio_threshold: Option<f32>,
-    /// Retry low-confidence decodes below this average log-probability.
-    pub logprob_threshold: Option<f32>,
     /// Skip likely silence when no-speech probability exceeds this threshold.
     pub no_speech_threshold: Option<f32>,
 }
@@ -107,18 +142,52 @@ impl Default for DecodeOptions {
         Self {
             task: WhisperTask::Transcribe,
             language: None,
-            temperature: 0.0,
+            strategy: DecodeStrategy::Beam { size: 5 },
+            fallback: Some(FallbackPolicy::default()),
             sample_len: None,
             suppress_blank: true,
             suppress_tokens: Some(vec![-1]),
             max_initial_timestamp: Some(1.0),
-            beam_size: Some(5),
-            temperature_inc: 0.2,
-            compression_ratio_threshold: Some(2.4),
-            logprob_threshold: Some(-1.0),
             no_speech_threshold: Some(0.6),
         }
     }
+}
+
+impl DecodeOptions {
+    /// Validate strategy geometry and sampling parameters before graph preparation.
+    pub fn validate(&self) -> std::result::Result<(), &'static str> {
+        match self.strategy {
+            DecodeStrategy::Beam { size: 0 } => return Err("beam size must be non-zero"),
+            DecodeStrategy::Sample { temperature } if !valid_temperature(temperature) => {
+                return Err("sampling temperature must be finite and positive");
+            }
+            _ => {}
+        }
+        if let Some(fallback) = &self.fallback {
+            if fallback.sampling_temperatures.is_empty() {
+                return Err("fallback sampling temperatures must be non-empty");
+            }
+            if fallback.sampling_temperatures.iter().any(|&temperature| !valid_temperature(temperature)) {
+                return Err("fallback sampling temperatures must be finite and positive");
+            }
+            if fallback.compression_ratio_threshold.is_some_and(|threshold| !threshold.is_finite() || threshold <= 0.0)
+            {
+                return Err("compression ratio threshold must be finite and positive");
+            }
+            if fallback.logprob_threshold.is_some_and(|threshold| !threshold.is_finite()) {
+                return Err("log-probability threshold must be finite");
+            }
+        }
+        if self.no_speech_threshold.is_some_and(|threshold| !threshold.is_finite() || !(0.0..=1.0).contains(&threshold))
+        {
+            return Err("no-speech threshold must be between zero and one");
+        }
+        Ok(())
+    }
+}
+
+fn valid_temperature(temperature: f32) -> bool {
+    temperature.is_finite() && temperature > 0.0
 }
 
 #[derive(Clone, Debug)]
@@ -128,6 +197,7 @@ pub struct DecodeResult {
     pub text: String,
     pub avg_logprob: f32,
     pub no_speech_prob: f32,
+    /// Sampling temperature of the accepted attempt; zero for greedy or beam.
     pub temperature: f32,
     pub compression_ratio: f32,
     pub language: Option<String>,
@@ -141,7 +211,11 @@ impl DecodeResult {
         if self.no_speech_prob <= no_speech_threshold {
             return false;
         }
-        options.logprob_threshold.is_none_or(|threshold| self.avg_logprob <= threshold)
+        options
+            .fallback
+            .as_ref()
+            .and_then(|fallback| fallback.logprob_threshold)
+            .is_none_or(|threshold| self.avg_logprob <= threshold)
     }
 
     pub fn clear_speech(&mut self) {
@@ -165,34 +239,35 @@ pub fn decode_with_fallback_cached(
     pos_embedding: &[f32],
     n_state: usize,
 ) -> Result<DecodeResult> {
+    options.validate().map_err(decode_err)?;
     let resolved_lang = resolve_language(options, decoder_jit, n_text_ctx, n_vocab, tokenizer)?;
 
-    let temperatures = build_temperature_schedule(options);
+    let mut strategies = vec![options.strategy];
+    if let Some(fallback) = &options.fallback {
+        strategies
+            .extend(fallback.sampling_temperatures.iter().map(|&temperature| DecodeStrategy::Sample { temperature }));
+    }
     let mut best: Option<DecodeResult> = None;
 
-    for (t_idx, &temp) in temperatures.iter().enumerate() {
+    for (attempt, &strategy) in strategies.iter().enumerate() {
         let mut opts = options.clone();
-        opts.temperature = temp;
+        opts.strategy = strategy;
+        opts.fallback = None;
         opts.language = resolved_lang.clone();
-        if temp > 0.0 {
-            opts.beam_size = None;
-        }
 
-        let result = if temp == 0.0 && opts.beam_size.unwrap_or(0) > 0 {
-            let bs = opts.beam_size.unwrap();
-            beam_decode_cached(
+        let result = match strategy {
+            DecodeStrategy::Beam { size } => beam_decode_cached(
                 prefill_jit,
-                step_jits.get_mut(&bs).ok_or_else(|| decode_err("beam JIT missing"))?,
+                step_jits.get_mut(&size).ok_or_else(|| decode_err("beam JIT missing"))?,
                 n_text_ctx,
                 n_vocab,
                 tokenizer,
                 &opts,
-                bs,
+                size,
                 pos_embedding,
                 n_state,
-            )
-        } else {
-            greedy_decode_cached(
+            )?,
+            DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => greedy_decode_cached(
                 prefill_jit,
                 step_jits.get_mut(&1).ok_or_else(|| decode_err("greedy JIT missing"))?,
                 n_text_ctx,
@@ -201,10 +276,11 @@ pub fn decode_with_fallback_cached(
                 &opts,
                 pos_embedding,
                 n_state,
-            )
-        }?;
+            )?,
+        };
 
-        let needs_fallback = t_idx < temperatures.len() - 1 && check_fallback(&result, options);
+        let needs_fallback = attempt < strategies.len() - 1
+            && options.fallback.as_ref().is_some_and(|fallback| check_fallback(&result, fallback, options));
         best = Some(result);
         if !needs_fallback {
             break;
@@ -230,34 +306,12 @@ fn resolve_language(
     Ok(Some(detection.language))
 }
 
-fn build_temperature_schedule(options: &DecodeOptions) -> Vec<f32> {
-    if options.temperature_inc <= 0.0 {
-        return vec![options.temperature];
-    }
-    let mut temps = Vec::new();
-    let mut t = options.temperature;
-    while t < 1.0 + 1e-6 {
-        temps.push(t);
-        t += options.temperature_inc;
-    }
-    temps
-}
-
-fn check_fallback(result: &DecodeResult, options: &DecodeOptions) -> bool {
-    if let Some(th) = options.compression_ratio_threshold
-        && result.compression_ratio > th
-    {
-        return true;
-    }
-    if let Some(th) = options.logprob_threshold
-        && result.avg_logprob < th
-    {
-        if let Some(ns) = options.no_speech_threshold {
-            return result.no_speech_prob <= ns;
-        }
-        return true;
-    }
-    false
+pub(crate) fn check_fallback(result: &DecodeResult, fallback: &FallbackPolicy, options: &DecodeOptions) -> bool {
+    let repetitive = fallback.compression_ratio_threshold.is_some_and(|threshold| result.compression_ratio > threshold);
+    let low_confidence = fallback.logprob_threshold.is_some_and(|threshold| result.avg_logprob < threshold);
+    let silence =
+        options.no_speech_threshold.is_some_and(|threshold| result.no_speech_prob > threshold) && low_confidence;
+    (repetitive || low_confidence) && !silence
 }
 
 // ─── Cached greedy decode ───────────────────────────────────────────────────
@@ -288,7 +342,7 @@ pub fn greedy_decode_cached(
         0,
         &ctx.suppress_tokens,
     );
-    let mut next_token = pick_token(&filtered, options.temperature);
+    let mut next_token = pick_token(&filtered, options.strategy.temperature());
     let mut sum_logprob = log_softmax(&filtered, next_token as usize);
     let no_speech_prob = ctx.no_speech_prob;
 
@@ -328,7 +382,7 @@ pub fn greedy_decode_cached(
             &ctx.suppress_tokens,
         );
 
-        next_token = pick_token(&filtered, options.temperature);
+        next_token = pick_token(&filtered, options.strategy.temperature());
         let token_logprob = log_softmax(&filtered, next_token as usize);
         sum_logprob += token_logprob;
 
@@ -416,7 +470,7 @@ impl DecodeLane {
             0,
             &ctx.suppress_tokens,
         );
-        let next_token = pick_token(&filtered, options.temperature);
+        let next_token = pick_token(&filtered, options.strategy.temperature());
         let sum_logprob = log_softmax(&filtered, next_token as usize);
 
         let mut tokens = Vec::new();
@@ -576,7 +630,7 @@ pub fn run_batched_decode(
                 step,
                 &lane.suppress_tokens,
             );
-            lane.next_token = pick_token(&filtered, options.temperature);
+            lane.next_token = pick_token(&filtered, options.strategy.temperature());
             let token_logprob = log_softmax(&filtered, lane.next_token as usize);
             lane.sum_logprob += token_logprob;
 
@@ -842,7 +896,7 @@ pub fn beam_decode_cached(
         text,
         avg_logprob,
         no_speech_prob: ctx.no_speech_prob,
-        temperature: options.temperature,
+        temperature: options.strategy.temperature(),
         compression_ratio,
         language: options.language.clone(),
     })
@@ -1203,7 +1257,7 @@ fn finish_decode(
         text,
         avg_logprob,
         no_speech_prob,
-        temperature: options.temperature,
+        temperature: options.strategy.temperature(),
         compression_ratio,
         language: options.language.clone(),
     })

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -532,6 +532,31 @@ pub(crate) fn collect_ordered<T>(results: Vec<Option<T>>) -> std::result::Result
     results.into_iter().map(|result| result.ok_or("missing scheduled result")).collect()
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct DecodeScheduleStats {
+    pub(crate) dispatches: usize,
+    pub(crate) active_row_steps: usize,
+    pub(crate) reserved_row_steps: usize,
+    pub(crate) capacity_row_steps: usize,
+    pub(crate) cache_clone_ops: usize,
+    pub(crate) cache_clone_bytes: usize,
+    pub(crate) attempts: usize,
+    pub(crate) fallback_attempts: usize,
+}
+
+impl DecodeScheduleStats {
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.dispatches += other.dispatches;
+        self.active_row_steps += other.active_row_steps;
+        self.reserved_row_steps += other.reserved_row_steps;
+        self.capacity_row_steps += other.capacity_row_steps;
+        self.cache_clone_ops += other.cache_clone_ops;
+        self.cache_clone_bytes += other.cache_clone_bytes;
+        self.attempts += other.attempts;
+        self.fallback_attempts += other.fallback_attempts;
+    }
+}
+
 /// Small independently-testable allocator enforcing whole-attempt admission.
 #[derive(Debug)]
 pub(crate) struct SlotAllocator {
@@ -576,6 +601,10 @@ impl SlotAllocator {
                 *slot = None;
             }
         }
+    }
+
+    fn reserved(&self) -> usize {
+        self.owners.iter().filter(|owner| owner.is_some()).count()
     }
 
     #[cfg(test)]
@@ -835,7 +864,7 @@ pub(crate) fn run_fixed_slot_decode(
     tokenizer: &WhisperTokenizer,
     n_text_ctx: usize,
     n_vocab: usize,
-) -> Result<Vec<DecodeResult>> {
+) -> Result<(Vec<DecodeResult>, DecodeScheduleStats)> {
     if seeds.len() != request_options.len() {
         return Err(decode_err("decode seed/options count mismatch"));
     }
@@ -853,6 +882,7 @@ pub(crate) fn run_fixed_slot_decode(
     let mut allocator = SlotAllocator::new(capacity);
     let mut attempts: Vec<Option<ScheduledAttempt>> = (0..seeds.len()).map(|_| None).collect();
     let mut results: Vec<Option<DecodeResult>> = (0..seeds.len()).map(|_| None).collect();
+    let mut stats = DecodeScheduleStats::default();
 
     while results.iter().any(Option::is_none) {
         while let Some(&(request, strategy_index)) = queue.front() {
@@ -866,6 +896,8 @@ pub(crate) fn run_fixed_slot_decode(
             let attempt = start_attempt(strategy_index, strategy, rows, &seeds[request], tokenizer, &options, n_vocab)?;
             seed_attempt_rows(step_jit, &attempt.reserved_rows, &seeds[request], n_text_ctx)?;
             attempts[request] = Some(attempt);
+            stats.attempts += 1;
+            stats.fallback_attempts += usize::from(strategy_index > 0);
         }
 
         let active_requests: Vec<_> =
@@ -918,6 +950,16 @@ pub(crate) fn run_fixed_slot_decode(
         }
 
         if dispatch {
+            stats.dispatches += 1;
+            stats.capacity_row_steps += capacity;
+            stats.reserved_row_steps += allocator.reserved();
+            stats.active_row_steps += active_requests
+                .iter()
+                .map(|&request| match &attempts[request].as_ref().expect("active attempt").kind {
+                    AttemptKind::Single(_) => 1,
+                    AttemptKind::Beam(beam) => beam.active.len(),
+                })
+                .sum::<usize>();
             step_jit.execute().context(JitSnafu)?;
             for &request in &active_requests {
                 let attempt = attempts[request].as_mut().expect("active attempt");
@@ -1004,6 +1046,8 @@ pub(crate) fn run_fixed_slot_decode(
                             per_pos_bytes,
                             row_stride_bytes,
                         )?;
+                        stats.cache_clone_ops += assignment.copies.len();
+                        stats.cache_clone_bytes += assignment.copies.len() * (attempt.pos + 1) * per_pos_bytes * 2;
                         beam.active = active;
                         beam.rows = assignment.rows;
                     }
@@ -1041,7 +1085,7 @@ pub(crate) fn run_fixed_slot_decode(
         }
     }
 
-    collect_ordered(results).map_err(decode_err)
+    Ok((collect_ordered(results).map_err(decode_err)?, stats))
 }
 
 // ─── Batched JIT buffer row helpers ─────────────────────────────────────────

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -868,12 +868,12 @@ pub(crate) fn run_fixed_slot_decode(
                             .get(attempt.pos * seed.n_state..(attempt.pos + 1) * seed.n_state)
                             .ok_or_else(|| decode_err("position embedding is out of bounds"))?,
                     )?;
-                    write_self_mask_row(step_jit, row, attempt.pos, n_text_ctx)?;
+                    write_self_key_len_row(step_jit, row, attempt.pos)?;
                     control_ops = control_ops.saturating_add(3);
                     control_bytes = control_bytes.saturating_add(
                         std::mem::size_of::<i32>()
                             + seed.n_state * std::mem::size_of::<f32>()
-                            + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
+                            + std::mem::size_of::<i32>(),
                     );
                 }
                 AttemptKind::Beam(beam) => {
@@ -890,12 +890,12 @@ pub(crate) fn run_fixed_slot_decode(
                                 .get(attempt.pos * seed.n_state..(attempt.pos + 1) * seed.n_state)
                                 .ok_or_else(|| decode_err("position embedding is out of bounds"))?,
                         )?;
-                        write_self_mask_row(step_jit, row, attempt.pos, n_text_ctx)?;
+                        write_self_key_len_row(step_jit, row, attempt.pos)?;
                         control_ops = control_ops.saturating_add(3);
                         control_bytes = control_bytes.saturating_add(
                             std::mem::size_of::<i32>()
                                 + seed.n_state * std::mem::size_of::<f32>()
-                                + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
+                                + std::mem::size_of::<i32>(),
                         );
                     }
                 }
@@ -1125,23 +1125,15 @@ fn write_pos_emb_row(jit: &mut WhisperDecoderStepJit, row: usize, emb: &[f32]) -
     Ok(())
 }
 
-fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, n_text_ctx: usize) -> Result<()> {
-    let buf = jit.self_mask_mut().context(JitSnafu)?;
+fn write_self_key_len_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize) -> Result<()> {
+    let buf = jit.self_key_lens_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-    // mask is [max_lanes, 1, 1, n_text_ctx + 1]; row stride = (n_text_ctx+1)*4
-    let stride = n_text_ctx
-        .checked_add(1)
-        .and_then(|positions| positions.checked_mul(std::mem::size_of::<f32>()))
-        .ok_or_else(|| decode_err("mask row stride overflow"))?;
-    let off = row.checked_mul(stride).ok_or_else(|| decode_err("mask row offset overflow"))?;
-    // [0..pos) = 0.0 (attend), [pos..n_text_ctx) = -inf (mask), [n_text_ctx] = 0.0
-    let mut mask = vec![0f32; n_text_ctx + 1];
-    let masked = mask.get_mut(pos..n_text_ctx).ok_or_else(|| decode_err("decoder position exceeds text context"))?;
-    for v in masked {
-        *v = f32::NEG_INFINITY;
-    }
-    let bytes: &[u8] = bytemuck::cast_slice(&mask);
-    let target = dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("mask row is out of bounds"))?;
+    let off =
+        row.checked_mul(std::mem::size_of::<i32>()).ok_or_else(|| decode_err("self key length row offset overflow"))?;
+    let len = i32::try_from(pos).map_err(|_| decode_err("decoder position exceeds i32"))?;
+    let bytes: &[u8] = bytemuck::bytes_of(&len);
+    let target =
+        dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("self key length row is out of bounds"))?;
     target.copy_from_slice(bytes);
     Ok(())
 }

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -343,14 +343,13 @@ pub(crate) fn prefill_decode_seed(
 }
 
 fn clone_device_cache(src: &Buffer) -> Result<Buffer> {
-    let element_bytes = src.dtype().bytes();
-    if element_bytes == 0 || !src.size().is_multiple_of(element_bytes) {
-        return Err(decode_err("prefill cache is not element-aligned"));
+    if src.dtype() != DType::Float32 || !src.size().is_multiple_of(std::mem::size_of::<f32>()) {
+        return Err(decode_err("prefill cache must contain aligned float32 data"));
     }
     let mut clone = Buffer::allocate(
         src.allocator_arc(),
-        src.dtype().clone(),
-        vec![src.size() / element_bytes],
+        DType::Float32,
+        vec![src.size() / std::mem::size_of::<f32>()],
         BufferSpec { cpu_access: false, ..BufferSpec::default() },
     )
     .context(DeviceSnafu)?;
@@ -371,12 +370,6 @@ fn build_decode_seed(
     if cross_k.size() == 0 || cross_k.size() != cross_v.size() {
         return Err(decode_err("invalid prefill cross-cache geometry"));
     }
-    if self_k.dtype() != self_v.dtype() || cross_k.dtype() != cross_v.dtype() {
-        return Err(decode_err("prefill K/V cache dtypes disagree"));
-    }
-    if self_k.dtype() != cross_k.dtype() {
-        return Err(decode_err("prefill self and cross cache dtypes disagree"));
-    }
     for cache in [&self_v, &cross_k, &cross_v] {
         if !std::ptr::eq(self_k.allocator(), cache.allocator()) {
             return Err(decode_err("prefill caches use different allocators"));
@@ -387,8 +380,8 @@ fn build_decode_seed(
         .checked_div(metadata.init_len)
         .filter(|&bytes| bytes != 0 && bytes.checked_mul(metadata.init_len) == Some(self_k.size()))
         .ok_or_else(|| decode_err("self cache is not position-aligned"))?;
-    if per_pos_bytes % self_k.dtype().bytes() != 0 {
-        return Err(decode_err("self cache position is not element-aligned"));
+    if per_pos_bytes % std::mem::size_of::<f32>() != 0 {
+        return Err(decode_err("self cache position is not float32-aligned"));
     }
     let cross_positions = cross_k
         .size()
@@ -714,17 +707,6 @@ fn append_row_cache(
     per_pos_bytes: usize,
     row_stride_bytes: usize,
 ) -> Result<()> {
-    let output_k_dtype = jit.new_self_k().context(JitSnafu)?.dtype().clone();
-    let output_v_dtype = jit.new_self_v().context(JitSnafu)?.dtype().clone();
-    let cache_k_dtype = jit.self_k_cache_mut().context(JitSnafu)?.dtype().clone();
-    let cache_v_dtype = jit.self_v_cache_mut().context(JitSnafu)?.dtype().clone();
-    if output_k_dtype != output_v_dtype || output_k_dtype != cache_k_dtype || output_v_dtype != cache_v_dtype {
-        return Err(decode_err("step K/V outputs and cache destination dtypes disagree"));
-    }
-    let element_bytes = output_k_dtype.bytes();
-    if !per_pos_bytes.is_multiple_of(element_bytes) || !row_stride_bytes.is_multiple_of(element_bytes) {
-        return Err(decode_err("self cache append is not element-aligned"));
-    }
     let dst = row
         .checked_mul(row_stride_bytes)
         .and_then(|base| pos.checked_mul(per_pos_bytes).and_then(|offset| base.checked_add(offset)))
@@ -891,7 +873,7 @@ pub(crate) fn run_fixed_slot_decode(
                     control_bytes = control_bytes.saturating_add(
                         std::mem::size_of::<i32>()
                             + seed.n_state * std::mem::size_of::<f32>()
-                            + (n_text_ctx + 1) * DType::Bool.bytes(),
+                            + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
                     );
                 }
                 AttemptKind::Beam(beam) => {
@@ -913,7 +895,7 @@ pub(crate) fn run_fixed_slot_decode(
                         control_bytes = control_bytes.saturating_add(
                             std::mem::size_of::<i32>()
                                 + seed.n_state * std::mem::size_of::<f32>()
-                                + (n_text_ctx + 1) * DType::Bool.bytes(),
+                                + (n_text_ctx + 1) * std::mem::size_of::<f32>(),
                         );
                     }
                 }
@@ -1146,36 +1128,28 @@ fn write_pos_emb_row(jit: &mut WhisperDecoderStepJit, row: usize, emb: &[f32]) -
 fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, n_text_ctx: usize) -> Result<()> {
     let buf = jit.self_mask_mut().context(JitSnafu)?;
     let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-    if buf.dtype() != DType::Bool {
-        return Err(decode_err("decoder self mask must be bool"));
-    }
-    // True masks cached positions [pos..n_text_ctx); the appended current
-    // position at n_text_ctx remains visible, exactly matching the old mask.
-    let bool_bytes = DType::Bool.bytes();
-    if bool_bytes != 1 {
-        return Err(decode_err("decoder bool mask host encoding must be one byte"));
-    }
+    // mask is [max_lanes, 1, 1, n_text_ctx + 1]; row stride = (n_text_ctx+1)*4
     let stride = n_text_ctx
         .checked_add(1)
-        .and_then(|positions| positions.checked_mul(bool_bytes))
+        .and_then(|positions| positions.checked_mul(std::mem::size_of::<f32>()))
         .ok_or_else(|| decode_err("mask row stride overflow"))?;
     let off = row.checked_mul(stride).ok_or_else(|| decode_err("mask row offset overflow"))?;
-    let mut mask = vec![0u8; n_text_ctx + 1];
+    // [0..pos) = 0.0 (attend), [pos..n_text_ctx) = -inf (mask), [n_text_ctx] = 0.0
+    let mut mask = vec![0f32; n_text_ctx + 1];
     let masked = mask.get_mut(pos..n_text_ctx).ok_or_else(|| decode_err("decoder position exceeds text context"))?;
-    masked.fill(1);
-    let target = dst.get_mut(off..off + mask.len()).ok_or_else(|| decode_err("mask row is out of bounds"))?;
-    target.copy_from_slice(&mask);
+    for v in masked {
+        *v = f32::NEG_INFINITY;
+    }
+    let bytes: &[u8] = bytemuck::cast_slice(&mask);
+    let target = dst.get_mut(off..off + bytes.len()).ok_or_else(|| decode_err("mask row is out of bounds"))?;
+    target.copy_from_slice(bytes);
     Ok(())
 }
 
 /// Seed one physical cache row from an immutable device-local snapshot.
 fn copy_device_cache_row(buf: &mut Buffer, row: usize, row_stride_bytes: usize, data: &Buffer) -> Result<()> {
-    if buf.dtype() != data.dtype() {
-        return Err(decode_err("cache seed source and destination dtypes disagree"));
-    }
-    let element_bytes = data.dtype().bytes();
-    if !row_stride_bytes.is_multiple_of(element_bytes) || !data.size().is_multiple_of(element_bytes) {
-        return Err(decode_err("cache seed copy is not element-aligned"));
+    if buf.dtype() != DType::Float32 || data.dtype() != DType::Float32 {
+        return Err(decode_err("cache seed buffers must be float32"));
     }
     if !std::ptr::eq(buf.allocator(), data.allocator()) {
         return Err(decode_err("cache seed and decoder row use different allocators"));
@@ -1823,9 +1797,9 @@ mod scheduler_seed_tests {
     use std::sync::Arc;
     use svod_device::CpuAllocator;
 
-    fn cache(allocator: Arc<CpuAllocator>, values: &[u16]) -> Buffer {
+    fn cache(allocator: Arc<CpuAllocator>, values: &[f32]) -> Buffer {
         let mut buffer =
-            Buffer::allocate(allocator, DType::Float16, vec![values.len()], BufferSpec::default()).unwrap();
+            Buffer::allocate(allocator, DType::Float32, vec![values.len()], BufferSpec::default()).unwrap();
         buffer.copyin(bytemuck::cast_slice(values)).unwrap();
         buffer
     }
@@ -1833,8 +1807,8 @@ mod scheduler_seed_tests {
     #[test]
     fn scheduler_seed_owns_device_buffers_and_seeds_multiple_rows() {
         let allocator = Arc::new(CpuAllocator);
-        let self_values = [0x3c00u16, 0x4000, 0x4200, 0x4400];
-        let cross_values = [0x4500u16, 0x4600, 0x4700, 0x4800, 0x4880, 0x4900];
+        let self_values = [1.0f32, 2.0, 3.0, 4.0];
+        let cross_values = [5.0f32, 6.0, 7.0, 8.0, 9.0, 10.0];
         let self_k_source = cache(allocator.clone(), &self_values);
         let self_v_source = cache(allocator.clone(), &self_values);
         let cross_k_source = cache(allocator.clone(), &cross_values);
@@ -1860,7 +1834,7 @@ mod scheduler_seed_tests {
         .unwrap();
 
         assert_eq!(seed.metadata.initial_tokens, [1, 2]);
-        assert_eq!(seed.per_pos_bytes, 2 * DType::Float16.bytes());
+        assert_eq!(seed.per_pos_bytes, 2 * std::mem::size_of::<f32>());
         assert_eq!(seed.self_cache_bytes, std::mem::size_of_val(&self_values));
         assert_eq!(seed.cross_cache_bytes, std::mem::size_of_val(&cross_values));
         assert_eq!((seed.self_positions, seed.cross_positions), (2, 3));
@@ -1872,8 +1846,8 @@ mod scheduler_seed_tests {
         let self_stride = 4 * seed.per_pos_bytes;
         let mut self_rows = Buffer::allocate(
             allocator.clone(),
-            DType::Float16,
-            vec![2 * self_stride / DType::Float16.bytes()],
+            DType::Float32,
+            vec![2 * self_stride / std::mem::size_of::<f32>()],
             BufferSpec::default(),
         )
         .unwrap();
@@ -1886,8 +1860,8 @@ mod scheduler_seed_tests {
 
         let mut cross_rows = Buffer::allocate(
             allocator,
-            DType::Float16,
-            vec![2 * seed.cross_cache_bytes / DType::Float16.bytes()],
+            DType::Float32,
+            vec![2 * seed.cross_cache_bytes / std::mem::size_of::<f32>()],
             BufferSpec::default(),
         )
         .unwrap();

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -4,6 +4,8 @@
 use super::error::{DeviceSnafu, Error, JitSnafu, Result};
 use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
 use super::tokenizer::WhisperTokenizer;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use snafu::ResultExt;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
@@ -128,6 +130,8 @@ pub struct DecodeOptions {
     pub strategy: DecodeStrategy,
     /// Optional quality-gated sampling retries.
     pub fallback: Option<FallbackPolicy>,
+    /// Base seed for reproducible per-request sampling streams.
+    pub sampling_seed: Option<u64>,
     /// Maximum generated token count; defaults to half the text context.
     pub sample_len: Option<usize>,
     /// Suppress blank/space as the first generated token.
@@ -147,6 +151,7 @@ impl Default for DecodeOptions {
             language: None,
             strategy: DecodeStrategy::Beam { size: 5 },
             fallback: Some(FallbackPolicy::default()),
+            sampling_seed: None,
             sample_len: None,
             suppress_blank: true,
             suppress_tokens: Some(vec![-1]),
@@ -255,6 +260,7 @@ pub fn decode_with_fallback_cached(
             .extend(fallback.sampling_temperatures.iter().map(|&temperature| DecodeStrategy::Sample { temperature }));
     }
     let mut best: Option<DecodeResult> = None;
+    let mut rng = sampling_rng(options, 0);
 
     for (attempt, &strategy) in strategies.iter().enumerate() {
         let mut opts = options.clone();
@@ -274,7 +280,7 @@ pub fn decode_with_fallback_cached(
                 pos_embedding,
                 n_state,
             )?,
-            DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => greedy_decode_cached(
+            DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => greedy_decode_cached_with_rng(
                 prefill_jit,
                 step_jits.get_mut(&1).ok_or_else(|| decode_err("greedy JIT missing"))?,
                 n_text_ctx,
@@ -283,6 +289,7 @@ pub fn decode_with_fallback_cached(
                 &opts,
                 pos_embedding,
                 n_state,
+                &mut rng,
             )?,
         };
 
@@ -334,6 +341,32 @@ pub fn greedy_decode_cached(
     pos_embedding: &[f32],
     n_state: usize,
 ) -> Result<DecodeResult> {
+    let mut rng = sampling_rng(options, 0);
+    greedy_decode_cached_with_rng(
+        prefill_jit,
+        step_jit,
+        n_text_ctx,
+        n_vocab,
+        tokenizer,
+        options,
+        pos_embedding,
+        n_state,
+        &mut rng,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn greedy_decode_cached_with_rng(
+    prefill_jit: &mut WhisperPrefillJit,
+    step_jit: &mut WhisperDecoderStepJit,
+    n_text_ctx: usize,
+    n_vocab: usize,
+    tokenizer: &WhisperTokenizer,
+    options: &DecodeOptions,
+    pos_embedding: &[f32],
+    n_state: usize,
+    rng: &mut StdRng,
+) -> Result<DecodeResult> {
     let mut ctx = init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)?;
     ctx.write_caches_greedy(step_jit)?;
 
@@ -349,7 +382,7 @@ pub fn greedy_decode_cached(
         0,
         &ctx.suppress_tokens,
     );
-    let mut next_token = pick_token(&filtered, options.strategy.temperature());
+    let mut next_token = pick_token_with_rng(&filtered, options.strategy.temperature(), rng);
     let mut sum_logprob = log_softmax(&filtered, next_token as usize);
     let no_speech_prob = ctx.no_speech_prob;
 
@@ -394,7 +427,7 @@ pub fn greedy_decode_cached(
             &ctx.suppress_tokens,
         );
 
-        next_token = pick_token(&filtered, options.strategy.temperature());
+        next_token = pick_token_with_rng(&filtered, options.strategy.temperature(), rng);
         let token_logprob = log_softmax(&filtered, next_token as usize);
         sum_logprob += token_logprob;
 
@@ -657,6 +690,7 @@ impl ScheduledAttempt {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn start_attempt(
     strategy_index: usize,
     strategy: DecodeStrategy,
@@ -665,6 +699,7 @@ fn start_attempt(
     tokenizer: &WhisperTokenizer,
     options: &DecodeOptions,
     n_vocab: usize,
+    rng: &mut StdRng,
 ) -> Result<ScheduledAttempt> {
     let ctx = &seed.ctx;
     let last = ctx
@@ -698,7 +733,7 @@ fn start_attempt(
                     }),
                 });
             }
-            let next_token = pick_token(&filtered, strategy.temperature());
+            let next_token = pick_token_with_rng(&filtered, strategy.temperature(), rng);
             let sum_logprob = log_softmax(&filtered, next_token as usize);
             let (tokens, token_probs) = if next_token == tokenizer.eot() {
                 (Vec::new(), Vec::new())
@@ -883,6 +918,8 @@ pub(crate) fn run_fixed_slot_decode(
     let mut attempts: Vec<Option<ScheduledAttempt>> = (0..seeds.len()).map(|_| None).collect();
     let mut results: Vec<Option<DecodeResult>> = (0..seeds.len()).map(|_| None).collect();
     let mut stats = DecodeScheduleStats::default();
+    let mut rngs: Vec<_> =
+        request_options.iter().enumerate().map(|(request, options)| sampling_rng(options, request)).collect();
 
     while results.iter().any(Option::is_none) {
         while let Some(&(request, strategy_index)) = queue.front() {
@@ -893,7 +930,16 @@ pub(crate) fn run_fixed_slot_decode(
             queue.pop_front();
             let mut options = request_options[request].clone();
             options.strategy = strategy;
-            let attempt = start_attempt(strategy_index, strategy, rows, &seeds[request], tokenizer, &options, n_vocab)?;
+            let attempt = start_attempt(
+                strategy_index,
+                strategy,
+                rows,
+                &seeds[request],
+                tokenizer,
+                &options,
+                n_vocab,
+                &mut rngs[request],
+            )?;
             seed_attempt_rows(step_jit, &attempt.reserved_rows, &seeds[request], n_text_ctx)?;
             attempts[request] = Some(attempt);
             stats.attempts += 1;
@@ -991,7 +1037,8 @@ pub(crate) fn run_fixed_slot_decode(
                             attempt.pos + 1 - seed.init_len,
                             &seed.suppress_tokens,
                         );
-                        single.next_token = pick_token(&logits, attempt.strategy.temperature());
+                        single.next_token =
+                            pick_token_with_rng(&logits, attempt.strategy.temperature(), &mut rngs[request]);
                         let logprob = log_softmax(&logits, single.next_token as usize);
                         single.sum_logprob += logprob;
                         if single.next_token != tokenizer.eot() {
@@ -1863,8 +1910,23 @@ fn finish_decode(
     })
 }
 
-fn pick_token(logits: &[f32], temperature: f32) -> u32 {
-    if temperature > 0.0 { sample_from_logits(logits, temperature) } else { argmax(logits) as u32 }
+fn pick_token_with_rng(logits: &[f32], temperature: f32, rng: &mut impl Rng) -> u32 {
+    if temperature > 0.0 { sample_from_logits(logits, temperature, rng) } else { argmax(logits) as u32 }
+}
+
+pub(crate) fn derived_sampling_seed(base: u64, request: usize) -> u64 {
+    if request == 0 {
+        return base;
+    }
+    let mut value = base ^ (request as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn sampling_rng(options: &DecodeOptions, request: usize) -> StdRng {
+    let seed = options.sampling_seed.map(|base| derived_sampling_seed(base, request)).unwrap_or_else(rand::random);
+    StdRng::seed_from_u64(seed)
 }
 
 fn decode_err(msg: &str) -> Error {
@@ -2144,14 +2206,14 @@ fn compression_ratio_text(text: &str) -> f32 {
 /// reference's `Categorical(logits=logits/T).sample()` (`decoding.py:283`),
 /// which PyTorch implements as a numerically stable softmax (max-subtract
 /// before exp) followed by inverse-CDF sampling.
-fn sample_from_logits(logits: &[f32], temperature: f32) -> u32 {
+fn sample_from_logits(logits: &[f32], temperature: f32, rng: &mut impl Rng) -> u32 {
     // Max-subtract for numerical stability: exp(x - m) avoids overflow on
     // large positive logits. The max is a no-op for the sampling distribution
     // (it's a constant shift that cancels in normalization).
     let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max) / temperature;
     let probs: Vec<f32> = logits.iter().map(|&l| ((l / temperature) - max_val).exp()).collect();
     let sum: f32 = probs.iter().copied().sum();
-    let mut r = rand::random::<f32>() * sum;
+    let mut r = rng.r#gen::<f32>() * sum;
     for (i, &p) in probs.iter().enumerate() {
         r -= p;
         if r <= 0.0 {

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -1,5 +1,4 @@
-//! KV-cached Whisper decoder: greedy, beam search, temperature fallback,
-//! and language detection — matching `whisper.decoding`.
+//! Scheduled Whisper decoding, temperature fallback, and language detection.
 
 use super::error::{DeviceSnafu, Error, JitSnafu, Result};
 use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
@@ -198,6 +197,7 @@ fn valid_temperature(temperature: f32) -> bool {
     temperature.is_finite() && temperature > 0.0
 }
 
+#[cfg(test)]
 pub(crate) fn remaining_sample_steps(sample_len: usize) -> usize {
     sample_len.saturating_sub(1)
 }
@@ -237,89 +237,6 @@ impl DecodeResult {
     }
 }
 
-// ─── Decode with temperature fallback (cached) ──────────────────────────────
-
-#[allow(clippy::too_many_arguments)]
-pub fn decode_with_fallback_cached(
-    prefill_jit: &mut WhisperPrefillJit,
-    step_jits: &mut rustc_hash::FxHashMap<usize, WhisperDecoderStepJit>,
-    decoder_jit: &mut WhisperDecoderJit,
-    n_text_ctx: usize,
-    n_vocab: usize,
-    tokenizer: &WhisperTokenizer,
-    options: &DecodeOptions,
-    pos_embedding: &[f32],
-    n_state: usize,
-) -> Result<DecodeResult> {
-    options.validate().map_err(decode_err)?;
-    let resolved_lang = resolve_language(options, decoder_jit, n_text_ctx, n_vocab, tokenizer)?;
-
-    let mut strategies = vec![options.strategy];
-    if let Some(fallback) = &options.fallback {
-        strategies
-            .extend(fallback.sampling_temperatures.iter().map(|&temperature| DecodeStrategy::Sample { temperature }));
-    }
-    let mut best: Option<DecodeResult> = None;
-    let mut rng = sampling_rng(options, 0);
-
-    for (attempt, &strategy) in strategies.iter().enumerate() {
-        let mut opts = options.clone();
-        opts.strategy = strategy;
-        opts.fallback = None;
-        opts.language = resolved_lang.clone();
-
-        let result = match strategy {
-            DecodeStrategy::Beam { size } => beam_decode_cached(
-                prefill_jit,
-                step_jits.get_mut(&size).ok_or_else(|| decode_err("beam JIT missing"))?,
-                n_text_ctx,
-                n_vocab,
-                tokenizer,
-                &opts,
-                size,
-                pos_embedding,
-                n_state,
-            )?,
-            DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => greedy_decode_cached_with_rng(
-                prefill_jit,
-                step_jits.get_mut(&1).ok_or_else(|| decode_err("greedy JIT missing"))?,
-                n_text_ctx,
-                n_vocab,
-                tokenizer,
-                &opts,
-                pos_embedding,
-                n_state,
-                &mut rng,
-            )?,
-        };
-
-        let needs_fallback = attempt < strategies.len() - 1
-            && options.fallback.as_ref().is_some_and(|fallback| check_fallback(&result, fallback, options));
-        best = Some(result);
-        if !needs_fallback {
-            break;
-        }
-    }
-    best.ok_or_else(|| decode_err("no result"))
-}
-
-fn resolve_language(
-    options: &DecodeOptions,
-    decoder_jit: &mut WhisperDecoderJit,
-    n_text_ctx: usize,
-    n_vocab: usize,
-    tokenizer: &WhisperTokenizer,
-) -> Result<Option<String>> {
-    if !tokenizer.multilingual {
-        return Ok(Some("en".to_string()));
-    }
-    if options.language.is_some() {
-        return Ok(options.language.clone());
-    }
-    let detection = detect_language(decoder_jit, n_text_ctx, n_vocab, tokenizer)?;
-    Ok(Some(detection.language))
-}
-
 pub(crate) fn check_fallback(result: &DecodeResult, fallback: &FallbackPolicy, options: &DecodeOptions) -> bool {
     let repetitive = fallback.compression_ratio_threshold.is_some_and(|threshold| result.compression_ratio > threshold);
     let low_confidence = fallback.logprob_threshold.is_some_and(|threshold| result.avg_logprob < threshold);
@@ -328,128 +245,13 @@ pub(crate) fn check_fallback(result: &DecodeResult, fallback: &FallbackPolicy, o
     (repetitive || low_confidence) && !silence
 }
 
-// ─── Cached greedy decode ───────────────────────────────────────────────────
-
-#[allow(clippy::too_many_arguments)]
-pub fn greedy_decode_cached(
-    prefill_jit: &mut WhisperPrefillJit,
-    step_jit: &mut WhisperDecoderStepJit,
-    n_text_ctx: usize,
-    n_vocab: usize,
-    tokenizer: &WhisperTokenizer,
-    options: &DecodeOptions,
-    pos_embedding: &[f32],
-    n_state: usize,
-) -> Result<DecodeResult> {
-    let mut rng = sampling_rng(options, 0);
-    greedy_decode_cached_with_rng(
-        prefill_jit,
-        step_jit,
-        n_text_ctx,
-        n_vocab,
-        tokenizer,
-        options,
-        pos_embedding,
-        n_state,
-        &mut rng,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn greedy_decode_cached_with_rng(
-    prefill_jit: &mut WhisperPrefillJit,
-    step_jit: &mut WhisperDecoderStepJit,
-    n_text_ctx: usize,
-    n_vocab: usize,
-    tokenizer: &WhisperTokenizer,
-    options: &DecodeOptions,
-    pos_embedding: &[f32],
-    n_state: usize,
-    rng: &mut StdRng,
-) -> Result<DecodeResult> {
-    let mut ctx = init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)?;
-    ctx.write_caches_greedy(step_jit)?;
-
-    // First token from prefill logits
-    let last_logits = &ctx.prefill_logits[(ctx.init_len - 1) * n_vocab..ctx.init_len * n_vocab];
-    let mut filtered = last_logits.to_vec();
-    apply_logit_filters(
-        &mut filtered,
-        tokenizer,
-        options,
-        &ctx.initial_tokens,
-        ctx.sample_begin,
-        0,
-        &ctx.suppress_tokens,
-    );
-    let mut next_token = pick_token_with_rng(&filtered, options.strategy.temperature(), rng);
-    let mut sum_logprob = log_softmax(&filtered, next_token as usize);
-    let no_speech_prob = ctx.no_speech_prob;
-
-    let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
-    if sample_len == 0 {
-        return finish_decode(&[], &[], tokenizer, 0.0, no_speech_prob, options);
-    }
-
-    let mut tokens = Vec::new();
-    let mut token_probs = Vec::new();
-    if next_token != tokenizer.eot() {
-        tokens.push(next_token);
-        token_probs.push(sum_logprob.exp());
-    }
-
-    // Prefill produced generated token 1, so only the remaining budget needs
-    // decoder-step dispatches.
-    for step in 0..remaining_sample_steps(sample_len) {
-        if next_token == tokenizer.eot() {
-            break;
-        }
-        let pos = ctx.init_len + step;
-
-        write_token_buf(step_jit, &[next_token as i32])?;
-        let off = pos * ctx.n_state;
-        write_f32_input(step_jit.pos_emb_mut().context(JitSnafu)?, &ctx.pos_embedding[off..off + ctx.n_state])?;
-        ctx.write_mask(step_jit, pos, n_text_ctx, 1)?;
-        step_jit.execute().context(JitSnafu)?;
-        ctx.copy_kv(step_jit, pos)?;
-
-        ctx.read_logits_into(step_jit, n_vocab)?;
-        let logits = &ctx.logits_buf;
-        let all_toks: Vec<u32> = ctx.initial_tokens.iter().copied().chain(tokens.iter().copied()).collect();
-        let mut filtered = logits.to_vec();
-        apply_logit_filters(
-            &mut filtered,
-            tokenizer,
-            options,
-            &all_toks,
-            ctx.sample_begin,
-            step + 1,
-            &ctx.suppress_tokens,
-        );
-
-        next_token = pick_token_with_rng(&filtered, options.strategy.temperature(), rng);
-        let token_logprob = log_softmax(&filtered, next_token as usize);
-        sum_logprob += token_logprob;
-
-        if next_token != tokenizer.eot() {
-            tokens.push(next_token);
-            token_probs.push(token_logprob.exp());
-        }
-        if tokens.len() >= sample_len {
-            break;
-        }
-    }
-
-    finish_decode(&tokens, &token_probs, tokenizer, sum_logprob, no_speech_prob, options)
-}
-
 // ─── Fixed-slot mixed-strategy scheduler ────────────────────────────────────
 
 /// Immutable output of token prefill. Fallback attempts reuse this seed rather
 /// than rerunning prefill. Cache snapshots remain device-local and are copied
 /// into a row only when that row changes request ownership.
 pub(crate) struct DecodeSeed {
-    ctx: DecodeCtx,
+    metadata: PrefillMetadata,
     self_k_cache: Buffer,
     self_v_cache: Buffer,
     cross_k: Buffer,
@@ -470,12 +272,12 @@ pub(crate) fn prefill_decode_seed(
     pos_embedding: &[f32],
     n_state: usize,
 ) -> Result<DecodeSeed> {
-    let ctx = execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state)?;
+    let metadata = execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state)?;
     let self_k = clone_device_cache(prefill_jit.self_k().context(JitSnafu)?)?;
     let self_v = clone_device_cache(prefill_jit.self_v().context(JitSnafu)?)?;
     let cross_k = clone_device_cache(prefill_jit.prepared_cross_k_mut().context(JitSnafu)?)?;
     let cross_v = clone_device_cache(prefill_jit.prepared_cross_v_mut().context(JitSnafu)?)?;
-    let seed = build_decode_seed(ctx, self_k, self_v, cross_k, cross_v)?;
+    let seed = build_decode_seed(metadata, self_k, self_v, cross_k, cross_v)?;
     if seed.self_positions > n_text_ctx {
         return Err(decode_err("prefill self cache exceeds text context"));
     }
@@ -498,13 +300,13 @@ fn clone_device_cache(src: &Buffer) -> Result<Buffer> {
 }
 
 fn build_decode_seed(
-    ctx: DecodeCtx,
+    metadata: PrefillMetadata,
     self_k: Buffer,
     self_v: Buffer,
     cross_k: Buffer,
     cross_v: Buffer,
 ) -> Result<DecodeSeed> {
-    if ctx.init_len == 0 || self_k.size() == 0 || self_k.size() != self_v.size() {
+    if metadata.init_len == 0 || self_k.size() == 0 || self_k.size() != self_v.size() {
         return Err(decode_err("invalid prefill self-cache geometry"));
     }
     if cross_k.size() == 0 || cross_k.size() != cross_v.size() {
@@ -517,8 +319,8 @@ fn build_decode_seed(
     }
     let per_pos_bytes = self_k
         .size()
-        .checked_div(ctx.init_len)
-        .filter(|&bytes| bytes != 0 && bytes.checked_mul(ctx.init_len) == Some(self_k.size()))
+        .checked_div(metadata.init_len)
+        .filter(|&bytes| bytes != 0 && bytes.checked_mul(metadata.init_len) == Some(self_k.size()))
         .ok_or_else(|| decode_err("self cache is not position-aligned"))?;
     if per_pos_bytes % std::mem::size_of::<f32>() != 0 {
         return Err(decode_err("self cache position is not float32-aligned"));
@@ -539,9 +341,9 @@ fn build_decode_seed(
         per_pos_bytes,
         self_cache_bytes,
         cross_cache_bytes,
-        self_positions: ctx.init_len,
+        self_positions: metadata.init_len,
         cross_positions,
-        ctx,
+        metadata,
     })
 }
 
@@ -701,20 +503,20 @@ fn start_attempt(
     n_vocab: usize,
     rng: &mut StdRng,
 ) -> Result<ScheduledAttempt> {
-    let ctx = &seed.ctx;
-    let last = ctx
+    let metadata = &seed.metadata;
+    let last = metadata
         .prefill_logits
-        .get((ctx.init_len - 1) * n_vocab..ctx.init_len * n_vocab)
+        .get((metadata.init_len - 1) * n_vocab..metadata.init_len * n_vocab)
         .ok_or_else(|| decode_err("prefill logits are truncated"))?;
     let mut filtered = last.to_vec();
     apply_logit_filters(
         &mut filtered,
         tokenizer,
         options,
-        &ctx.initial_tokens,
-        ctx.sample_begin,
+        &metadata.initial_tokens,
+        metadata.sample_begin,
         0,
-        &ctx.suppress_tokens,
+        &metadata.suppress_tokens,
     );
     let kind = match strategy {
         DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => {
@@ -723,7 +525,7 @@ fn start_attempt(
                     strategy_index,
                     strategy,
                     reserved_rows: rows,
-                    pos: ctx.init_len,
+                    pos: metadata.init_len,
                     generated_tokens: 0,
                     kind: AttemptKind::Single(SingleAttempt {
                         next_token: tokenizer.eot(),
@@ -746,7 +548,7 @@ fn start_attempt(
             if options.sample_len == Some(0) {
                 let active = vec![BeamHypothesis {
                     logical_id: 0,
-                    tokens: ctx.initial_tokens.clone(),
+                    tokens: metadata.initial_tokens.clone(),
                     token_probs: Vec::new(),
                     sum_logprob: 0.0,
                 }];
@@ -754,7 +556,7 @@ fn start_attempt(
                     strategy_index,
                     strategy,
                     reserved_rows: rows.clone(),
-                    pos: ctx.init_len,
+                    pos: metadata.init_len,
                     generated_tokens: 0,
                     kind: AttemptKind::Beam(BeamAttempt {
                         active,
@@ -773,7 +575,7 @@ fn start_attempt(
                 if active.len() >= size {
                     break;
                 }
-                let mut tokens = ctx.initial_tokens.clone();
+                let mut tokens = metadata.initial_tokens.clone();
                 tokens.push(token as u32);
                 let hypothesis = BeamHypothesis {
                     logical_id: next_logical_id,
@@ -792,7 +594,14 @@ fn start_attempt(
             AttemptKind::Beam(BeamAttempt { active, rows: active_rows, finished, next_logical_id })
         }
     };
-    Ok(ScheduledAttempt { strategy_index, strategy, reserved_rows: rows, pos: ctx.init_len, generated_tokens: 1, kind })
+    Ok(ScheduledAttempt {
+        strategy_index,
+        strategy,
+        reserved_rows: rows,
+        pos: metadata.init_len,
+        generated_tokens: 1,
+        kind,
+    })
 }
 
 fn seed_attempt_rows(
@@ -868,21 +677,21 @@ fn finish_attempt(
             &single.token_probs,
             tokenizer,
             if options.sample_len == Some(0) { 0.0 } else { single.sum_logprob },
-            seed.ctx.no_speech_prob,
+            seed.metadata.no_speech_prob,
             options,
         ),
         AttemptKind::Beam(beam) => {
             let size = attempt.reserved_rows.len();
             let best =
-                finalize_beam_hypotheses(beam.active, beam.finished, size, tokenizer.eot(), seed.ctx.sample_begin)
+                finalize_beam_hypotheses(beam.active, beam.finished, size, tokenizer.eot(), seed.metadata.sample_begin)
                     .ok_or_else(|| decode_err("beam produced nothing"))?;
-            let tokens: Vec<_> = best.tokens[seed.ctx.sample_begin..]
+            let tokens: Vec<_> = best.tokens[seed.metadata.sample_begin..]
                 .iter()
                 .copied()
                 .take_while(|&token| token != tokenizer.eot())
                 .collect();
             let token_probs = best.token_probs.into_iter().take(tokens.len()).collect::<Vec<_>>();
-            finish_decode(&tokens, &token_probs, tokenizer, best.sum_logprob, seed.ctx.no_speech_prob, options)
+            finish_decode(&tokens, &token_probs, tokenizer, best.sum_logprob, seed.metadata.no_speech_prob, options)
         }
     }
 }
@@ -960,7 +769,7 @@ pub(crate) fn run_fixed_slot_decode(
             if attempt.is_done(sample_len, tokenizer.eot()) {
                 continue;
             }
-            let seed = &seeds[request].ctx;
+            let seed = &seeds[request].metadata;
             match &attempt.kind {
                 AttemptKind::Single(single) => {
                     let row = attempt.reserved_rows[0];
@@ -1014,7 +823,7 @@ pub(crate) fn run_fixed_slot_decode(
                     continue;
                 }
                 let decode_seed = &seeds[request];
-                let seed = &decode_seed.ctx;
+                let seed = &decode_seed.metadata;
                 let per_pos_bytes = decode_seed.per_pos_bytes;
                 let row_stride_bytes = n_text_ctx
                     .checked_mul(per_pos_bytes)
@@ -1369,183 +1178,7 @@ pub(crate) fn finalize_beam_hypotheses(
     finished.into_iter().next()
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn beam_decode_cached(
-    prefill_jit: &mut WhisperPrefillJit,
-    step_jit: &mut WhisperDecoderStepJit,
-    n_text_ctx: usize,
-    n_vocab: usize,
-    tokenizer: &WhisperTokenizer,
-    options: &DecodeOptions,
-    beam_size: usize,
-    pos_embedding: &[f32],
-    n_state: usize,
-) -> Result<DecodeResult> {
-    let eot = tokenizer.eot();
-    let sample_len = options.sample_len.unwrap_or(n_text_ctx / 2);
-    let n_audio_ctx = 1500; // N_AUDIO_CTX
-    let mut ctx = init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)?;
-    ctx.write_caches_beam(step_jit, beam_size, n_text_ctx, n_audio_ctx)?;
-
-    // Seed beams from prefill logits
-    let last_logits = &ctx.prefill_logits[(ctx.init_len - 1) * n_vocab..ctx.init_len * n_vocab];
-    let mut filtered = last_logits.to_vec();
-    apply_logit_filters(
-        &mut filtered,
-        tokenizer,
-        options,
-        &ctx.initial_tokens,
-        ctx.sample_begin,
-        0,
-        &ctx.suppress_tokens,
-    );
-    let prefill_logprobs = log_softmax_vec(&filtered);
-
-    let mut indexed: Vec<(usize, f32)> = prefill_logprobs.into_iter().enumerate().collect();
-    indexed.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-
-    let mut beams = Vec::new();
-    let mut finished = Vec::new();
-    let mut next_logical_id = 0;
-    if sample_len == 0 {
-        beams.push(BeamHypothesis {
-            logical_id: next_logical_id,
-            tokens: ctx.initial_tokens.clone(),
-            token_probs: Vec::new(),
-            sum_logprob: 0.0,
-        });
-        next_logical_id += 1;
-    }
-    for (tok_id, lp) in &indexed {
-        if sample_len == 0 {
-            break;
-        }
-        if beams.len() >= beam_size {
-            break;
-        }
-        let mut toks = ctx.initial_tokens.clone();
-        toks.push(*tok_id as u32);
-        if *tok_id as u32 == eot {
-            finished.push(BeamHypothesis {
-                logical_id: next_logical_id,
-                tokens: toks,
-                token_probs: vec![lp.exp()],
-                sum_logprob: *lp,
-            });
-        } else {
-            beams.push(BeamHypothesis {
-                logical_id: next_logical_id,
-                tokens: toks,
-                token_probs: vec![lp.exp()],
-                sum_logprob: *lp,
-            });
-        }
-        next_logical_id += 1;
-    }
-
-    let per_beam_floats = ctx.per_beam_floats(n_text_ctx);
-    let sample_begin = ctx.sample_begin;
-
-    for step in 0..remaining_sample_steps(sample_len) {
-        if beams.is_empty() || finished.len() >= beam_size {
-            break;
-        }
-        let pos = ctx.init_len + step;
-
-        ctx.write_beam_inputs(step_jit, &beams, beam_size, pos, n_text_ctx, eot)?;
-        step_jit.execute().context(JitSnafu)?;
-
-        // Device-side K/V copy FIRST (SDMA, synchronized by subsequent logits read)
-        let per_pos_bytes = ctx.per_pos_bytes();
-        let cache_pos = pos * per_pos_bytes;
-        for bi in 0..beam_size {
-            let dst = bi * per_beam_floats * 4 + cache_pos;
-            step_jit.copy_output_to_self_k_cache(1, dst, bi * per_pos_bytes, per_pos_bytes).context(JitSnafu)?;
-            step_jit.copy_output_to_self_v_cache(2, dst, bi * per_pos_bytes, per_pos_bytes).context(JitSnafu)?;
-        }
-
-        let suppress_tokens: Vec<i32> = ctx.suppress_tokens.clone();
-        ctx.read_logits_into(step_jit, n_vocab * beam_size)?;
-        let all_logits = &ctx.logits_buf;
-
-        // Generate + rank candidates
-        let mut candidates = Vec::new();
-        for (bi, beam) in beams.iter().enumerate() {
-            let start = bi * n_vocab;
-            let Some(beam_logits) = all_logits.get(start..start + n_vocab) else {
-                return Err(decode_err("beam logits row is truncated"));
-            };
-            let mut filtered = beam_logits.to_vec();
-            apply_logit_filters(
-                &mut filtered,
-                tokenizer,
-                options,
-                &beam.tokens,
-                sample_begin,
-                step + 1,
-                &suppress_tokens,
-            );
-            let logprobs = log_softmax_vec(&filtered);
-            let mut idx: Vec<(usize, f32)> = logprobs.iter().copied().enumerate().collect();
-            idx.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-            for (tok_id, lp) in idx.into_iter().take(beam_size + 1) {
-                candidates.push(BeamCandidate {
-                    parent_index: bi,
-                    parent_logical_id: beam.logical_id,
-                    parent_row: bi,
-                    token_id: tok_id as u32,
-                    token_logprob: lp,
-                    sum_logprob: beam.sum_logprob + lp,
-                });
-            }
-        }
-
-        let (new_beams, newly_finished, survivors) = select_beam_candidates(
-            &beams,
-            candidates,
-            beam_size,
-            eot,
-            beam_size - finished.len(),
-            &mut next_logical_id,
-        );
-        finished.extend(newly_finished);
-        let parent_map: Vec<usize> = survivors.iter().map(|survivor| survivor.parent_row).collect();
-
-        // Reorder cache by parent_map (host-side, copies ENTIRE cache incl new K/V)
-        if !parent_map.is_empty() {
-            reorder_cache_host(step_jit.self_k_cache_mut().context(JitSnafu)?, &parent_map, per_beam_floats)?;
-            reorder_cache_host(step_jit.self_v_cache_mut().context(JitSnafu)?, &parent_map, per_beam_floats)?;
-        }
-
-        beams = new_beams;
-
-        if beams.iter().all(|b| b.tokens.len() >= n_text_ctx) {
-            break;
-        }
-    }
-
-    let best = finalize_beam_hypotheses(beams, finished, beam_size, eot, ctx.sample_begin)
-        .ok_or_else(|| decode_err("beam produced nothing"))?;
-    let output_tokens: Vec<u32> = best.tokens[ctx.sample_begin..].iter().copied().take_while(|&t| t != eot).collect();
-    let token_probs = best.token_probs.into_iter().take(output_tokens.len()).collect();
-    let text = tokenizer.decode(&output_tokens);
-    let avg_logprob = best.sum_logprob / (output_tokens.len() + 1) as f32;
-    let compression_ratio = compression_ratio_text(&text);
-    Ok(DecodeResult {
-        tokens: output_tokens,
-        token_probs,
-        text,
-        avg_logprob,
-        no_speech_prob: ctx.no_speech_prob,
-        temperature: options.strategy.temperature(),
-        compression_ratio,
-        language: options.language.clone(),
-    })
-}
-
-// ─── Shared decode context ──────────────────────────────────────────────────
-
-struct DecodeCtx {
+struct PrefillMetadata {
     initial_tokens: Vec<u32>,
     sample_begin: usize,
     init_len: usize,
@@ -1554,178 +1187,6 @@ struct DecodeCtx {
     no_speech_prob: f32,
     pos_embedding: Vec<f32>,
     n_state: usize,
-    self_k_cache: Vec<f32>,
-    self_v_cache: Vec<f32>,
-    cross_k: Vec<f32>,
-    cross_v: Vec<f32>,
-    // Reusable scratch buffers (avoid per-step allocation)
-    logits_buf: Vec<f32>,
-    mask_buf: Vec<f32>,
-}
-
-impl DecodeCtx {
-    fn write_caches_greedy(&self, step_jit: &mut WhisperDecoderStepJit) -> Result<()> {
-        copyin_cache_full(step_jit.self_k_cache_mut().context(JitSnafu)?, &self.self_k_cache)?;
-        copyin_cache_full(step_jit.self_v_cache_mut().context(JitSnafu)?, &self.self_v_cache)?;
-        copyin_cache_full(step_jit.cross_k_mut().context(JitSnafu)?, &self.cross_k)?;
-        copyin_cache_full(step_jit.cross_v_mut().context(JitSnafu)?, &self.cross_v)?;
-        Ok(())
-    }
-
-    fn write_caches_beam(
-        &self,
-        step_jit: &mut WhisperDecoderStepJit,
-        beam_size: usize,
-        n_text_ctx: usize,
-        n_audio_ctx: usize,
-    ) -> Result<()> {
-        let layer_heads_dh = self.self_k_cache.len() / self.init_len;
-        let self_stride = n_text_ctx * layer_heads_dh;
-        let cross_stride = n_audio_ctx * layer_heads_dh;
-        copyin_replicated_cache(
-            step_jit.self_k_cache_mut().context(JitSnafu)?,
-            &self.self_k_cache,
-            beam_size,
-            self_stride,
-        )?;
-        copyin_replicated_cache(
-            step_jit.self_v_cache_mut().context(JitSnafu)?,
-            &self.self_v_cache,
-            beam_size,
-            self_stride,
-        )?;
-        copyin_replicated_cache(step_jit.cross_k_mut().context(JitSnafu)?, &self.cross_k, beam_size, cross_stride)?;
-        copyin_replicated_cache(step_jit.cross_v_mut().context(JitSnafu)?, &self.cross_v, beam_size, cross_stride)?;
-        Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn write_beam_inputs(
-        &self,
-        step_jit: &mut WhisperDecoderStepJit,
-        beams: &[BeamHypothesis],
-        beam_size: usize,
-        pos: usize,
-        n_text_ctx: usize,
-        eot: u32,
-    ) -> Result<()> {
-        // Tokens
-        let mut tokens = vec![eot as i32; beam_size];
-        for (bi, beam) in beams.iter().enumerate() {
-            tokens[bi] = *beam.tokens.last().unwrap() as i32;
-        }
-        write_token_buf(step_jit, &tokens)?;
-        // Broadcast pos_emb [n_state] to [beam_size, 1, n_state]
-        {
-            let off = pos * self.n_state;
-            let emb = &self.pos_embedding[off..off + self.n_state];
-            let mut packed = vec![0f32; beam_size * self.n_state];
-            for bi in 0..beam_size {
-                packed[bi * self.n_state..(bi + 1) * self.n_state].copy_from_slice(emb);
-            }
-            write_f32_input(step_jit.pos_emb_mut().context(JitSnafu)?, &packed)?;
-        }
-        write_self_mask(step_jit, pos, n_text_ctx, beam_size)
-    }
-
-    fn copy_kv(&self, step_jit: &mut WhisperDecoderStepJit, pos: usize) -> Result<()> {
-        let b = self.per_pos_bytes();
-        step_jit.copy_output_to_self_k_cache(1, pos * b, 0, b).context(JitSnafu)?;
-        step_jit.copy_output_to_self_v_cache(2, pos * b, 0, b).context(JitSnafu)
-    }
-
-    fn per_beam_floats(&self, n_text_ctx: usize) -> usize {
-        n_text_ctx * self.per_pos_floats()
-    }
-
-    fn per_pos_floats(&self) -> usize {
-        self.self_k_cache.len() / self.init_len
-    }
-
-    fn per_pos_bytes(&self) -> usize {
-        self.per_pos_floats() * std::mem::size_of::<f32>()
-    }
-
-    /// Read step logits into the reusable buffer, returns &mut [f32].
-    fn read_logits_into(&mut self, step_jit: &mut WhisperDecoderStepJit, n_vocab: usize) -> Result<()> {
-        let buf = step_jit.logits().context(JitSnafu)?;
-        let src = buf.as_host_bytes().context(DeviceSnafu)?;
-        let available = src.len() / std::mem::size_of::<f32>();
-        let n = n_vocab.min(available);
-        self.logits_buf.clear();
-        self.logits_buf.extend_from_slice(bytemuck::cast_slice(&src[..n * std::mem::size_of::<f32>()]));
-        Ok(())
-    }
-
-    /// Write the causal mask for the current position into the step JIT.
-    /// Uses mask_buf to avoid allocating per step.
-    fn write_mask(
-        &mut self,
-        step_jit: &mut WhisperDecoderStepJit,
-        pos: usize,
-        n_text_ctx: usize,
-        batch: usize,
-    ) -> Result<()> {
-        let needed = (n_text_ctx + 1) * batch;
-        if self.mask_buf.len() < needed {
-            self.mask_buf.resize(needed, f32::NEG_INFINITY);
-        }
-        for bi in 0..batch {
-            let off = bi * (n_text_ctx + 1);
-            // Fill [0..pos) with 0.0, [pos..n_text_ctx) with -inf, [n_text_ctx] with 0.0
-            for i in 0..pos {
-                self.mask_buf[off + i] = 0.0;
-            }
-            for i in pos..n_text_ctx {
-                self.mask_buf[off + i] = f32::NEG_INFINITY;
-            }
-            self.mask_buf[off + n_text_ctx] = 0.0;
-        }
-        let buf = step_jit.self_mask_mut().context(JitSnafu)?;
-        let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-        let src_bytes: &[u8] = bytemuck::cast_slice(&self.mask_buf[..needed]);
-        dst[..src_bytes.len()].copy_from_slice(src_bytes);
-        Ok(())
-    }
-}
-
-fn write_token_buf(step_jit: &mut WhisperDecoderStepJit, tokens: &[i32]) -> Result<()> {
-    let buf = step_jit.token_mut().context(JitSnafu)?;
-    write_buf(buf, bytemuck::cast_slice(tokens))?;
-    Ok(())
-}
-
-fn init_decode(
-    prefill_jit: &mut WhisperPrefillJit,
-    tokenizer: &WhisperTokenizer,
-    options: &DecodeOptions,
-    n_text_ctx: usize,
-    n_vocab: usize,
-    pos_embedding: &[f32],
-    n_state: usize,
-) -> Result<DecodeCtx> {
-    let mut ctx = execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state)?;
-
-    // Serial debug/oracle decoders retain host caches for their existing cache
-    // upload and host-remapping paths.
-    let read_output = |jit: &WhisperPrefillJit,
-                       accessor: fn(&WhisperPrefillJit) -> crate::jit::Result<&Buffer>|
-     -> Result<Vec<f32>> {
-        let buf = accessor(jit).context(JitSnafu)?;
-        read_buf(buf, buf.size() / std::mem::size_of::<f32>())
-    };
-    ctx.self_k_cache = read_output(prefill_jit, WhisperPrefillJit::self_k)?;
-    ctx.self_v_cache = read_output(prefill_jit, WhisperPrefillJit::self_v)?;
-    ctx.cross_k = {
-        let buf = prefill_jit.prepared_cross_k_mut().context(JitSnafu)?;
-        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
-    };
-    ctx.cross_v = {
-        let buf = prefill_jit.prepared_cross_v_mut().context(JitSnafu)?;
-        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
-    };
-    let _ = n_text_ctx;
-    Ok(ctx)
 }
 
 fn execute_prefill(
@@ -1735,7 +1196,7 @@ fn execute_prefill(
     n_vocab: usize,
     pos_embedding: &[f32],
     n_state: usize,
-) -> Result<DecodeCtx> {
+) -> Result<PrefillMetadata> {
     // Build initial tokens
     let mut initial_tokens = vec![tokenizer.sot()];
     if tokenizer.multilingual {
@@ -1771,7 +1232,7 @@ fn execute_prefill(
         .map(|ns| softmax_prob(&prefill_logits[..n_vocab.min(prefill_logits.len())], ns as usize))
         .unwrap_or(f32::NAN);
 
-    Ok(DecodeCtx {
+    Ok(PrefillMetadata {
         initial_tokens,
         sample_begin,
         init_len,
@@ -1780,12 +1241,6 @@ fn execute_prefill(
         no_speech_prob,
         pos_embedding: pos_embedding.to_vec(),
         n_state,
-        self_k_cache: Vec::new(),
-        self_v_cache: Vec::new(),
-        cross_k: Vec::new(),
-        cross_v: Vec::new(),
-        logits_buf: Vec::new(),
-        mask_buf: Vec::new(),
     })
 }
 
@@ -1945,18 +1400,6 @@ fn read_uncached(jit: &WhisperDecoderJit) -> Result<Vec<f32>> {
     read_buf(buf, buf.size() / std::mem::size_of::<f32>())
 }
 
-fn write_self_mask(step_jit: &mut WhisperDecoderStepJit, pos: usize, n_text_ctx: usize, batch: usize) -> Result<()> {
-    let mut mask = vec![f32::NEG_INFINITY; (n_text_ctx + 1) * batch];
-    for bi in 0..batch {
-        let off = bi * (n_text_ctx + 1);
-        mask[off..off + pos].fill(0.0);
-        mask[off + n_text_ctx] = 0.0;
-    }
-    let buf = step_jit.self_mask_mut().context(JitSnafu)?;
-    write_buf(buf, bytemuck::cast_slice(&mask))?;
-    Ok(())
-}
-
 /// Write data directly into the buffer's host-visible mapping.
 /// `as_host_bytes_mut` syncs pending GPU work before returning the slice.
 /// Subsequent `execute()` sees our writes (unified memory / BAR).
@@ -1973,51 +1416,6 @@ fn read_buf(buf: &svod_device::Buffer, n: usize) -> Result<Vec<f32>> {
     let src = buf.as_host_bytes().context(DeviceSnafu)?;
     let n = n.min(src.len() / std::mem::size_of::<f32>());
     Ok(bytemuck::cast_slice(&src[..n * std::mem::size_of::<f32>()]).to_vec())
-}
-
-fn write_f32_input(buf: &mut svod_device::Buffer, data: &[f32]) -> Result<()> {
-    write_buf(buf, bytemuck::cast_slice(data))
-}
-
-/// Copy a host `&[f32]` into a device-local cache buffer via the copy engine.
-/// The cache buffers are device-local (no host mapping); the greedy path writes
-/// from byte 0 (single-row buffer, data may be shorter than the full allocation).
-fn copyin_cache_full(buf: &mut svod_device::Buffer, data: &[f32]) -> Result<()> {
-    let bytes: &[u8] = bytemuck::cast_slice(data);
-    buf.copyin_at(0, bytes).context(DeviceSnafu)
-}
-
-fn copyin_replicated_cache(
-    buf: &mut svod_device::Buffer,
-    single_data: &[f32],
-    beam_size: usize,
-    per_beam_floats: usize,
-) -> Result<()> {
-    let n = single_data.len().min(per_beam_floats);
-    let total = per_beam_floats * beam_size;
-    let mut packed = vec![0f32; total];
-    for bi in 0..beam_size {
-        packed[bi * per_beam_floats..bi * per_beam_floats + n].copy_from_slice(&single_data[..n]);
-    }
-    buf.copyin_at(0, bytemuck::cast_slice(&packed)).context(DeviceSnafu)
-}
-
-fn reorder_cache_host(buf: &mut svod_device::Buffer, parent_map: &[usize], per_beam_floats: usize) -> Result<()> {
-    let total = per_beam_floats * parent_map.len();
-    // Device-local cache: read out via copyout_prefix, reorder on host, write
-    // back via copyin_at. This is the beam-reorder path (runs once per step
-    // when beams survive/drop), not the per-step hot loop.
-    let mut staging = vec![0u8; total * std::mem::size_of::<f32>()];
-    buf.copyout_prefix(&mut staging).context(DeviceSnafu)?;
-    let current: &[f32] = bytemuck::cast_slice(&staging);
-
-    let mut reordered = vec![0f32; total];
-    for (new_idx, &parent_idx) in parent_map.iter().enumerate() {
-        let (src, dst) = (parent_idx * per_beam_floats, new_idx * per_beam_floats);
-        reordered[dst..dst + per_beam_floats].copy_from_slice(&current[src..src + per_beam_floats]);
-    }
-
-    buf.copyin_at(0, bytemuck::cast_slice(&reordered)).context(DeviceSnafu)
 }
 
 // ─── Logit filter helpers ───────────────────────────────────────────────────
@@ -2245,7 +1643,7 @@ mod scheduler_seed_tests {
         let self_v_source = cache(allocator.clone(), &self_values);
         let cross_k_source = cache(allocator.clone(), &cross_values);
         let cross_v_source = cache(allocator.clone(), &cross_values);
-        let ctx = DecodeCtx {
+        let metadata = PrefillMetadata {
             initial_tokens: vec![1, 2],
             sample_begin: 2,
             init_len: 2,
@@ -2254,16 +1652,10 @@ mod scheduler_seed_tests {
             no_speech_prob: f32::NAN,
             pos_embedding: Vec::new(),
             n_state: 0,
-            self_k_cache: Vec::new(),
-            self_v_cache: Vec::new(),
-            cross_k: Vec::new(),
-            cross_v: Vec::new(),
-            logits_buf: Vec::new(),
-            mask_buf: Vec::new(),
         };
 
         let seed = build_decode_seed(
-            ctx,
+            metadata,
             clone_device_cache(&self_k_source).unwrap(),
             clone_device_cache(&self_v_source).unwrap(),
             clone_device_cache(&cross_k_source).unwrap(),
@@ -2271,10 +1663,7 @@ mod scheduler_seed_tests {
         )
         .unwrap();
 
-        assert!(seed.ctx.self_k_cache.is_empty());
-        assert!(seed.ctx.self_v_cache.is_empty());
-        assert!(seed.ctx.cross_k.is_empty());
-        assert!(seed.ctx.cross_v.is_empty());
+        assert_eq!(seed.metadata.initial_tokens, [1, 2]);
         assert_eq!(seed.per_pos_bytes, 2 * std::mem::size_of::<f32>());
         assert_eq!(seed.self_cache_bytes, std::mem::size_of_val(&self_values));
         assert_eq!(seed.cross_cache_bytes, std::mem::size_of_val(&cross_values));

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -1,7 +1,6 @@
 //! KV-cached Whisper decoder: greedy, beam search, temperature fallback,
 //! and language detection — matching `whisper.decoding`.
 
-use super::config::N_AUDIO_CTX;
 use super::error::{DeviceSnafu, Error, JitSnafu, Result};
 use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperPrefillJit};
 use super::tokenizer::WhisperTokenizer;
@@ -9,6 +8,8 @@ use snafu::ResultExt;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use svod_arch::pipelines::audio::Segment;
+use svod_device::{Buffer, BufferSpec};
+use svod_dtype::DType;
 
 // ─── Language detection ─────────────────────────────────────────────────────
 
@@ -412,10 +413,19 @@ pub fn greedy_decode_cached(
 // ─── Fixed-slot mixed-strategy scheduler ────────────────────────────────────
 
 /// Immutable output of token prefill. Fallback attempts reuse this seed rather
-/// than rerunning prefill. Cache vectors are currently host-resident and are
-/// copied into a row only when that row changes request ownership.
+/// than rerunning prefill. Cache snapshots remain device-local and are copied
+/// into a row only when that row changes request ownership.
 pub(crate) struct DecodeSeed {
     ctx: DecodeCtx,
+    self_k_cache: Buffer,
+    self_v_cache: Buffer,
+    cross_k: Buffer,
+    cross_v: Buffer,
+    per_pos_bytes: usize,
+    self_cache_bytes: usize,
+    cross_cache_bytes: usize,
+    self_positions: usize,
+    cross_positions: usize,
 }
 
 pub(crate) fn prefill_decode_seed(
@@ -427,7 +437,79 @@ pub(crate) fn prefill_decode_seed(
     pos_embedding: &[f32],
     n_state: usize,
 ) -> Result<DecodeSeed> {
-    Ok(DecodeSeed { ctx: init_decode(prefill_jit, tokenizer, options, n_text_ctx, n_vocab, pos_embedding, n_state)? })
+    let ctx = execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state)?;
+    let self_k = clone_device_cache(prefill_jit.self_k().context(JitSnafu)?)?;
+    let self_v = clone_device_cache(prefill_jit.self_v().context(JitSnafu)?)?;
+    let cross_k = clone_device_cache(prefill_jit.prepared_cross_k_mut().context(JitSnafu)?)?;
+    let cross_v = clone_device_cache(prefill_jit.prepared_cross_v_mut().context(JitSnafu)?)?;
+    let seed = build_decode_seed(ctx, self_k, self_v, cross_k, cross_v)?;
+    if seed.self_positions > n_text_ctx {
+        return Err(decode_err("prefill self cache exceeds text context"));
+    }
+    Ok(seed)
+}
+
+fn clone_device_cache(src: &Buffer) -> Result<Buffer> {
+    if src.dtype() != DType::Float32 || !src.size().is_multiple_of(std::mem::size_of::<f32>()) {
+        return Err(decode_err("prefill cache must contain aligned float32 data"));
+    }
+    let mut clone = Buffer::allocate(
+        src.allocator_arc(),
+        DType::Float32,
+        vec![src.size() / std::mem::size_of::<f32>()],
+        BufferSpec { cpu_access: false, ..BufferSpec::default() },
+    )
+    .context(DeviceSnafu)?;
+    clone.copy_from(src).context(DeviceSnafu)?;
+    Ok(clone)
+}
+
+fn build_decode_seed(
+    ctx: DecodeCtx,
+    self_k: Buffer,
+    self_v: Buffer,
+    cross_k: Buffer,
+    cross_v: Buffer,
+) -> Result<DecodeSeed> {
+    if ctx.init_len == 0 || self_k.size() == 0 || self_k.size() != self_v.size() {
+        return Err(decode_err("invalid prefill self-cache geometry"));
+    }
+    if cross_k.size() == 0 || cross_k.size() != cross_v.size() {
+        return Err(decode_err("invalid prefill cross-cache geometry"));
+    }
+    for cache in [&self_v, &cross_k, &cross_v] {
+        if !std::ptr::eq(self_k.allocator(), cache.allocator()) {
+            return Err(decode_err("prefill caches use different allocators"));
+        }
+    }
+    let per_pos_bytes = self_k
+        .size()
+        .checked_div(ctx.init_len)
+        .filter(|&bytes| bytes != 0 && bytes.checked_mul(ctx.init_len) == Some(self_k.size()))
+        .ok_or_else(|| decode_err("self cache is not position-aligned"))?;
+    if per_pos_bytes % std::mem::size_of::<f32>() != 0 {
+        return Err(decode_err("self cache position is not float32-aligned"));
+    }
+    let cross_positions = cross_k
+        .size()
+        .checked_div(per_pos_bytes)
+        .filter(|&positions| positions != 0 && positions.checked_mul(per_pos_bytes) == Some(cross_k.size()))
+        .ok_or_else(|| decode_err("cross cache is not position-aligned"))?;
+    let self_cache_bytes = self_k.size();
+    let cross_cache_bytes = cross_k.size();
+
+    Ok(DecodeSeed {
+        self_k_cache: self_k,
+        self_v_cache: self_v,
+        cross_k,
+        cross_v,
+        per_pos_bytes,
+        self_cache_bytes,
+        cross_cache_bytes,
+        self_positions: ctx.init_len,
+        cross_positions,
+        ctx,
+    })
 }
 
 pub(crate) fn strategy_width(strategy: DecodeStrategy) -> usize {
@@ -655,15 +737,20 @@ fn seed_attempt_rows(
     seed: &DecodeSeed,
     n_text_ctx: usize,
 ) -> Result<()> {
-    let ctx = &seed.ctx;
-    let per_pos = ctx.per_pos_floats();
-    let self_stride = n_text_ctx.checked_mul(per_pos).ok_or_else(|| decode_err("self cache stride overflow"))?;
-    let cross_stride = N_AUDIO_CTX.checked_mul(per_pos).ok_or_else(|| decode_err("cross cache stride overflow"))?;
+    if seed.self_positions > n_text_ctx
+        || seed.self_positions.checked_mul(seed.per_pos_bytes) != Some(seed.self_cache_bytes)
+        || seed.cross_positions.checked_mul(seed.per_pos_bytes) != Some(seed.cross_cache_bytes)
+    {
+        return Err(decode_err("decode seed cache geometry mismatch"));
+    }
+    let self_stride =
+        n_text_ctx.checked_mul(seed.per_pos_bytes).ok_or_else(|| decode_err("self cache stride overflow"))?;
+    let cross_stride = seed.cross_cache_bytes;
     for &row in rows {
-        copyin_cache_row(jit.self_k_cache_mut().context(JitSnafu)?, row, self_stride, &ctx.self_k_cache)?;
-        copyin_cache_row(jit.self_v_cache_mut().context(JitSnafu)?, row, self_stride, &ctx.self_v_cache)?;
-        copyin_cache_row(jit.cross_k_mut().context(JitSnafu)?, row, cross_stride, &ctx.cross_k)?;
-        copyin_cache_row(jit.cross_v_mut().context(JitSnafu)?, row, cross_stride, &ctx.cross_v)?;
+        copy_device_cache_row(jit.self_k_cache_mut().context(JitSnafu)?, row, self_stride, &seed.self_k_cache)?;
+        copy_device_cache_row(jit.self_v_cache_mut().context(JitSnafu)?, row, self_stride, &seed.self_v_cache)?;
+        copy_device_cache_row(jit.cross_k_mut().context(JitSnafu)?, row, cross_stride, &seed.cross_k)?;
+        copy_device_cache_row(jit.cross_v_mut().context(JitSnafu)?, row, cross_stride, &seed.cross_v)?;
     }
     Ok(())
 }
@@ -838,8 +925,9 @@ pub(crate) fn run_fixed_slot_decode(
                 if attempt.is_done(sample_len, tokenizer.eot()) {
                     continue;
                 }
-                let seed = &seeds[request].ctx;
-                let per_pos_bytes = seed.per_pos_bytes();
+                let decode_seed = &seeds[request];
+                let seed = &decode_seed.ctx;
+                let per_pos_bytes = decode_seed.per_pos_bytes;
                 let row_stride_bytes = n_text_ctx
                     .checked_mul(per_pos_bytes)
                     .ok_or_else(|| decode_err("self cache row stride overflow"))?;
@@ -1007,23 +1095,20 @@ fn write_self_mask_row(jit: &mut WhisperDecoderStepJit, row: usize, pos: usize, 
     Ok(())
 }
 
-/// Copy a full cache buffer (self or cross) into one row of a device-local
-/// batched JIT input via the copy engine. `row_stride_floats` is the buffer's
-/// per-row capacity (N_TEXT_CTX or N_AUDIO_CTX positions × per_pos_floats);
-/// `data` may be shorter (e.g. only `init_len` positions populated for the self
-/// cache after prefill). Used for one-time seeding; the cache then grows
-/// on-device via SDMA append.
-fn copyin_cache_row(buf: &mut svod_device::Buffer, row: usize, row_stride_floats: usize, data: &[f32]) -> Result<()> {
-    let row_bytes = row_stride_floats
-        .checked_mul(std::mem::size_of::<f32>())
-        .ok_or_else(|| decode_err("cache row stride overflow"))?;
-    let off = row.checked_mul(row_bytes).ok_or_else(|| decode_err("cache row offset overflow"))?;
-    let bytes: &[u8] = bytemuck::cast_slice(data);
-    let end = off.checked_add(bytes.len()).ok_or_else(|| decode_err("cache seed end overflow"))?;
-    if end > buf.size() || bytes.len() > row_bytes {
+/// Seed one physical cache row from an immutable device-local snapshot.
+fn copy_device_cache_row(buf: &mut Buffer, row: usize, row_stride_bytes: usize, data: &Buffer) -> Result<()> {
+    if buf.dtype() != DType::Float32 || data.dtype() != DType::Float32 {
+        return Err(decode_err("cache seed buffers must be float32"));
+    }
+    if !std::ptr::eq(buf.allocator(), data.allocator()) {
+        return Err(decode_err("cache seed and decoder row use different allocators"));
+    }
+    let off = row.checked_mul(row_stride_bytes).ok_or_else(|| decode_err("cache row offset overflow"))?;
+    let end = off.checked_add(data.size()).ok_or_else(|| decode_err("cache seed end overflow"))?;
+    if end > buf.size() || data.size() > row_stride_bytes {
         return Err(decode_err("cache seed row is out of bounds"));
     }
-    buf.copyin_at(off, bytes).context(DeviceSnafu)
+    buf.copy_region_from(off, data, 0, data.size()).context(DeviceSnafu)
 }
 
 /// Read one lane's logits row `[n_vocab]` from the batched JIT output.
@@ -1528,6 +1613,38 @@ fn init_decode(
     pos_embedding: &[f32],
     n_state: usize,
 ) -> Result<DecodeCtx> {
+    let mut ctx = execute_prefill(prefill_jit, tokenizer, options, n_vocab, pos_embedding, n_state)?;
+
+    // Serial debug/oracle decoders retain host caches for their existing cache
+    // upload and host-remapping paths.
+    let read_output = |jit: &WhisperPrefillJit,
+                       accessor: fn(&WhisperPrefillJit) -> crate::jit::Result<&Buffer>|
+     -> Result<Vec<f32>> {
+        let buf = accessor(jit).context(JitSnafu)?;
+        read_buf(buf, buf.size() / std::mem::size_of::<f32>())
+    };
+    ctx.self_k_cache = read_output(prefill_jit, WhisperPrefillJit::self_k)?;
+    ctx.self_v_cache = read_output(prefill_jit, WhisperPrefillJit::self_v)?;
+    ctx.cross_k = {
+        let buf = prefill_jit.prepared_cross_k_mut().context(JitSnafu)?;
+        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
+    };
+    ctx.cross_v = {
+        let buf = prefill_jit.prepared_cross_v_mut().context(JitSnafu)?;
+        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
+    };
+    let _ = n_text_ctx;
+    Ok(ctx)
+}
+
+fn execute_prefill(
+    prefill_jit: &mut WhisperPrefillJit,
+    tokenizer: &WhisperTokenizer,
+    options: &DecodeOptions,
+    n_vocab: usize,
+    pos_embedding: &[f32],
+    n_state: usize,
+) -> Result<DecodeCtx> {
     // Build initial tokens
     let mut initial_tokens = vec![tokenizer.sot()];
     if tokenizer.multilingual {
@@ -1563,32 +1680,6 @@ fn init_decode(
         .map(|ns| softmax_prob(&prefill_logits[..n_vocab.min(prefill_logits.len())], ns as usize))
         .unwrap_or(f32::NAN);
 
-    // Read packed K/V from outputs 1-4 via copyout (synchronizes device)
-    let read_output = |jit: &WhisperPrefillJit,
-                       accessor: fn(&WhisperPrefillJit) -> crate::jit::Result<&svod_device::Buffer>|
-     -> Result<Vec<f32>> {
-        let buf = accessor(jit).context(JitSnafu)?;
-        read_buf(buf, buf.size() / std::mem::size_of::<f32>())
-    };
-
-    // Infer 4D shape from total element count: [1, seq, n_layer*H, Dh]
-    // seq = init_len for self, 1500 for cross. d_head = n_state / n_head.
-    // total = seq * n_layer * n_head * d_head. So layer_heads_dh = total / seq.
-    let self_k_cache = read_output(prefill_jit, WhisperPrefillJit::self_k)?;
-    let self_v_cache = read_output(prefill_jit, WhisperPrefillJit::self_v)?;
-    // Cross K/V were projected once before fallback decoding and remain in
-    // prefill's device-local inputs. Read them only to seed the step graph.
-    let cross_k = {
-        let buf = prefill_jit.prepared_cross_k_mut().context(JitSnafu)?;
-        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
-    };
-    let cross_v = {
-        let buf = prefill_jit.prepared_cross_v_mut().context(JitSnafu)?;
-        read_buf(buf, buf.size() / std::mem::size_of::<f32>())?
-    };
-
-    let _ = n_text_ctx;
-
     Ok(DecodeCtx {
         initial_tokens,
         sample_begin,
@@ -1598,10 +1689,10 @@ fn init_decode(
         no_speech_prob,
         pos_embedding: pos_embedding.to_vec(),
         n_state,
-        self_k_cache,
-        self_v_cache,
-        cross_k,
-        cross_v,
+        self_k_cache: Vec::new(),
+        self_v_cache: Vec::new(),
+        cross_k: Vec::new(),
+        cross_v: Vec::new(),
         logits_buf: Vec::new(),
         mask_buf: Vec::new(),
     })
@@ -2024,4 +2115,96 @@ fn sample_from_logits(logits: &[f32], temperature: f32) -> u32 {
         }
     }
     (probs.len() - 1) as u32
+}
+
+#[cfg(test)]
+mod scheduler_seed_tests {
+    use super::*;
+    use std::sync::Arc;
+    use svod_device::CpuAllocator;
+
+    fn cache(allocator: Arc<CpuAllocator>, values: &[f32]) -> Buffer {
+        let mut buffer =
+            Buffer::allocate(allocator, DType::Float32, vec![values.len()], BufferSpec::default()).unwrap();
+        buffer.copyin(bytemuck::cast_slice(values)).unwrap();
+        buffer
+    }
+
+    #[test]
+    fn scheduler_seed_owns_device_buffers_and_seeds_multiple_rows() {
+        let allocator = Arc::new(CpuAllocator);
+        let self_values = [1.0f32, 2.0, 3.0, 4.0];
+        let cross_values = [5.0f32, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let self_k_source = cache(allocator.clone(), &self_values);
+        let self_v_source = cache(allocator.clone(), &self_values);
+        let cross_k_source = cache(allocator.clone(), &cross_values);
+        let cross_v_source = cache(allocator.clone(), &cross_values);
+        let ctx = DecodeCtx {
+            initial_tokens: vec![1, 2],
+            sample_begin: 2,
+            init_len: 2,
+            suppress_tokens: Vec::new(),
+            prefill_logits: vec![0.0; 4],
+            no_speech_prob: f32::NAN,
+            pos_embedding: Vec::new(),
+            n_state: 0,
+            self_k_cache: Vec::new(),
+            self_v_cache: Vec::new(),
+            cross_k: Vec::new(),
+            cross_v: Vec::new(),
+            logits_buf: Vec::new(),
+            mask_buf: Vec::new(),
+        };
+
+        let seed = build_decode_seed(
+            ctx,
+            clone_device_cache(&self_k_source).unwrap(),
+            clone_device_cache(&self_v_source).unwrap(),
+            clone_device_cache(&cross_k_source).unwrap(),
+            clone_device_cache(&cross_v_source).unwrap(),
+        )
+        .unwrap();
+
+        assert!(seed.ctx.self_k_cache.is_empty());
+        assert!(seed.ctx.self_v_cache.is_empty());
+        assert!(seed.ctx.cross_k.is_empty());
+        assert!(seed.ctx.cross_v.is_empty());
+        assert_eq!(seed.per_pos_bytes, 2 * std::mem::size_of::<f32>());
+        assert_eq!(seed.self_cache_bytes, std::mem::size_of_val(&self_values));
+        assert_eq!(seed.cross_cache_bytes, std::mem::size_of_val(&cross_values));
+        assert_eq!((seed.self_positions, seed.cross_positions), (2, 3));
+        assert_ne!(seed.self_k_cache.storage_id(), self_k_source.storage_id());
+        assert_ne!(seed.self_v_cache.storage_id(), self_v_source.storage_id());
+        assert_ne!(seed.cross_k.storage_id(), cross_k_source.storage_id());
+        assert_ne!(seed.cross_v.storage_id(), cross_v_source.storage_id());
+
+        let self_stride = 4 * seed.per_pos_bytes;
+        let mut self_rows = Buffer::allocate(
+            allocator.clone(),
+            DType::Float32,
+            vec![2 * self_stride / std::mem::size_of::<f32>()],
+            BufferSpec::default(),
+        )
+        .unwrap();
+        copy_device_cache_row(&mut self_rows, 0, self_stride, &seed.self_k_cache).unwrap();
+        copy_device_cache_row(&mut self_rows, 1, self_stride, &seed.self_k_cache).unwrap();
+        let self_bytes = self_rows.as_host_bytes().unwrap();
+        let expected_self: &[u8] = bytemuck::cast_slice(&self_values);
+        assert_eq!(&self_bytes[..expected_self.len()], expected_self);
+        assert_eq!(&self_bytes[self_stride..self_stride + expected_self.len()], expected_self);
+
+        let mut cross_rows = Buffer::allocate(
+            allocator,
+            DType::Float32,
+            vec![2 * seed.cross_cache_bytes / std::mem::size_of::<f32>()],
+            BufferSpec::default(),
+        )
+        .unwrap();
+        copy_device_cache_row(&mut cross_rows, 0, seed.cross_cache_bytes, &seed.cross_k).unwrap();
+        copy_device_cache_row(&mut cross_rows, 1, seed.cross_cache_bytes, &seed.cross_k).unwrap();
+        let cross_bytes = cross_rows.as_host_bytes().unwrap();
+        let expected_cross: &[u8] = bytemuck::cast_slice(&cross_values);
+        assert_eq!(&cross_bytes[..expected_cross.len()], expected_cross);
+        assert_eq!(&cross_bytes[seed.cross_cache_bytes..], expected_cross);
+    }
 }

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -708,7 +708,8 @@ pub(crate) fn run_fixed_slot_decode(
     tokenizer: &WhisperTokenizer,
     n_text_ctx: usize,
     n_vocab: usize,
-) -> Result<(Vec<DecodeResult>, DecodeScheduleStats)> {
+    profile: bool,
+) -> Result<(Vec<DecodeResult>, DecodeScheduleStats, Vec<svod_runtime::KernelProfile>)> {
     if seeds.len() != request_options.len() {
         return Err(decode_err("decode seed/options count mismatch"));
     }
@@ -727,6 +728,7 @@ pub(crate) fn run_fixed_slot_decode(
     let mut attempts: Vec<Option<ScheduledAttempt>> = (0..seeds.len()).map(|_| None).collect();
     let mut results: Vec<Option<DecodeResult>> = (0..seeds.len()).map(|_| None).collect();
     let mut stats = DecodeScheduleStats::default();
+    let mut profiled_kernels = Vec::new();
     let mut rngs: Vec<_> =
         request_options.iter().enumerate().map(|(request, options)| sampling_rng(options, request)).collect();
 
@@ -815,7 +817,11 @@ pub(crate) fn run_fixed_slot_decode(
                     AttemptKind::Beam(beam) => beam.active.len(),
                 })
                 .sum::<usize>();
-            step_jit.execute().context(JitSnafu)?;
+            if profile && profiled_kernels.is_empty() {
+                profiled_kernels = step_jit.execute_profiled().context(JitSnafu)?;
+            } else {
+                step_jit.execute().context(JitSnafu)?;
+            }
             for &request in &active_requests {
                 let attempt = attempts[request].as_mut().expect("active attempt");
                 let sample_len = request_options[request].sample_len.unwrap_or(n_text_ctx / 2);
@@ -941,7 +947,7 @@ pub(crate) fn run_fixed_slot_decode(
         }
     }
 
-    Ok((collect_ordered(results).map_err(decode_err)?, stats))
+    Ok((collect_ordered(results).map_err(decode_err)?, stats, profiled_kernels))
 }
 
 // ─── Batched JIT buffer row helpers ─────────────────────────────────────────

--- a/model/src/whisper/decode.rs
+++ b/model/src/whisper/decode.rs
@@ -288,7 +288,7 @@ pub fn greedy_decode_cached(
 
         write_token_buf(step_jit, &[next_token as i32])?;
         let off = pos * ctx.n_state;
-        write_f32_input(step_jit.pos_emb_mut(), &ctx.pos_embedding[off..off + ctx.n_state])?;
+        write_f32_input(step_jit.pos_emb_mut().context(JitSnafu)?, &ctx.pos_embedding[off..off + ctx.n_state])?;
         ctx.write_mask(step_jit, pos, n_text_ctx, 1)?;
         step_jit.execute().context(JitSnafu)?;
         ctx.copy_kv(step_jit, pos)?;
@@ -347,13 +347,16 @@ pub struct DecodeLane {
     pub pos_embedding: Vec<f32>,
     pub n_state: usize,
 
-    // KV caches — packed into the batched step JIT at this lane's row.
-    // self_k/v grow as tokens decode (one position appended per step via
-    // SDMA writeback); cross_k/v are fixed after prefill.
+    // KV caches — seeded once into the batched step JIT's device-local buffer
+    // at this lane's row. After seeding, the cache lives on-device and grows
+    // one position per step via SDMA writeback (`copy_output_to_self_k_cache`);
+    // the host never rewrites it. `seeded_row` is the row the cache currently
+    // occupies in the [max_lanes, ...] buffer (changes on lane compaction).
     pub self_k_cache: Vec<f32>,
     pub self_v_cache: Vec<f32>,
     pub cross_k: Vec<f32>,
     pub cross_v: Vec<f32>,
+    pub seeded_row: Option<usize>,
 
     // Per-step loop state (mutated each step)
     pub next_token: u32,
@@ -412,6 +415,7 @@ impl DecodeLane {
             self_v_cache: ctx.self_v_cache,
             cross_k: ctx.cross_k,
             cross_v: ctx.cross_v,
+            seeded_row: None,
             next_token,
             tokens,
             sum_logprob,
@@ -475,15 +479,52 @@ pub fn run_batched_decode(
         // Pack each active lane's inputs into the batched JIT at its row.
         // Rows are contiguous: active lane `j` (j=0..active_count) maps to
         // row `j` in the [active_count, ...] dispatch.
+        //
+        // KV caches are device-local: the first time a lane occupies a row
+        // (and whenever compaction moves it to a new row), the seed cache
+        // (read from prefill) is copied in once via `copyin`. Thereafter the
+        // cache grows on-device via SDMA append (teardown below) — the host
+        // never rewrites it. This is the bandwidth win: one seed per lane,
+        // not a full-cache rewrite per step.
         for (row, &lane_idx) in active.iter().enumerate() {
-            let lane = &lanes[lane_idx];
+            let lane = &mut lanes[lane_idx];
             write_token_row(step_jit, row, lane.next_token)?;
             write_pos_emb_row(step_jit, row, &lane.pos_embedding[lane.pos * n_state..(lane.pos + 1) * n_state])?;
             write_self_mask_row(step_jit, row, lane.pos, n_text_ctx)?;
-            write_cache_row(step_jit.self_k_cache_mut(), row, self_row_stride, &lane.self_k_cache)?;
-            write_cache_row(step_jit.self_v_cache_mut(), row, self_row_stride, &lane.self_v_cache)?;
-            write_cache_row(step_jit.cross_k_mut(), row, cross_row_stride, &lane.cross_k)?;
-            write_cache_row(step_jit.cross_v_mut(), row, cross_row_stride, &lane.cross_v)?;
+
+            // Seed caches into this row only when the lane's row changed.
+            //
+            // Two cases:
+            // - First activation (`seeded_row == None`): seed from the host Vec
+            //   (the prefill prefix). The cache then grows on-device via SDMA.
+            // - Compaction (`seeded_row == Some(old_row)`): the earlier lane
+            //   dropped out, shifting this lane down to `row`. Copy the GROWN
+            //   cache device-to-device from `old_row` to `row` — NOT from the
+            //   host Vec, which only holds the stale prefill prefix and would
+            //   clobber positions [init_len, pos) written by prior SDMA appends.
+            match lane.seeded_row {
+                None => {
+                    copyin_cache_row(step_jit.self_k_cache_mut().context(JitSnafu)?, row, self_row_stride, &lane.self_k_cache)?;
+                    copyin_cache_row(step_jit.self_v_cache_mut().context(JitSnafu)?, row, self_row_stride, &lane.self_v_cache)?;
+                    copyin_cache_row(step_jit.cross_k_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_k)?;
+                    copyin_cache_row(step_jit.cross_v_mut().context(JitSnafu)?, row, cross_row_stride, &lane.cross_v)?;
+                }
+                Some(old_row) if old_row != row => {
+                    let grown_bytes = lane.pos * lane.per_pos_bytes();
+                    let new_self_off = row * self_row_stride * std::mem::size_of::<f32>();
+                    let old_self_off = old_row * self_row_stride * std::mem::size_of::<f32>();
+                    copy_cache_row_device(step_jit.self_k_cache_mut().context(JitSnafu)?, new_self_off, old_self_off, grown_bytes)?;
+                    copy_cache_row_device(step_jit.self_v_cache_mut().context(JitSnafu)?, new_self_off, old_self_off, grown_bytes)?;
+                    // Cross cache is static after prefill — copy the full row.
+                    let cross_bytes = N_AUDIO_CTX * lane.per_pos_bytes();
+                    let new_cross_off = row * cross_row_stride * std::mem::size_of::<f32>();
+                    let old_cross_off = old_row * cross_row_stride * std::mem::size_of::<f32>();
+                    copy_cache_row_device(step_jit.cross_k_mut().context(JitSnafu)?, new_cross_off, old_cross_off, cross_bytes)?;
+                    copy_cache_row_device(step_jit.cross_v_mut().context(JitSnafu)?, new_cross_off, old_cross_off, cross_bytes)?;
+                }
+                _ => {}
+            }
+            lane.seeded_row = Some(row);
         }
 
         // One dispatch for all active lanes, rebound to the live count.
@@ -581,22 +622,35 @@ fn write_self_mask_row(jit: &mut WhisperDecoderStepBatchedJit, row: usize, pos: 
     Ok(())
 }
 
-/// Write a full cache buffer (self or cross) into one row of the batched JIT.
-/// `row_stride_floats` is the buffer's per-row capacity (N_TEXT_CTX or
-/// N_AUDIO_CTX positions × per_pos_floats); `data` may be shorter (e.g. only
-/// `init_len` positions populated for the self cache after prefill).
-fn write_cache_row(
-    buf_result: crate::jit::Result<&mut svod_device::Buffer>,
+/// Copy a full cache buffer (self or cross) into one row of a device-local
+/// batched JIT input via the copy engine. `row_stride_floats` is the buffer's
+/// per-row capacity (N_TEXT_CTX or N_AUDIO_CTX positions × per_pos_floats);
+/// `data` may be shorter (e.g. only `init_len` positions populated for the self
+/// cache after prefill). Used for one-time seeding; the cache then grows
+/// on-device via SDMA append.
+fn copyin_cache_row(
+    buf: &mut svod_device::Buffer,
     row: usize,
     row_stride_floats: usize,
     data: &[f32],
 ) -> Result<()> {
-    let buf = buf_result.context(JitSnafu)?;
-    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
     let off = row * row_stride_floats * std::mem::size_of::<f32>();
     let bytes: &[u8] = bytemuck::cast_slice(data);
-    dst[off..off + bytes.len()].copy_from_slice(bytes);
-    Ok(())
+    buf.copyin_at(off, bytes).context(DeviceSnafu)
+}
+
+/// On-device cache row relocation for lane compaction. When an earlier lane
+/// drops out, later lanes shift down — their grown caches move with them via
+/// `Buffer::copy_within` (SDMA, no host round-trip). Used instead of re-seeding
+/// from the stale host Vec, which only holds the prefill prefix and would
+/// clobber positions [init_len, pos) grown by prior SDMA appends.
+fn copy_cache_row_device(
+    buf: &mut svod_device::Buffer,
+    new_off: usize,
+    old_off: usize,
+    len: usize,
+) -> Result<()> {
+    buf.copy_within(new_off, old_off, len).context(DeviceSnafu)
 }
 
 /// Read one lane's logits row `[n_vocab]` from the batched JIT output.
@@ -742,8 +796,8 @@ pub fn beam_decode_cached(
 
         // Reorder cache by parent_map (host-side, copies ENTIRE cache incl new K/V)
         if !parent_map.is_empty() {
-            reorder_cache_host(step_jit.self_k_cache_mut(), &parent_map, per_beam_floats)?;
-            reorder_cache_host(step_jit.self_v_cache_mut(), &parent_map, per_beam_floats)?;
+            reorder_cache_host(step_jit.self_k_cache_mut().context(JitSnafu)?, &parent_map, per_beam_floats)?;
+            reorder_cache_host(step_jit.self_v_cache_mut().context(JitSnafu)?, &parent_map, per_beam_floats)?;
         }
 
         beams = new_beams;
@@ -816,10 +870,10 @@ struct DecodeCtx {
 
 impl DecodeCtx {
     fn write_caches_greedy(&self, step_jit: &mut WhisperDecoderStepJit) -> Result<()> {
-        write_f32_input(step_jit.self_k_cache_mut(), &self.self_k_cache)?;
-        write_f32_input(step_jit.self_v_cache_mut(), &self.self_v_cache)?;
-        write_f32_input(step_jit.cross_k_mut(), &self.cross_k)?;
-        write_f32_input(step_jit.cross_v_mut(), &self.cross_v)?;
+        copyin_cache_full(step_jit.self_k_cache_mut().context(JitSnafu)?, &self.self_k_cache)?;
+        copyin_cache_full(step_jit.self_v_cache_mut().context(JitSnafu)?, &self.self_v_cache)?;
+        copyin_cache_full(step_jit.cross_k_mut().context(JitSnafu)?, &self.cross_k)?;
+        copyin_cache_full(step_jit.cross_v_mut().context(JitSnafu)?, &self.cross_v)?;
         Ok(())
     }
 
@@ -833,10 +887,10 @@ impl DecodeCtx {
         let layer_heads_dh = self.self_k_cache.len() / self.init_len;
         let self_stride = n_text_ctx * layer_heads_dh;
         let cross_stride = n_audio_ctx * layer_heads_dh;
-        write_replicated_cache(step_jit.self_k_cache_mut(), &self.self_k_cache, beam_size, self_stride)?;
-        write_replicated_cache(step_jit.self_v_cache_mut(), &self.self_v_cache, beam_size, self_stride)?;
-        write_replicated_cache(step_jit.cross_k_mut(), &self.cross_k, beam_size, cross_stride)?;
-        write_replicated_cache(step_jit.cross_v_mut(), &self.cross_v, beam_size, cross_stride)?;
+        copyin_replicated_cache(step_jit.self_k_cache_mut().context(JitSnafu)?, &self.self_k_cache, beam_size, self_stride)?;
+        copyin_replicated_cache(step_jit.self_v_cache_mut().context(JitSnafu)?, &self.self_v_cache, beam_size, self_stride)?;
+        copyin_replicated_cache(step_jit.cross_k_mut().context(JitSnafu)?, &self.cross_k, beam_size, cross_stride)?;
+        copyin_replicated_cache(step_jit.cross_v_mut().context(JitSnafu)?, &self.cross_v, beam_size, cross_stride)?;
         Ok(())
     }
 
@@ -864,7 +918,7 @@ impl DecodeCtx {
             for bi in 0..beam_size {
                 packed[bi * self.n_state..(bi + 1) * self.n_state].copy_from_slice(emb);
             }
-            write_f32_input(step_jit.pos_emb_mut(), &packed)?;
+            write_f32_input(step_jit.pos_emb_mut().context(JitSnafu)?, &packed)?;
         }
         write_self_mask(step_jit, pos, n_text_ctx, beam_size)
     }
@@ -1086,35 +1140,45 @@ fn read_buf(buf: &svod_device::Buffer, n: usize) -> Result<Vec<f32>> {
     Ok(bytemuck::cast_slice(&src[..n * std::mem::size_of::<f32>()]).to_vec())
 }
 
-fn write_f32_input(buf_result: crate::jit::Result<&mut svod_device::Buffer>, data: &[f32]) -> Result<()> {
-    let buf = buf_result.context(JitSnafu)?;
+fn write_f32_input(buf: &mut svod_device::Buffer, data: &[f32]) -> Result<()> {
     write_buf(buf, bytemuck::cast_slice(data))
 }
 
-fn write_replicated_cache(
-    buf_result: crate::jit::Result<&mut svod_device::Buffer>,
+/// Copy a host `&[f32]` into a device-local cache buffer via the copy engine.
+/// The cache buffers are device-local (no host mapping); the greedy path writes
+/// from byte 0 (single-row buffer, data may be shorter than the full allocation).
+fn copyin_cache_full(buf: &mut svod_device::Buffer, data: &[f32]) -> Result<()> {
+    let bytes: &[u8] = bytemuck::cast_slice(data);
+    buf.copyin_at(0, bytes).context(DeviceSnafu)
+}
+
+fn copyin_replicated_cache(
+    buf: &mut svod_device::Buffer,
     single_data: &[f32],
     beam_size: usize,
     per_beam_floats: usize,
 ) -> Result<()> {
-    let buf = buf_result.context(JitSnafu)?;
     let n = single_data.len().min(per_beam_floats);
     let total = per_beam_floats * beam_size;
     let mut packed = vec![0f32; total];
     for bi in 0..beam_size {
         packed[bi * per_beam_floats..bi * per_beam_floats + n].copy_from_slice(&single_data[..n]);
     }
-    write_buf(buf, bytemuck::cast_slice(&packed))
+    buf.copyin_at(0, bytemuck::cast_slice(&packed)).context(DeviceSnafu)
 }
 
 fn reorder_cache_host(
-    buf_result: crate::jit::Result<&mut svod_device::Buffer>,
+    buf: &mut svod_device::Buffer,
     parent_map: &[usize],
     per_beam_floats: usize,
 ) -> Result<()> {
-    let buf = buf_result.context(JitSnafu)?;
     let total = per_beam_floats * parent_map.len();
-    let current = read_buf(buf, total)?;
+    // Device-local cache: read out via copyout_prefix, reorder on host, write
+    // back via copyin_at. This is the beam-reorder path (runs once per step
+    // when beams survive/drop), not the per-step hot loop.
+    let mut staging = vec![0u8; total * std::mem::size_of::<f32>()];
+    buf.copyout_prefix(&mut staging).context(DeviceSnafu)?;
+    let current: &[f32] = bytemuck::cast_slice(&staging);
 
     let mut reordered = vec![0f32; total];
     for (new_idx, &parent_idx) in parent_map.iter().enumerate() {
@@ -1122,7 +1186,7 @@ fn reorder_cache_host(
         reordered[dst..dst + per_beam_floats].copy_from_slice(&current[src..src + per_beam_floats]);
     }
 
-    write_buf(buf, bytemuck::cast_slice(&reordered))
+    buf.copyin_at(0, bytemuck::cast_slice(&reordered)).context(DeviceSnafu)
 }
 
 // ─── Logit filter helpers ───────────────────────────────────────────────────

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -456,6 +456,13 @@ impl TextDecoder {
                     operation: "forward_step cache length".into(),
                 }),
             })? + 1;
+        let cross_key_count =
+            cross_k.shape().context(TensorSnafu)?[1].as_const().ok_or_else(|| super::error::Error::Tensor {
+                source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
+                    operation: "forward_step cross cache length".into(),
+                }),
+            })?;
+        let cross_splits = if cross_key_count >= 1000 && cross_key_count.is_multiple_of(10) { 10 } else { 1 };
 
         // Embed single token + positional embedding
         let tok_emb = self.token_embedding.embedding(token).context(TensorSnafu)?;
@@ -538,17 +545,30 @@ impl TextDecoder {
                 .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
                 .context(TensorSnafu)?;
 
-            let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-            let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-            let layer_cv_h = layer_cv.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-            let cross_out = cq_h
-                .scaled_dot_product_attention()
-                .key(&layer_ck_h)
-                .value(&layer_cv_h)
-                .is_causal(false)
-                .call()
-                .context(TensorSnafu)?;
-            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
+            let direct = svod_tk::single_query_attention(
+                &cq_seq,
+                &layer_ck,
+                &layer_cv,
+                svod_tk::SqAttentionOpts { split: cross_splits, ..Default::default() },
+            )
+            .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+            .context(TensorSnafu)?;
+            let cross_out = match direct {
+                Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
+                None => {
+                    let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let layer_cv_h = layer_cv.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let out = cq_h
+                        .scaled_dot_product_attention()
+                        .key(&layer_ck_h)
+                        .value(&layer_cv_h)
+                        .is_causal(false)
+                        .call()
+                        .context(TensorSnafu)?;
+                    block.cross_attn.merge_heads(&out)?
+                }
+            };
             let cross_out = block.cross_attn.out.forward(&cross_out)?;
             x = x.try_add(&cross_out).context(TensorSnafu)?;
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -462,7 +462,7 @@ impl TextDecoder {
                     operation: "forward_step cross cache length".into(),
                 }),
             })?;
-        let cross_splits = if cross_key_count >= 1000 && cross_key_count.is_multiple_of(10) { 10 } else { 1 };
+        let cross_splits = if cross_key_count >= 1000 && cross_key_count.is_multiple_of(4) { 4 } else { 1 };
 
         // Embed single token + positional embedding
         let tok_emb = self.token_embedding.embedding(token).context(TensorSnafu)?;

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -501,7 +501,7 @@ impl TextDecoder {
                 &q_seq,
                 &full_k,
                 &full_v,
-                svod_tk::SqAttentionOpts { key_lens: Some(self_key_lens), include_last: true },
+                svod_tk::SqAttentionOpts { key_lens: Some(self_key_lens), include_last: true, split: 1 },
             )
             .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
             .context(TensorSnafu)?;
@@ -538,25 +538,17 @@ impl TextDecoder {
                 .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
                 .context(TensorSnafu)?;
 
-            let direct = svod_tk::single_query_attention(&cq_seq, &layer_ck, &layer_cv, Default::default())
-                .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+            let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+            let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+            let layer_cv_h = layer_cv.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+            let cross_out = cq_h
+                .scaled_dot_product_attention()
+                .key(&layer_ck_h)
+                .value(&layer_cv_h)
+                .is_causal(false)
+                .call()
                 .context(TensorSnafu)?;
-            let cross_out = match direct {
-                Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
-                None => {
-                    let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-                    let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-                    let layer_cv_h = layer_cv.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-                    let out = cq_h
-                        .scaled_dot_product_attention()
-                        .key(&layer_ck_h)
-                        .value(&layer_cv_h)
-                        .is_causal(false)
-                        .call()
-                        .context(TensorSnafu)?;
-                    block.cross_attn.merge_heads(&out)?
-                }
-            };
+            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
             let cross_out = block.cross_attn.out.forward(&cross_out)?;
             x = x.try_add(&cross_out).context(TensorSnafu)?;
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -13,6 +13,18 @@ use super::blocks::{LayerNormWeights, linear_with_bias};
 use super::config::ModelDimensions;
 use super::error::{Result, TensorSnafu};
 
+pub(crate) fn cached_step_mask(key_lens: &Tensor, batch: usize, key_count: usize) -> Result<Tensor> {
+    let range = Tensor::arange(key_count as i64, None, None)
+        .context(TensorSnafu)?
+        .try_reshape([1usize, 1, 1, key_count])
+        .context(TensorSnafu)?;
+    let lens = key_lens.try_reshape([batch, 1, 1, 1]).context(TensorSnafu)?;
+    let beyond_prefix = range.try_ge(&lens).context(TensorSnafu)?;
+    let final_key = Tensor::const_(ConstValue::Int(key_count as i64 - 1), DType::Int32);
+    let not_final = range.try_ne(&final_key).context(TensorSnafu)?;
+    beyond_prefix.try_bitand(&not_final).context(TensorSnafu)
+}
+
 /// Decoder transformer block: self-attn + cross-attn + MLP, all pre-norm.
 #[derive(Clone)]
 pub struct DecoderBlock {
@@ -413,7 +425,7 @@ impl TextDecoder {
     /// - `self_v_cache`: [B, max_len, n_layer*H, Dh] self-attn V cache
     /// - `cross_k`: [B, n_audio_ctx, n_layer*H, Dh] cross-attn K (fixed)
     /// - `cross_v`: [B, n_audio_ctx, n_layer*H, Dh] cross-attn V (fixed)
-    /// - `self_mask`: [B(or 1), 1, 1, max_len+1] additive float mask for self-attn
+    /// - `self_key_lens`: [B] i32 valid cached-key counts for self-attn
     ///
     /// Returns `(logits[B, n_vocab], new_self_k[B, 1, n_layer*H, Dh], new_self_v[...])`.
     #[allow(clippy::too_many_arguments)]
@@ -425,7 +437,7 @@ impl TextDecoder {
         self_v_cache: &Tensor,
         cross_k: &Tensor,
         cross_v: &Tensor,
-        self_mask: &Tensor,
+        self_key_lens: &Tensor,
     ) -> Result<(Tensor, Tensor, Tensor)> {
         let n_head = self.n_head;
         let n_layer = self.blocks.len();
@@ -438,6 +450,12 @@ impl TextDecoder {
                 operation: "forward_step batch".into(),
             }),
         })?;
+        let self_key_count =
+            self_k_cache.shape().context(TensorSnafu)?[1].as_const().ok_or_else(|| super::error::Error::Tensor {
+                source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
+                    operation: "forward_step cache length".into(),
+                }),
+            })? + 1;
 
         // Embed single token + positional embedding
         let tok_emb = self.token_embedding.embedding(token).context(TensorSnafu)?;
@@ -458,66 +476,87 @@ impl TextDecoder {
             let new_k_raw = block.attn.key.forward(&h)?;
             let new_v_raw = block.attn.value.forward(&h)?;
 
-            // Split heads: [B, 1, D] → [B, H, 1, Dh]
-            let q_h = block.attn.split_heads(&q)?;
+            // Sequence-major projections are consumed directly by the custom path.
+            let q_seq = q.try_reshape([batch, 1, n_head, d_head]).context(TensorSnafu)?;
+            let new_k_seq = new_k_raw.try_reshape([batch, 1, n_head, d_head]).context(TensorSnafu)?;
+            let new_v_seq = new_v_raw.try_reshape([batch, 1, n_head, d_head]).context(TensorSnafu)?;
             let new_k_h = block.attn.split_heads(&new_k_raw)?;
             let new_v_h = block.attn.split_heads(&new_v_raw)?;
 
             // Slice this layer's cached K/V: [B, max_len, n_layer*H, Dh]
-            // → [B, max_len, H, Dh] → permute → [B, H, max_len, Dh]
+            // → [B, max_len, H, Dh].
             let cached_k = self_k_cache
                 .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
-                .context(TensorSnafu)?; // [B, H, max_len, Dh]
+                .context(TensorSnafu)?;
             let cached_v = self_v_cache
                 .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
                 .context(TensorSnafu)?;
 
             // Concatenate cached K/V with new K/V along seq dim:
-            // [B, H, max_len, Dh] cat [B, H, 1, Dh] → [B, H, max_len+1, Dh]
-            let full_k = Tensor::cat(&[&cached_k, &new_k_h], 2).context(TensorSnafu)?;
-            let full_v = Tensor::cat(&[&cached_v, &new_v_h], 2).context(TensorSnafu)?;
+            // [B, max_len, H, Dh] cat [B, 1, H, Dh] → [B, max_len+1, H, Dh]
+            let full_k = Tensor::cat(&[&cached_k, &new_k_seq], 1).context(TensorSnafu)?;
+            let full_v = Tensor::cat(&[&cached_v, &new_v_seq], 1).context(TensorSnafu)?;
 
-            // Attention with additive mask
-            let out = q_h
-                .scaled_dot_product_attention()
-                .key(&full_k)
-                .value(&full_v)
-                .attn_mask(self_mask)
-                .is_causal(false)
-                .call()
-                .context(TensorSnafu)?;
-            let attn_out = block.attn.merge_heads(&out)?;
+            let direct = svod_tk::single_query_attention(
+                &q_seq,
+                &full_k,
+                &full_v,
+                svod_tk::SqAttentionOpts { key_lens: Some(self_key_lens), include_last: true },
+            )
+            .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+            .context(TensorSnafu)?;
+            let attn_out = match direct {
+                Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
+                None => {
+                    let q_h = q_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let full_k_h = full_k.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let full_v_h = full_v.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let mask = cached_step_mask(self_key_lens, batch, self_key_count)?;
+                    let out = q_h
+                        .scaled_dot_product_attention()
+                        .key(&full_k_h)
+                        .value(&full_v_h)
+                        .attn_mask(&mask)
+                        .is_causal(false)
+                        .call()
+                        .context(TensorSnafu)?;
+                    block.attn.merge_heads(&out)?
+                }
+            };
             let attn_out = block.attn.out.forward(&attn_out)?;
             x = x.try_add(&attn_out).context(TensorSnafu)?;
 
             // ── Cross-attn (fixed cache, no mask) ────────────────────────
             let h = block.cross_attn_ln.apply(&x)?;
             let cq = block.cross_attn.query.forward(&h)?;
-            let cq_h = block.cross_attn.split_heads(&cq)?;
+            let cq_seq = cq.try_reshape([batch, 1, n_head, d_head]).context(TensorSnafu)?;
 
             let layer_ck = cross_k
                 .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
-                .context(TensorSnafu)?; // [B, H, n_audio_ctx, Dh]
+                .context(TensorSnafu)?;
             let layer_cv = cross_v
                 .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
                 .context(TensorSnafu)?;
 
-            let cross_out = cq_h
-                .scaled_dot_product_attention()
-                .key(&layer_ck)
-                .value(&layer_cv)
-                .is_causal(false)
-                .call()
+            let direct = svod_tk::single_query_attention(&cq_seq, &layer_ck, &layer_cv, Default::default())
+                .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
                 .context(TensorSnafu)?;
-            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
+            let cross_out = match direct {
+                Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
+                None => {
+                    let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let layer_cv_h = layer_cv.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let out = cq_h
+                        .scaled_dot_product_attention()
+                        .key(&layer_ck_h)
+                        .value(&layer_cv_h)
+                        .is_causal(false)
+                        .call()
+                        .context(TensorSnafu)?;
+                    block.cross_attn.merge_heads(&out)?
+                }
+            };
             let cross_out = block.cross_attn.out.forward(&cross_out)?;
             x = x.try_add(&cross_out).context(TensorSnafu)?;
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -9,7 +9,7 @@ use crate::init::fan_in_uniform;
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
 
 use super::attention::{MultiHeadAttention, causal_mask};
-use super::blocks::LayerNormWeights;
+use super::blocks::{LayerNormWeights, linear_with_bias};
 use super::config::ModelDimensions;
 use super::error::{Result, TensorSnafu};
 
@@ -63,9 +63,9 @@ impl DecoderBlock {
 
         // MLP
         let h = self.mlp_ln.apply(&x)?;
-        let h = h.linear().weight(&self.mlp0_w).bias(&self.mlp0_b).call().context(TensorSnafu)?;
+        let h = linear_with_bias(&h, &self.mlp0_w, &self.mlp0_b)?;
         let h = h.gelu_exact().context(TensorSnafu)?;
-        let h = h.linear().weight(&self.mlp1_w).bias(&self.mlp1_b).call().context(TensorSnafu)?;
+        let h = linear_with_bias(&h, &self.mlp1_w, &self.mlp1_b)?;
         let x = x.try_add(&h).context(TensorSnafu)?;
         Ok(x)
     }
@@ -275,9 +275,9 @@ impl TextDecoder {
             }
 
             let h = block.mlp_ln.apply(&x)?;
-            let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
+            let h = linear_with_bias(&h, &block.mlp0_w, &block.mlp0_b)?;
             let h = h.gelu_exact().context(TensorSnafu)?;
-            let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
+            let h = linear_with_bias(&h, &block.mlp1_w, &block.mlp1_b)?;
             x = x.try_add(&h).context(TensorSnafu)?;
         }
         let selected_qk = selected_qk
@@ -363,9 +363,9 @@ impl TextDecoder {
             x = x.try_add(&cross_out).context(TensorSnafu)?;
 
             let h = block.mlp_ln.apply(&x)?;
-            let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
+            let h = linear_with_bias(&h, &block.mlp0_w, &block.mlp0_b)?;
             let h = h.gelu_exact().context(TensorSnafu)?;
-            let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
+            let h = linear_with_bias(&h, &block.mlp1_w, &block.mlp1_b)?;
             x = x.try_add(&h).context(TensorSnafu)?;
         }
 
@@ -518,9 +518,9 @@ impl TextDecoder {
 
             // ── MLP ───────────────────────────────────────────────────────
             let h = block.mlp_ln.apply(&x)?;
-            let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
+            let h = linear_with_bias(&h, &block.mlp0_w, &block.mlp0_b)?;
             let h = h.gelu_exact().context(TensorSnafu)?;
-            let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
+            let h = linear_with_bias(&h, &block.mlp1_w, &block.mlp1_b)?;
             x = x.try_add(&h).context(TensorSnafu)?;
 
             // Collect new K/V for cache update: [B, H, 1, Dh]

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -139,61 +139,22 @@ impl TextDecoder {
         Tensor::cat(&permuted.iter().collect::<Vec<_>>(), 2).context(TensorSnafu)
     }
 
-    fn validate_kv_dtypes(keys: &[Tensor], values: &[Tensor], cache: &str) -> Result<()> {
-        let dtype = keys.first().map(|tensor| tensor.uop().dtype());
-        if keys.len() != values.len()
-            || dtype.is_none()
-            || keys.iter().chain(values).any(|tensor| Some(tensor.uop().dtype()) != dtype)
-        {
-            return Err(super::error::Error::Decode { msg: format!("{cache} K/V producer dtypes are inconsistent") });
-        }
-        Ok(())
-    }
-
-    /// Packed cross-cache activation/output dtype. Dense projections currently
-    /// produce their weight dtype; quantized projections must expose a separate
-    /// output contract rather than treating low-bit weight storage as cache dtype.
-    pub fn cross_cache_output_dtype(&self) -> Result<DType> {
-        let first = self.blocks.first().ok_or_else(|| super::error::Error::Decode {
-            msg: "decoder has no cross-attention projections".to_string(),
-        })?;
-        let dtype = first.cross_attn.key.weight.uop().dtype();
-        for block in &self.blocks {
-            let key = &block.cross_attn.key;
-            let value = &block.cross_attn.value;
-            let consistent = key.weight.uop().dtype() == dtype
-                && value.weight.uop().dtype() == dtype
-                && key.bias.as_ref().is_none_or(|bias| bias.uop().dtype() == dtype)
-                && value.bias.as_ref().is_none_or(|bias| bias.uop().dtype() == dtype);
-            if !consistent {
-                return Err(super::error::Error::Decode {
-                    msg: "cross-attention K/V projection output dtypes are inconsistent".to_string(),
-                });
-            }
-        }
-        Ok(dtype.clone())
-    }
-
     /// Project encoder features into the fixed packed cross-attention cache.
     /// This graph is independent of decoder tokens and runs once per window.
     pub fn project_cross_kv(&self, xa: &Tensor) -> Result<(Tensor, Tensor)> {
-        let output_dtype = self.cross_cache_output_dtype()?;
-        let xa = xa.cast(output_dtype.clone()).context(TensorSnafu)?;
         let mut cross_ks = Vec::with_capacity(self.blocks.len());
         let mut cross_vs = Vec::with_capacity(self.blocks.len());
         for block in &self.blocks {
             // Keep each GEMM independent from the final layer/head packing.
-            let k = block.cross_attn.key.forward(&xa)?.contiguous();
-            let v = block.cross_attn.value.forward(&xa)?.contiguous();
-            if k.uop().dtype() != output_dtype || v.uop().dtype() != output_dtype {
-                return Err(super::error::Error::Decode {
-                    msg: "cross-attention K/V producers violated their output dtype contract".to_string(),
-                });
-            }
+            let k = block.cross_attn.key.forward(xa)?.contiguous();
+            let v = block.cross_attn.value.forward(xa)?.contiguous();
             cross_ks.push(block.cross_attn.split_heads(&k)?);
             cross_vs.push(block.cross_attn.split_heads(&v)?);
         }
-        Ok((Self::pack_kv(cross_ks)?, Self::pack_kv(cross_vs)?))
+        Ok((
+            Self::pack_kv(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+        ))
     }
 
     /// Forward pass producing logits for all positions.
@@ -417,8 +378,13 @@ impl TextDecoder {
             .cast(DType::Float32)
             .context(TensorSnafu)?;
 
-        Self::validate_kv_dtypes(&self_ks, &self_vs, "self-cache")?;
-        Ok((logits, Self::pack_kv(self_ks)?, Self::pack_kv(self_vs)?))
+        // K/V cache outputs cast to fp32 — the cache buffers are fp32 (host
+        // round-trips them as Vec<f32>), while compute is dims.dtype (fp16).
+        Ok((
+            logits,
+            Self::pack_kv(self_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(self_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+        ))
     }
 
     /// Decoder logits using an already prepared cross-attention cache.
@@ -442,7 +408,7 @@ impl TextDecoder {
     /// - `self_v_cache`: [B, max_len, n_layer*H, Dh] self-attn V cache
     /// - `cross_k`: [B, n_audio_ctx, n_layer*H, Dh] cross-attn K (fixed)
     /// - `cross_v`: [B, n_audio_ctx, n_layer*H, Dh] cross-attn V (fixed)
-    /// - `self_mask`: [B(or 1), 1, 1, max_len+1] bool mask; true masks a position
+    /// - `self_mask`: [B(or 1), 1, 1, max_len+1] additive float mask for self-attn
     ///
     /// Returns `(logits[B, n_vocab], new_self_k[B, 1, n_layer*H, Dh], new_self_v[...])`.
     #[allow(clippy::too_many_arguments)]
@@ -510,7 +476,7 @@ impl TextDecoder {
             let full_k = Tensor::cat(&[&cached_k, &new_k_h], 2).context(TensorSnafu)?;
             let full_v = Tensor::cat(&[&cached_v, &new_v_h], 2).context(TensorSnafu)?;
 
-            // Attention with a boolean mask, avoiding promotion of low-precision scores.
+            // Attention with additive mask
             let out = q_h
                 .scaled_dot_product_attention()
                 .key(&full_k)
@@ -570,8 +536,6 @@ impl TextDecoder {
         let permuted_vs: Vec<Tensor> =
             new_vs.iter().map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)).collect::<Result<Vec<_>>>()?;
 
-        Self::validate_kv_dtypes(&permuted_ks, &permuted_vs, "step self-cache")?;
-
         let stacked_k = Tensor::cat(&permuted_ks.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
         let stacked_v = Tensor::cat(&permuted_vs.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
 
@@ -611,7 +575,12 @@ impl TextDecoder {
         let logits =
             logits.try_reshape(&[svod_ir::SInt::Const(batch), svod_ir::SInt::Const(n_vocab)]).context(TensorSnafu)?;
 
-        Ok((logits, new_k_flat, new_v_flat))
+        // K/V outputs cast to fp32 — appended into the fp32 cache buffer via SDMA.
+        Ok((
+            logits,
+            new_k_flat.cast(DType::Float32).context(TensorSnafu)?,
+            new_v_flat.cast(DType::Float32).context(TensorSnafu)?,
+        ))
     }
 }
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -30,17 +30,21 @@ pub struct DecoderBlock {
 
 impl DecoderBlock {
     pub fn empty(n_state: usize, n_head: usize) -> Self {
+        Self::empty_dtype(n_state, n_head, DType::Float32)
+    }
+
+    pub fn empty_dtype(n_state: usize, n_head: usize, dtype: DType) -> Self {
         let mlp = n_state * 4;
         Self {
-            attn: MultiHeadAttention::empty(n_state, n_head),
-            attn_ln: LayerNormWeights::empty(n_state),
-            cross_attn: MultiHeadAttention::empty(n_state, n_head),
-            cross_attn_ln: LayerNormWeights::empty(n_state),
-            mlp0_w: fan_in_uniform(&[mlp, n_state], n_state, DType::Float32),
-            mlp0_b: fan_in_uniform(&[mlp], n_state, DType::Float32),
-            mlp1_w: fan_in_uniform(&[n_state, mlp], mlp, DType::Float32),
-            mlp1_b: fan_in_uniform(&[n_state], mlp, DType::Float32),
-            mlp_ln: LayerNormWeights::empty(n_state),
+            attn: MultiHeadAttention::empty_dtype(n_state, n_head, dtype.clone()),
+            attn_ln: LayerNormWeights::empty_dtype(n_state, dtype.clone()),
+            cross_attn: MultiHeadAttention::empty_dtype(n_state, n_head, dtype.clone()),
+            cross_attn_ln: LayerNormWeights::empty_dtype(n_state, dtype.clone()),
+            mlp0_w: fan_in_uniform(&[mlp, n_state], n_state, dtype.clone()),
+            mlp0_b: fan_in_uniform(&[mlp], n_state, dtype.clone()),
+            mlp1_w: fan_in_uniform(&[n_state, mlp], mlp, dtype.clone()),
+            mlp1_b: fan_in_uniform(&[n_state], mlp, dtype.clone()),
+            mlp_ln: LayerNormWeights::empty_dtype(n_state, dtype),
             n_state,
         }
     }
@@ -138,12 +142,15 @@ pub struct TextDecoder {
 impl TextDecoder {
     pub fn empty(dims: &ModelDimensions) -> Self {
         let n_state = dims.n_text_state;
+        let dtype = dims.dtype.clone();
         Self {
-            token_embedding: fan_in_uniform(&[dims.n_vocab, n_state], n_state, DType::Float32),
-            positional_embedding: Tensor::zeros(&[dims.n_text_ctx, n_state], DType::Float32)
+            token_embedding: fan_in_uniform(&[dims.n_vocab, n_state], n_state, dtype.clone()),
+            positional_embedding: Tensor::zeros(&[dims.n_text_ctx, n_state], dtype.clone())
                 .expect("positional embedding"),
-            blocks: (0..dims.n_text_layer).map(|_| DecoderBlock::empty(n_state, dims.n_text_head)).collect(),
-            ln: LayerNormWeights::empty(n_state),
+            blocks: (0..dims.n_text_layer)
+                .map(|_| DecoderBlock::empty_dtype(n_state, dims.n_text_head, dtype.clone()))
+                .collect(),
+            ln: LayerNormWeights::empty_dtype(n_state, dtype),
             n_state,
             n_head: dims.n_text_head,
             n_text_ctx: dims.n_text_ctx,
@@ -299,7 +306,15 @@ impl TextDecoder {
             .cast(DType::Float32)
             .context(TensorSnafu)?;
 
-        Ok((logits, pack(self_ks)?, pack(self_vs)?, pack(cross_ks)?, pack(cross_vs)?))
+        // K/V cache outputs cast to fp32 — the cache buffers are fp32 (host
+        // round-trips them as Vec<f32>), while compute is dims.dtype (fp16).
+        Ok((
+            logits,
+            pack(self_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            pack(self_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+            pack(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            pack(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+        ))
     }
 
     /// Single-token forward with KV cache. Used for incremental decoding.
@@ -478,7 +493,12 @@ impl TextDecoder {
         let logits =
             logits.try_reshape(&[svod_ir::SInt::Const(batch), svod_ir::SInt::Const(n_vocab)]).context(TensorSnafu)?;
 
-        Ok((logits, new_k_flat, new_v_flat))
+        // K/V outputs cast to fp32 — appended into the fp32 cache buffer via SDMA.
+        Ok((
+            logits,
+            new_k_flat.cast(DType::Float32).context(TensorSnafu)?,
+            new_v_flat.cast(DType::Float32).context(TensorSnafu)?,
+        ))
     }
 
     /// Symbolic-batch variant of [`forward_step`](Self::forward_step).
@@ -647,7 +667,12 @@ impl TextDecoder {
         })?;
         let logits = logits.try_reshape(&[bv, SInt::Const(n_vocab)]).context(TensorSnafu)?;
 
-        Ok((logits, new_k_flat, new_v_flat))
+        // K/V outputs cast to fp32 — appended into the fp32 cache buffer via SDMA.
+        Ok((
+            logits,
+            new_k_flat.cast(DType::Float32).context(TensorSnafu)?,
+            new_v_flat.cast(DType::Float32).context(TensorSnafu)?,
+        ))
     }
 }
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -111,6 +111,7 @@ pub struct TextDecoder {
     pub n_state: usize,
     pub n_head: usize,
     pub n_text_ctx: usize,
+    activation_dtype: DType,
 }
 
 impl TextDecoder {
@@ -128,6 +129,7 @@ impl TextDecoder {
             n_state,
             n_head: dims.n_text_head,
             n_text_ctx: dims.n_text_ctx,
+            activation_dtype: dims.dtype.clone(),
         }
     }
 
@@ -142,12 +144,13 @@ impl TextDecoder {
     /// Project encoder features into the fixed packed cross-attention cache.
     /// This graph is independent of decoder tokens and runs once per window.
     pub fn project_cross_kv(&self, xa: &Tensor) -> Result<(Tensor, Tensor)> {
+        let xa = xa.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
         let mut cross_ks = Vec::with_capacity(self.blocks.len());
         let mut cross_vs = Vec::with_capacity(self.blocks.len());
         for block in &self.blocks {
             // Keep each GEMM independent from the final layer/head packing.
-            let k = block.cross_attn.key.forward(xa)?.contiguous();
-            let v = block.cross_attn.value.forward(xa)?.contiguous();
+            let k = block.cross_attn.key.forward(&xa)?.contiguous();
+            let v = block.cross_attn.value.forward(&xa)?.contiguous();
             cross_ks.push(block.cross_attn.split_heads(&k)?);
             cross_vs.push(block.cross_attn.split_heads(&v)?);
         }
@@ -217,7 +220,9 @@ impl TextDecoder {
             self.positional_embedding.try_shrink([Some((0isize, seq_len as isize)), None]).context(TensorSnafu)?;
 
         let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
-        let x = x.cast(cross_k.uop().dtype()).context(TensorSnafu)?;
+        let x = x.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
+        let cross_k = cross_k.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
+        let cross_v = cross_v.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
 
         let mask = causal_mask(seq_len, x.uop().dtype().clone())?;
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -2,8 +2,8 @@
 
 use snafu::ResultExt;
 use svod_dtype::DType;
-use svod_ir::SInt;
-use svod_tensor::{BoundVariable, Tensor};
+use svod_ir::ConstValue;
+use svod_tensor::Tensor;
 
 use crate::init::fan_in_uniform;
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
@@ -157,6 +157,31 @@ impl TextDecoder {
         }
     }
 
+    fn pack_kv(kvs: Vec<Tensor>) -> Result<Tensor> {
+        let permuted: Vec<Tensor> = kvs
+            .into_iter()
+            .map(|tensor| tensor.try_permute(&[0, 2, 1, 3]).context(TensorSnafu))
+            .collect::<Result<Vec<_>>>()?;
+        Tensor::cat(&permuted.iter().collect::<Vec<_>>(), 2).context(TensorSnafu)
+    }
+
+    /// Project encoder features into the fixed packed cross-attention cache.
+    /// This graph is independent of decoder tokens and runs once per window.
+    pub fn project_cross_kv(&self, xa: &Tensor) -> Result<(Tensor, Tensor)> {
+        let mut cross_ks = Vec::with_capacity(self.blocks.len());
+        let mut cross_vs = Vec::with_capacity(self.blocks.len());
+        for block in &self.blocks {
+            let k = block.cross_attn.key.forward(xa)?;
+            let v = block.cross_attn.value.forward(xa)?;
+            cross_ks.push(block.cross_attn.split_heads(&k)?);
+            cross_vs.push(block.cross_attn.split_heads(&v)?);
+        }
+        Ok((
+            Self::pack_kv(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+        ))
+    }
+
     /// Forward pass producing logits for all positions.
     /// `tokens`: `[B, L]` int tensor. `xa`: `[B, T_enc, D]` encoder output.
     /// `offset`: positional embedding offset (for KV-cached incremental decoding).
@@ -195,9 +220,14 @@ impl TextDecoder {
         logits.cast(DType::Float32).context(TensorSnafu)
     }
 
-    /// Forward pass returning both logits and cross-attention QK weights per layer.
-    /// Used for DTW word-level alignment.
-    pub fn forward_with_alignment(&self, tokens: &Tensor, xa: &Tensor, offset: usize) -> Result<(Tensor, Vec<Tensor>)> {
+    /// Teacher-forced decoder pass returning raw scaled cross-attention QK
+    /// scores for the statically selected alignment heads.
+    pub fn forward_alignment(
+        &self,
+        tokens: &Tensor,
+        xa: &Tensor,
+        alignment_heads: &[(usize, usize)],
+    ) -> Result<Tensor> {
         let seq_len =
             tokens.shape().context(TensorSnafu)?[1].as_const().ok_or_else(|| super::error::Error::Tensor {
                 source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
@@ -207,10 +237,8 @@ impl TextDecoder {
 
         let tok_emb = self.token_embedding.embedding(tokens).context(TensorSnafu)?;
 
-        let pos_emb = self
-            .positional_embedding
-            .try_shrink([Some((offset as isize, (offset + seq_len) as isize)), None])
-            .context(TensorSnafu)?;
+        let pos_emb =
+            self.positional_embedding.try_shrink([Some((0isize, seq_len as isize)), None]).context(TensorSnafu)?;
 
         let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
         let x = x.cast(xa.uop().dtype()).context(TensorSnafu)?;
@@ -218,28 +246,66 @@ impl TextDecoder {
         let mask = causal_mask(seq_len, x.uop().dtype().clone())?;
 
         let mut x = x;
-        let mut all_qk = Vec::with_capacity(self.blocks.len());
-        for block in &self.blocks {
-            let (out, qk) = block.forward_with_qk(&x, xa, &mask)?;
-            x = out;
-            all_qk.push(qk);
-        }
+        let mut selected_qk = Vec::with_capacity(alignment_heads.len());
+        for (layer, block) in self.blocks.iter().enumerate() {
+            let h = block.attn_ln.apply(&x)?;
+            let attn_out = block.attn.forward(&h, None, Some(&mask))?;
+            x = x.try_add(&attn_out).context(TensorSnafu)?;
 
-        let x = self.ln.apply(&x)?;
-        let logits = x.linear().weight(&self.token_embedding).call().context(TensorSnafu)?;
-        Ok((logits.cast(DType::Float32).context(TensorSnafu)?, all_qk))
+            let h = block.cross_attn_ln.apply(&x)?;
+            let cross_out = block.cross_attn.forward(&h, Some(xa), None)?;
+            x = x.try_add(&cross_out).context(TensorSnafu)?;
+
+            let layer_heads: Vec<usize> = alignment_heads
+                .iter()
+                .filter_map(|&(selected_layer, head)| (selected_layer == layer).then_some(head))
+                .collect();
+            if !layer_heads.is_empty() {
+                // Keep the normal fused attention path above. Q/K are tapped a
+                // second time only in selected layers, and only selected head
+                // score matrices become graph outputs.
+                let q_heads = block.cross_attn.split_heads(&block.cross_attn.query.forward(&h)?)?;
+                let k_heads = block.cross_attn.split_heads(&block.cross_attn.key.forward(xa)?)?;
+                for head in layer_heads {
+                    let selected_q = q_heads
+                        .try_shrink([None, Some((head as isize, head as isize + 1)), None, None])
+                        .context(TensorSnafu)?;
+                    let selected_k = k_heads
+                        .try_shrink([None, Some((head as isize, head as isize + 1)), None, None])
+                        .context(TensorSnafu)?;
+                    let kt = selected_k.try_transpose(-1, -2).context(TensorSnafu)?;
+                    let scores = selected_q.matmul(&kt).context(TensorSnafu)?;
+                    let scale = Tensor::const_(
+                        ConstValue::Float(1.0 / ((self.n_state / self.n_head) as f64).sqrt()),
+                        scores.uop().dtype().clone(),
+                    );
+                    selected_qk.push(scores.try_mul(&scale).context(TensorSnafu)?);
+                }
+            }
+
+            let h = block.mlp_ln.apply(&x)?;
+            let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
+            let h = h.gelu_exact().context(TensorSnafu)?;
+            let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
+            x = x.try_add(&h).context(TensorSnafu)?;
+        }
+        Tensor::cat(&selected_qk.iter().collect::<Vec<_>>(), 1)
+            .context(TensorSnafu)?
+            .cast(DType::Float32)
+            .context(TensorSnafu)
     }
 
-    /// Prefill returning flat-packed K/V caches + logits for JIT.
-    /// Returns (logits[1,init_len,n_vocab], self_k, self_v, cross_k, cross_v)
-    /// where each packed K/V is [1, seq_len, n_layer*H, Dh].
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    /// Prefill consuming fixed packed cross-attention caches.
+    /// Returns `(logits[1, init_len, n_vocab], self_k, self_v)`, where each packed
+    /// self K/V is [1, seq_len, n_layer*H, Dh].
+    #[allow(clippy::too_many_arguments)]
     pub fn forward_prefill(
         &self,
         tokens: &Tensor,
-        xa: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
         offset: usize,
-    ) -> Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+    ) -> Result<(Tensor, Tensor, Tensor)> {
         let seq_len =
             tokens.shape().context(TensorSnafu)?[1].as_const().ok_or_else(|| super::error::Error::Tensor {
                 source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
@@ -254,17 +320,15 @@ impl TextDecoder {
             .context(TensorSnafu)?;
 
         let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
-        let x = x.cast(xa.uop().dtype()).context(TensorSnafu)?;
+        let x = x.cast(cross_k.uop().dtype()).context(TensorSnafu)?;
 
         let mask = causal_mask(seq_len, x.uop().dtype().clone())?;
 
         let mut x = x;
         let mut self_ks: Vec<Tensor> = Vec::with_capacity(self.blocks.len());
         let mut self_vs: Vec<Tensor> = Vec::with_capacity(self.blocks.len());
-        let mut cross_ks: Vec<Tensor> = Vec::with_capacity(self.blocks.len());
-        let mut cross_vs: Vec<Tensor> = Vec::with_capacity(self.blocks.len());
 
-        for block in &self.blocks {
+        for (layer, block) in self.blocks.iter().enumerate() {
             let h = block.attn_ln.apply(&x)?;
             let (attn_out, sk, sv) = block.attn.forward_return_kv(&h, None, Some(&mask))?;
             x = x.try_add(&attn_out).context(TensorSnafu)?;
@@ -273,11 +337,29 @@ impl TextDecoder {
             self_vs.push(block.attn.split_heads(&sv)?);
 
             let h = block.cross_attn_ln.apply(&x)?;
-            let (cross_out, ck, cv) = block.cross_attn.forward_return_kv(&h, Some(xa), None)?;
+            let query = block.cross_attn.split_heads(&block.cross_attn.query.forward(&h)?)?;
+            let head_start = layer * self.n_head;
+            let head_end = head_start + self.n_head;
+            let layer_ck = cross_k
+                .try_shrink([None, None, Some((head_start as isize, head_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+            let layer_cv = cross_v
+                .try_shrink([None, None, Some((head_start as isize, head_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+            let cross_out = query
+                .scaled_dot_product_attention()
+                .key(&layer_ck)
+                .value(&layer_cv)
+                .is_causal(false)
+                .call()
+                .context(TensorSnafu)?;
+            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
+            let cross_out = block.cross_attn.out.forward(&cross_out)?;
             x = x.try_add(&cross_out).context(TensorSnafu)?;
-
-            cross_ks.push(block.cross_attn.split_heads(&ck)?);
-            cross_vs.push(block.cross_attn.split_heads(&cv)?);
 
             let h = block.mlp_ln.apply(&x)?;
             let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
@@ -285,17 +367,6 @@ impl TextDecoder {
             let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
             x = x.try_add(&h).context(TensorSnafu)?;
         }
-
-        // Pack per-layer K/V: each is [1, H, seq_len, Dh] → permute [1, seq_len, H, Dh]
-        // → cat dim 2 → [1, seq_len, n_layer*H, Dh]
-        let pack = |kvs: Vec<Tensor>| -> Result<Tensor> {
-            let permuted: Vec<Tensor> = kvs
-                .into_iter()
-                .map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu))
-                .collect::<Result<Vec<_>>>()?;
-            let refs: Vec<&Tensor> = permuted.iter().collect();
-            Tensor::cat(&refs, 2).context(TensorSnafu)
-        };
 
         let x = self.ln.apply(&x)?;
         let logits = x
@@ -310,11 +381,21 @@ impl TextDecoder {
         // round-trips them as Vec<f32>), while compute is dims.dtype (fp16).
         Ok((
             logits,
-            pack(self_ks)?.cast(DType::Float32).context(TensorSnafu)?,
-            pack(self_vs)?.cast(DType::Float32).context(TensorSnafu)?,
-            pack(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
-            pack(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(self_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(self_vs)?.cast(DType::Float32).context(TensorSnafu)?,
         ))
+    }
+
+    /// Decoder logits using an already prepared cross-attention cache.
+    pub fn forward_with_cross_kv(
+        &self,
+        tokens: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
+        offset: usize,
+    ) -> Result<Tensor> {
+        let (logits, _, _) = self.forward_prefill(tokens, cross_k, cross_v, offset)?;
+        Ok(logits)
     }
 
     /// Single-token forward with KV cache. Used for incremental decoding.
@@ -492,180 +573,6 @@ impl TextDecoder {
         })?;
         let logits =
             logits.try_reshape(&[svod_ir::SInt::Const(batch), svod_ir::SInt::Const(n_vocab)]).context(TensorSnafu)?;
-
-        // K/V outputs cast to fp32 — appended into the fp32 cache buffer via SDMA.
-        Ok((
-            logits,
-            new_k_flat.cast(DType::Float32).context(TensorSnafu)?,
-            new_v_flat.cast(DType::Float32).context(TensorSnafu)?,
-        ))
-    }
-
-    /// Symbolic-batch variant of [`forward_step`](Self::forward_step).
-    ///
-    /// Identical computation, but the batch dimension is a JIT `Variable`
-    /// (`b`) rather than a constant inferred from `token`. Every batched
-    /// input is shrunk to `b` on dim 0 so a plan compiled at `max_batch`
-    /// serves any `b ∈ [1, max_batch]` via `execute_with_vars`.
-    ///
-    /// This is the entry point for continuous batching: the step JIT
-    /// compiles once and is rebound to the live lane count each dispatch.
-    /// The non-batched `forward_step` is unchanged for the existing
-    /// per-beam-size plans.
-    #[allow(clippy::too_many_arguments)]
-    pub fn forward_step_batched(
-        &self,
-        token: &Tensor,
-        pos_emb: &Tensor,
-        self_k_cache: &Tensor,
-        self_v_cache: &Tensor,
-        cross_k: &Tensor,
-        cross_v: &Tensor,
-        self_mask: &Tensor,
-        b: &BoundVariable,
-    ) -> Result<(Tensor, Tensor, Tensor)> {
-        let n_head = self.n_head;
-        let n_layer = self.blocks.len();
-        let d_head = self.n_state / n_head;
-        let bv = b.as_sint();
-
-        // Shrink every batched input to `b` on dim 0. The JIT buffers are
-        // sized for `max_batch`; this makes the live rows a symbolic slice
-        // that flows through the whole graph as a `DefineVar`.
-        let token = token.try_shrink([Some((SInt::Const(0), bv.clone())), None]).context(TensorSnafu)?;
-        let pos_emb = pos_emb.try_shrink([Some((SInt::Const(0), bv.clone())), None, None]).context(TensorSnafu)?;
-        let self_k_cache =
-            self_k_cache.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
-        let self_v_cache =
-            self_v_cache.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
-        let cross_k =
-            cross_k.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
-        let cross_v =
-            cross_v.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
-        let self_mask =
-            self_mask.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
-
-        // Embed single token + positional embedding
-        let tok_emb = self.token_embedding.embedding(&token).context(TensorSnafu)?;
-        let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
-        let x = x.cast(self_k_cache.uop().dtype()).context(TensorSnafu)?;
-
-        let mut x = x;
-        let mut new_ks: Vec<Tensor> = Vec::with_capacity(n_layer);
-        let mut new_vs: Vec<Tensor> = Vec::with_capacity(n_layer);
-
-        for (l, block) in self.blocks.iter().enumerate() {
-            let lh_start = l * n_head;
-            let lh_end = (l + 1) * n_head;
-
-            // ── Self-attn with cache ─────────────────────────────────────
-            let h = block.attn_ln.apply(&x)?;
-            let q = block.attn.query.forward(&h)?;
-            let new_k_raw = block.attn.key.forward(&h)?;
-            let new_v_raw = block.attn.value.forward(&h)?;
-
-            let q_h = block.attn.split_heads(&q)?;
-            let new_k_h = block.attn.split_heads(&new_k_raw)?;
-            let new_v_h = block.attn.split_heads(&new_v_raw)?;
-
-            let cached_k = self_k_cache
-                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
-                .context(TensorSnafu)?;
-            let cached_v = self_v_cache
-                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
-                .context(TensorSnafu)?;
-
-            let full_k = Tensor::cat(&[&cached_k, &new_k_h], 2).context(TensorSnafu)?;
-            let full_v = Tensor::cat(&[&cached_v, &new_v_h], 2).context(TensorSnafu)?;
-
-            let out = q_h
-                .scaled_dot_product_attention()
-                .key(&full_k)
-                .value(&full_v)
-                .attn_mask(&self_mask)
-                .is_causal(false)
-                .call()
-                .context(TensorSnafu)?;
-            let attn_out = block.attn.merge_heads(&out)?;
-            let attn_out = block.attn.out.forward(&attn_out)?;
-            x = x.try_add(&attn_out).context(TensorSnafu)?;
-
-            // ── Cross-attn (fixed cache, no mask) ────────────────────────
-            let h = block.cross_attn_ln.apply(&x)?;
-            let cq = block.cross_attn.query.forward(&h)?;
-            let cq_h = block.cross_attn.split_heads(&cq)?;
-
-            let layer_ck = cross_k
-                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
-                .context(TensorSnafu)?;
-            let layer_cv = cross_v
-                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?
-                .try_permute(&[0, 2, 1, 3])
-                .context(TensorSnafu)?;
-
-            let cross_out = cq_h
-                .scaled_dot_product_attention()
-                .key(&layer_ck)
-                .value(&layer_cv)
-                .is_causal(false)
-                .call()
-                .context(TensorSnafu)?;
-            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
-            let cross_out = block.cross_attn.out.forward(&cross_out)?;
-            x = x.try_add(&cross_out).context(TensorSnafu)?;
-
-            // ── MLP ───────────────────────────────────────────────────────
-            let h = block.mlp_ln.apply(&x)?;
-            let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
-            let h = h.gelu_exact().context(TensorSnafu)?;
-            let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
-            x = x.try_add(&h).context(TensorSnafu)?;
-
-            new_ks.push(new_k_h);
-            new_vs.push(new_v_h);
-        }
-
-        // Permute + cat new K/V. Batch is symbolic here (`bv`), so the
-        // reshape uses `bv` instead of `SInt::Const(batch)` — this is the
-        // key difference from `forward_step`.
-        let permuted_ks: Vec<Tensor> =
-            new_ks.iter().map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)).collect::<Result<Vec<_>>>()?;
-        let permuted_vs: Vec<Tensor> =
-            new_vs.iter().map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)).collect::<Result<Vec<_>>>()?;
-
-        let stacked_k = Tensor::cat(&permuted_ks.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
-        let stacked_v = Tensor::cat(&permuted_vs.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
-
-        let new_k_flat = stacked_k
-            .try_reshape(&[bv.clone(), SInt::Const(1usize), SInt::Const(n_layer * n_head), SInt::Const(d_head)])
-            .context(TensorSnafu)?;
-        let new_v_flat = stacked_v
-            .try_reshape(&[bv.clone(), SInt::Const(1usize), SInt::Const(n_layer * n_head), SInt::Const(d_head)])
-            .context(TensorSnafu)?;
-        let x = self.ln.apply(&x)?;
-        let logits = x
-            .linear()
-            .weight(&self.token_embedding)
-            .call()
-            .context(TensorSnafu)?
-            .cast(DType::Float32)
-            .context(TensorSnafu)?;
-
-        let n_vocab = self.token_embedding.shape().context(TensorSnafu)?[0].as_const().ok_or_else(|| {
-            super::error::Error::Tensor {
-                source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
-                    operation: "forward_step_batched n_vocab".into(),
-                }),
-            }
-        })?;
-        let logits = logits.try_reshape(&[bv, SInt::Const(n_vocab)]).context(TensorSnafu)?;
 
         // K/V outputs cast to fp32 — appended into the fp32 cache buffer via SDMA.
         Ok((

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -2,7 +2,7 @@
 
 use snafu::ResultExt;
 use svod_dtype::DType;
-use svod_ir::ConstValue;
+use svod_ir::{ConstValue, SInt};
 use svod_tensor::Tensor;
 
 use crate::init::fan_in_uniform;
@@ -111,24 +111,66 @@ pub struct TextDecoder {
     pub n_state: usize,
     pub n_head: usize,
     pub n_text_ctx: usize,
+    packed_cross_k_weight: Tensor, // [n_layer * D, D]
+    packed_cross_v_weight: Tensor, // [n_layer * D, D]
+    packed_cross_v_bias: Tensor,   // [n_layer * D]
 }
 
 impl TextDecoder {
     pub fn empty(dims: &ModelDimensions) -> Self {
         let n_state = dims.n_text_state;
         let dtype = dims.dtype.clone();
+        let blocks: Vec<_> = (0..dims.n_text_layer)
+            .map(|_| DecoderBlock::empty_dtype(n_state, dims.n_text_head, dtype.clone()))
+            .collect();
+        let (packed_cross_k_weight, packed_cross_v_weight, packed_cross_v_bias) =
+            Self::pack_cross_weights(&blocks).expect("cross-attention weights");
         Self {
             token_embedding: fan_in_uniform(&[dims.n_vocab, n_state], n_state, dtype.clone()),
             positional_embedding: Tensor::zeros(&[dims.n_text_ctx, n_state], dtype.clone())
                 .expect("positional embedding"),
-            blocks: (0..dims.n_text_layer)
-                .map(|_| DecoderBlock::empty_dtype(n_state, dims.n_text_head, dtype.clone()))
-                .collect(),
+            blocks,
             ln: LayerNormWeights::empty_dtype(n_state, dtype),
             n_state,
             n_head: dims.n_text_head,
             n_text_ctx: dims.n_text_ctx,
+            packed_cross_k_weight,
+            packed_cross_v_weight,
+            packed_cross_v_bias,
         }
+    }
+
+    fn pack_cross_weights(
+        blocks: &[DecoderBlock],
+    ) -> std::result::Result<(Tensor, Tensor, Tensor), Box<svod_tensor::error::Error>> {
+        let key_weights: Vec<_> = blocks.iter().map(|block| &block.cross_attn.key.weight).collect();
+        let value_weights: Vec<_> = blocks.iter().map(|block| &block.cross_attn.value.weight).collect();
+        let value_biases: Vec<_> = blocks
+            .iter()
+            .map(|block| block.cross_attn.value.bias.as_ref().expect("Whisper value projection has bias"))
+            .collect();
+        Ok((
+            Tensor::cat(&key_weights, 0).map_err(Box::new)?,
+            Tensor::cat(&value_weights, 0).map_err(Box::new)?,
+            Tensor::cat(&value_biases, 0).map_err(Box::new)?,
+        ))
+    }
+
+    fn rebuild_packed_cross_weights(&mut self) -> std::result::Result<(), Box<svod_tensor::error::Error>> {
+        let (mut key, mut value, mut value_bias) = Self::pack_cross_weights(&self.blocks)?;
+        Tensor::realize_batch([&mut key, &mut value, &mut value_bias]).map_err(Box::new)?;
+
+        for (layer, block) in self.blocks.iter_mut().enumerate() {
+            let start = (layer * self.n_state) as isize;
+            let end = start + self.n_state as isize;
+            block.cross_attn.key.weight = key.try_shrink([Some((start, end)), None]).map_err(Box::new)?;
+            block.cross_attn.value.weight = value.try_shrink([Some((start, end)), None]).map_err(Box::new)?;
+            block.cross_attn.value.bias = Some(value_bias.try_shrink([Some((start, end))]).map_err(Box::new)?);
+        }
+        self.packed_cross_k_weight = key;
+        self.packed_cross_v_weight = value;
+        self.packed_cross_v_bias = value_bias;
+        Ok(())
     }
 
     fn pack_kv(kvs: Vec<Tensor>) -> Result<Tensor> {
@@ -142,17 +184,23 @@ impl TextDecoder {
     /// Project encoder features into the fixed packed cross-attention cache.
     /// This graph is independent of decoder tokens and runs once per window.
     pub fn project_cross_kv(&self, xa: &Tensor) -> Result<(Tensor, Tensor)> {
-        let mut cross_ks = Vec::with_capacity(self.blocks.len());
-        let mut cross_vs = Vec::with_capacity(self.blocks.len());
-        for block in &self.blocks {
-            let k = block.cross_attn.key.forward(xa)?;
-            let v = block.cross_attn.value.forward(xa)?;
-            cross_ks.push(block.cross_attn.split_heads(&k)?);
-            cross_vs.push(block.cross_attn.split_heads(&v)?);
-        }
+        let shape = xa.shape().context(TensorSnafu)?;
+        let cache_shape = [
+            shape[0].clone(),
+            shape[1].clone(),
+            SInt::Const(self.blocks.len() * self.n_head),
+            SInt::Const(self.n_state / self.n_head),
+        ];
+        let k = xa.linear().weight(&self.packed_cross_k_weight).call().context(TensorSnafu)?;
+        let v = xa
+            .linear()
+            .weight(&self.packed_cross_v_weight)
+            .bias(&self.packed_cross_v_bias)
+            .call()
+            .context(TensorSnafu)?;
         Ok((
-            Self::pack_kv(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
-            Self::pack_kv(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
+            k.try_reshape(&cache_shape).context(TensorSnafu)?.cast(DType::Float32).context(TensorSnafu)?,
+            v.try_reshape(&cache_shape).context(TensorSnafu)?.cast(DType::Float32).context(TensorSnafu)?,
         ))
     }
 
@@ -602,6 +650,7 @@ impl HasStateDict for TextDecoder {
             block.load_state_dict(sd, &prefixed(prefix, &format!("blocks.{i}")))?;
         }
         self.ln.load_state_dict(sd, &prefixed(prefix, "ln"))?;
+        self.rebuild_packed_cross_weights().map_err(|source| state::Error::Tensor { source })?;
         Ok(())
     }
 }

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -69,32 +69,6 @@ impl DecoderBlock {
         let x = x.try_add(&h).context(TensorSnafu)?;
         Ok(x)
     }
-
-    /// Forward returning cross-attention QK weights (for DTW alignment).
-    /// Returns `(output, cross_attn_weights)`.
-    pub fn forward_with_qk(&self, x: &Tensor, xa: &Tensor, mask: &Tensor) -> Result<(Tensor, Tensor)> {
-        // Self-attention (causal)
-        let h = self.attn_ln.apply(x)?;
-        let attn_out = self.attn.forward(&h, None, Some(mask))?;
-        let x = x.try_add(&attn_out).context(TensorSnafu)?;
-
-        // Cross-attention with weight extraction
-        let h = self.cross_attn_ln.apply(&x)?;
-        let (cross_out, qk_weights) = self.cross_attn.forward_with_qk(&h, Some(xa), None)?;
-        let x = x.try_add(&cross_out).context(TensorSnafu)?;
-
-        // MLP
-        let h = self.mlp_ln.apply(&x)?;
-        let h = h.linear().weight(&self.mlp0_w).bias(&self.mlp0_b).call().context(TensorSnafu)?;
-        let h = h.gelu_exact().context(TensorSnafu)?;
-        let h = h.linear().weight(&self.mlp1_w).bias(&self.mlp1_b).call().context(TensorSnafu)?;
-        let x = x.try_add(&h).context(TensorSnafu)?;
-
-        let qk = qk_weights.unwrap_or_else(|| {
-            panic!("forward_with_qk requires cross-attention but got None");
-        });
-        Ok((x, qk))
-    }
 }
 
 impl HasStateDict for DecoderBlock {
@@ -220,12 +194,13 @@ impl TextDecoder {
         logits.cast(DType::Float32).context(TensorSnafu)
     }
 
-    /// Teacher-forced decoder pass returning raw scaled cross-attention QK
-    /// scores for the statically selected alignment heads.
+    /// Teacher-forced decoder pass over packed cross K/V, returning raw scaled
+    /// QK scores for the statically selected alignment heads.
     pub fn forward_alignment(
         &self,
         tokens: &Tensor,
-        xa: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
         alignment_heads: &[(usize, usize)],
     ) -> Result<Tensor> {
         let seq_len =
@@ -241,46 +216,61 @@ impl TextDecoder {
             self.positional_embedding.try_shrink([Some((0isize, seq_len as isize)), None]).context(TensorSnafu)?;
 
         let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
-        let x = x.cast(xa.uop().dtype()).context(TensorSnafu)?;
+        let x = x.cast(cross_k.uop().dtype()).context(TensorSnafu)?;
 
         let mask = causal_mask(seq_len, x.uop().dtype().clone())?;
 
         let mut x = x;
-        let mut selected_qk = Vec::with_capacity(alignment_heads.len());
+        let mut selected_qk: Vec<Option<Tensor>> = (0..alignment_heads.len()).map(|_| None).collect();
         for (layer, block) in self.blocks.iter().enumerate() {
             let h = block.attn_ln.apply(&x)?;
             let attn_out = block.attn.forward(&h, None, Some(&mask))?;
             x = x.try_add(&attn_out).context(TensorSnafu)?;
 
             let h = block.cross_attn_ln.apply(&x)?;
-            let cross_out = block.cross_attn.forward(&h, Some(xa), None)?;
+            let query = block.cross_attn.split_heads(&block.cross_attn.query.forward(&h)?)?;
+            let head_start = layer * self.n_head;
+            let head_end = head_start + self.n_head;
+            let layer_ck = cross_k
+                .try_shrink([None, None, Some((head_start as isize, head_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+            let layer_cv = cross_v
+                .try_shrink([None, None, Some((head_start as isize, head_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+            let cross_out = query
+                .scaled_dot_product_attention()
+                .key(&layer_ck)
+                .value(&layer_cv)
+                .is_causal(false)
+                .call()
+                .context(TensorSnafu)?;
+            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
+            let cross_out = block.cross_attn.out.forward(&cross_out)?;
             x = x.try_add(&cross_out).context(TensorSnafu)?;
 
-            let layer_heads: Vec<usize> = alignment_heads
+            let layer_heads: Vec<(usize, usize)> = alignment_heads
                 .iter()
-                .filter_map(|&(selected_layer, head)| (selected_layer == layer).then_some(head))
+                .enumerate()
+                .filter_map(|(selected, &(selected_layer, head))| (selected_layer == layer).then_some((selected, head)))
                 .collect();
-            if !layer_heads.is_empty() {
-                // Keep the normal fused attention path above. Q/K are tapped a
-                // second time only in selected layers, and only selected head
-                // score matrices become graph outputs.
-                let q_heads = block.cross_attn.split_heads(&block.cross_attn.query.forward(&h)?)?;
-                let k_heads = block.cross_attn.split_heads(&block.cross_attn.key.forward(xa)?)?;
-                for head in layer_heads {
-                    let selected_q = q_heads
-                        .try_shrink([None, Some((head as isize, head as isize + 1)), None, None])
-                        .context(TensorSnafu)?;
-                    let selected_k = k_heads
-                        .try_shrink([None, Some((head as isize, head as isize + 1)), None, None])
-                        .context(TensorSnafu)?;
-                    let kt = selected_k.try_transpose(-1, -2).context(TensorSnafu)?;
-                    let scores = selected_q.matmul(&kt).context(TensorSnafu)?;
-                    let scale = Tensor::const_(
-                        ConstValue::Float(1.0 / ((self.n_state / self.n_head) as f64).sqrt()),
-                        scores.uop().dtype().clone(),
-                    );
-                    selected_qk.push(scores.try_mul(&scale).context(TensorSnafu)?);
-                }
+            for (selected, head) in layer_heads {
+                let selected_q = query
+                    .try_shrink([None, Some((head as isize, head as isize + 1)), None, None])
+                    .context(TensorSnafu)?;
+                let selected_k = layer_ck
+                    .try_shrink([None, Some((head as isize, head as isize + 1)), None, None])
+                    .context(TensorSnafu)?;
+                let kt = selected_k.try_transpose(-1, -2).context(TensorSnafu)?;
+                let scores = selected_q.matmul(&kt).context(TensorSnafu)?;
+                let scale = Tensor::const_(
+                    ConstValue::Float(1.0 / ((self.n_state / self.n_head) as f64).sqrt()),
+                    scores.uop().dtype().clone(),
+                );
+                selected_qk[selected] = Some(scores.try_mul(&scale).context(TensorSnafu)?);
             }
 
             let h = block.mlp_ln.apply(&x)?;
@@ -289,6 +279,16 @@ impl TextDecoder {
             let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
             x = x.try_add(&h).context(TensorSnafu)?;
         }
+        let selected_qk = selected_qk
+            .into_iter()
+            .map(|qk| {
+                qk.ok_or_else(|| super::error::Error::Tensor {
+                    source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
+                        operation: "alignment head layer out of range".into(),
+                    }),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
         Tensor::cat(&selected_qk.iter().collect::<Vec<_>>(), 1)
             .context(TensorSnafu)?
             .cast(DType::Float32)

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -2,7 +2,8 @@
 
 use snafu::ResultExt;
 use svod_dtype::DType;
-use svod_tensor::Tensor;
+use svod_ir::SInt;
+use svod_tensor::{BoundVariable, Tensor};
 
 use crate::init::fan_in_uniform;
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
@@ -476,6 +477,175 @@ impl TextDecoder {
         })?;
         let logits =
             logits.try_reshape(&[svod_ir::SInt::Const(batch), svod_ir::SInt::Const(n_vocab)]).context(TensorSnafu)?;
+
+        Ok((logits, new_k_flat, new_v_flat))
+    }
+
+    /// Symbolic-batch variant of [`forward_step`](Self::forward_step).
+    ///
+    /// Identical computation, but the batch dimension is a JIT `Variable`
+    /// (`b`) rather than a constant inferred from `token`. Every batched
+    /// input is shrunk to `b` on dim 0 so a plan compiled at `max_batch`
+    /// serves any `b ∈ [1, max_batch]` via `execute_with_vars`.
+    ///
+    /// This is the entry point for continuous batching: the step JIT
+    /// compiles once and is rebound to the live lane count each dispatch.
+    /// The non-batched `forward_step` is unchanged for the existing
+    /// per-beam-size plans.
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_step_batched(
+        &self,
+        token: &Tensor,
+        pos_emb: &Tensor,
+        self_k_cache: &Tensor,
+        self_v_cache: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
+        self_mask: &Tensor,
+        b: &BoundVariable,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        let n_head = self.n_head;
+        let n_layer = self.blocks.len();
+        let d_head = self.n_state / n_head;
+        let bv = b.as_sint();
+
+        // Shrink every batched input to `b` on dim 0. The JIT buffers are
+        // sized for `max_batch`; this makes the live rows a symbolic slice
+        // that flows through the whole graph as a `DefineVar`.
+        let token = token.try_shrink([Some((SInt::Const(0), bv.clone())), None]).context(TensorSnafu)?;
+        let pos_emb = pos_emb.try_shrink([Some((SInt::Const(0), bv.clone())), None, None]).context(TensorSnafu)?;
+        let self_k_cache =
+            self_k_cache.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
+        let self_v_cache =
+            self_v_cache.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
+        let cross_k =
+            cross_k.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
+        let cross_v =
+            cross_v.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
+        let self_mask =
+            self_mask.try_shrink([Some((SInt::Const(0), bv.clone())), None, None, None]).context(TensorSnafu)?;
+
+        // Embed single token + positional embedding
+        let tok_emb = self.token_embedding.embedding(&token).context(TensorSnafu)?;
+        let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
+        let x = x.cast(self_k_cache.uop().dtype()).context(TensorSnafu)?;
+
+        let mut x = x;
+        let mut new_ks: Vec<Tensor> = Vec::with_capacity(n_layer);
+        let mut new_vs: Vec<Tensor> = Vec::with_capacity(n_layer);
+
+        for (l, block) in self.blocks.iter().enumerate() {
+            let lh_start = l * n_head;
+            let lh_end = (l + 1) * n_head;
+
+            // ── Self-attn with cache ─────────────────────────────────────
+            let h = block.attn_ln.apply(&x)?;
+            let q = block.attn.query.forward(&h)?;
+            let new_k_raw = block.attn.key.forward(&h)?;
+            let new_v_raw = block.attn.value.forward(&h)?;
+
+            let q_h = block.attn.split_heads(&q)?;
+            let new_k_h = block.attn.split_heads(&new_k_raw)?;
+            let new_v_h = block.attn.split_heads(&new_v_raw)?;
+
+            let cached_k = self_k_cache
+                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+            let cached_v = self_v_cache
+                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+
+            let full_k = Tensor::cat(&[&cached_k, &new_k_h], 2).context(TensorSnafu)?;
+            let full_v = Tensor::cat(&[&cached_v, &new_v_h], 2).context(TensorSnafu)?;
+
+            let out = q_h
+                .scaled_dot_product_attention()
+                .key(&full_k)
+                .value(&full_v)
+                .attn_mask(&self_mask)
+                .is_causal(false)
+                .call()
+                .context(TensorSnafu)?;
+            let attn_out = block.attn.merge_heads(&out)?;
+            let attn_out = block.attn.out.forward(&attn_out)?;
+            x = x.try_add(&attn_out).context(TensorSnafu)?;
+
+            // ── Cross-attn (fixed cache, no mask) ────────────────────────
+            let h = block.cross_attn_ln.apply(&x)?;
+            let cq = block.cross_attn.query.forward(&h)?;
+            let cq_h = block.cross_attn.split_heads(&cq)?;
+
+            let layer_ck = cross_k
+                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+            let layer_cv = cross_v
+                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                .context(TensorSnafu)?
+                .try_permute(&[0, 2, 1, 3])
+                .context(TensorSnafu)?;
+
+            let cross_out = cq_h
+                .scaled_dot_product_attention()
+                .key(&layer_ck)
+                .value(&layer_cv)
+                .is_causal(false)
+                .call()
+                .context(TensorSnafu)?;
+            let cross_out = block.cross_attn.merge_heads(&cross_out)?;
+            let cross_out = block.cross_attn.out.forward(&cross_out)?;
+            x = x.try_add(&cross_out).context(TensorSnafu)?;
+
+            // ── MLP ───────────────────────────────────────────────────────
+            let h = block.mlp_ln.apply(&x)?;
+            let h = h.linear().weight(&block.mlp0_w).bias(&block.mlp0_b).call().context(TensorSnafu)?;
+            let h = h.gelu_exact().context(TensorSnafu)?;
+            let h = h.linear().weight(&block.mlp1_w).bias(&block.mlp1_b).call().context(TensorSnafu)?;
+            x = x.try_add(&h).context(TensorSnafu)?;
+
+            new_ks.push(new_k_h);
+            new_vs.push(new_v_h);
+        }
+
+        // Permute + cat new K/V. Batch is symbolic here (`bv`), so the
+        // reshape uses `bv` instead of `SInt::Const(batch)` — this is the
+        // key difference from `forward_step`.
+        let permuted_ks: Vec<Tensor> =
+            new_ks.iter().map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)).collect::<Result<Vec<_>>>()?;
+        let permuted_vs: Vec<Tensor> =
+            new_vs.iter().map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)).collect::<Result<Vec<_>>>()?;
+
+        let stacked_k = Tensor::cat(&permuted_ks.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
+        let stacked_v = Tensor::cat(&permuted_vs.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
+
+        let new_k_flat = stacked_k
+            .try_reshape(&[bv.clone(), SInt::Const(1usize), SInt::Const(n_layer * n_head), SInt::Const(d_head)])
+            .context(TensorSnafu)?;
+        let new_v_flat = stacked_v
+            .try_reshape(&[bv.clone(), SInt::Const(1usize), SInt::Const(n_layer * n_head), SInt::Const(d_head)])
+            .context(TensorSnafu)?;
+        let x = self.ln.apply(&x)?;
+        let logits = x
+            .linear()
+            .weight(&self.token_embedding)
+            .call()
+            .context(TensorSnafu)?
+            .cast(DType::Float32)
+            .context(TensorSnafu)?;
+
+        let n_vocab = self.token_embedding.shape().context(TensorSnafu)?[0].as_const().ok_or_else(|| {
+            super::error::Error::Tensor {
+                source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported {
+                    operation: "forward_step_batched n_vocab".into(),
+                }),
+            }
+        })?;
+        let logits = logits.try_reshape(&[bv, SInt::Const(n_vocab)]).context(TensorSnafu)?;
 
         Ok((logits, new_k_flat, new_v_flat))
     }

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -139,22 +139,61 @@ impl TextDecoder {
         Tensor::cat(&permuted.iter().collect::<Vec<_>>(), 2).context(TensorSnafu)
     }
 
+    fn validate_kv_dtypes(keys: &[Tensor], values: &[Tensor], cache: &str) -> Result<()> {
+        let dtype = keys.first().map(|tensor| tensor.uop().dtype());
+        if keys.len() != values.len()
+            || dtype.is_none()
+            || keys.iter().chain(values).any(|tensor| Some(tensor.uop().dtype()) != dtype)
+        {
+            return Err(super::error::Error::Decode { msg: format!("{cache} K/V producer dtypes are inconsistent") });
+        }
+        Ok(())
+    }
+
+    /// Packed cross-cache activation/output dtype. Dense projections currently
+    /// produce their weight dtype; quantized projections must expose a separate
+    /// output contract rather than treating low-bit weight storage as cache dtype.
+    pub fn cross_cache_output_dtype(&self) -> Result<DType> {
+        let first = self.blocks.first().ok_or_else(|| super::error::Error::Decode {
+            msg: "decoder has no cross-attention projections".to_string(),
+        })?;
+        let dtype = first.cross_attn.key.weight.uop().dtype();
+        for block in &self.blocks {
+            let key = &block.cross_attn.key;
+            let value = &block.cross_attn.value;
+            let consistent = key.weight.uop().dtype() == dtype
+                && value.weight.uop().dtype() == dtype
+                && key.bias.as_ref().is_none_or(|bias| bias.uop().dtype() == dtype)
+                && value.bias.as_ref().is_none_or(|bias| bias.uop().dtype() == dtype);
+            if !consistent {
+                return Err(super::error::Error::Decode {
+                    msg: "cross-attention K/V projection output dtypes are inconsistent".to_string(),
+                });
+            }
+        }
+        Ok(dtype.clone())
+    }
+
     /// Project encoder features into the fixed packed cross-attention cache.
     /// This graph is independent of decoder tokens and runs once per window.
     pub fn project_cross_kv(&self, xa: &Tensor) -> Result<(Tensor, Tensor)> {
+        let output_dtype = self.cross_cache_output_dtype()?;
+        let xa = xa.cast(output_dtype.clone()).context(TensorSnafu)?;
         let mut cross_ks = Vec::with_capacity(self.blocks.len());
         let mut cross_vs = Vec::with_capacity(self.blocks.len());
         for block in &self.blocks {
             // Keep each GEMM independent from the final layer/head packing.
-            let k = block.cross_attn.key.forward(xa)?.contiguous();
-            let v = block.cross_attn.value.forward(xa)?.contiguous();
+            let k = block.cross_attn.key.forward(&xa)?.contiguous();
+            let v = block.cross_attn.value.forward(&xa)?.contiguous();
+            if k.uop().dtype() != output_dtype || v.uop().dtype() != output_dtype {
+                return Err(super::error::Error::Decode {
+                    msg: "cross-attention K/V producers violated their output dtype contract".to_string(),
+                });
+            }
             cross_ks.push(block.cross_attn.split_heads(&k)?);
             cross_vs.push(block.cross_attn.split_heads(&v)?);
         }
-        Ok((
-            Self::pack_kv(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
-            Self::pack_kv(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
-        ))
+        Ok((Self::pack_kv(cross_ks)?, Self::pack_kv(cross_vs)?))
     }
 
     /// Forward pass producing logits for all positions.
@@ -378,13 +417,8 @@ impl TextDecoder {
             .cast(DType::Float32)
             .context(TensorSnafu)?;
 
-        // K/V cache outputs cast to fp32 — the cache buffers are fp32 (host
-        // round-trips them as Vec<f32>), while compute is dims.dtype (fp16).
-        Ok((
-            logits,
-            Self::pack_kv(self_ks)?.cast(DType::Float32).context(TensorSnafu)?,
-            Self::pack_kv(self_vs)?.cast(DType::Float32).context(TensorSnafu)?,
-        ))
+        Self::validate_kv_dtypes(&self_ks, &self_vs, "self-cache")?;
+        Ok((logits, Self::pack_kv(self_ks)?, Self::pack_kv(self_vs)?))
     }
 
     /// Decoder logits using an already prepared cross-attention cache.
@@ -408,7 +442,7 @@ impl TextDecoder {
     /// - `self_v_cache`: [B, max_len, n_layer*H, Dh] self-attn V cache
     /// - `cross_k`: [B, n_audio_ctx, n_layer*H, Dh] cross-attn K (fixed)
     /// - `cross_v`: [B, n_audio_ctx, n_layer*H, Dh] cross-attn V (fixed)
-    /// - `self_mask`: [B(or 1), 1, 1, max_len+1] additive float mask for self-attn
+    /// - `self_mask`: [B(or 1), 1, 1, max_len+1] bool mask; true masks a position
     ///
     /// Returns `(logits[B, n_vocab], new_self_k[B, 1, n_layer*H, Dh], new_self_v[...])`.
     #[allow(clippy::too_many_arguments)]
@@ -476,7 +510,7 @@ impl TextDecoder {
             let full_k = Tensor::cat(&[&cached_k, &new_k_h], 2).context(TensorSnafu)?;
             let full_v = Tensor::cat(&[&cached_v, &new_v_h], 2).context(TensorSnafu)?;
 
-            // Attention with additive mask
+            // Attention with a boolean mask, avoiding promotion of low-precision scores.
             let out = q_h
                 .scaled_dot_product_attention()
                 .key(&full_k)
@@ -536,6 +570,8 @@ impl TextDecoder {
         let permuted_vs: Vec<Tensor> =
             new_vs.iter().map(|t| t.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)).collect::<Result<Vec<_>>>()?;
 
+        Self::validate_kv_dtypes(&permuted_ks, &permuted_vs, "step self-cache")?;
+
         let stacked_k = Tensor::cat(&permuted_ks.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
         let stacked_v = Tensor::cat(&permuted_vs.iter().collect::<Vec<_>>(), 1).context(TensorSnafu)?;
 
@@ -575,12 +611,7 @@ impl TextDecoder {
         let logits =
             logits.try_reshape(&[svod_ir::SInt::Const(batch), svod_ir::SInt::Const(n_vocab)]).context(TensorSnafu)?;
 
-        // K/V outputs cast to fp32 — appended into the fp32 cache buffer via SDMA.
-        Ok((
-            logits,
-            new_k_flat.cast(DType::Float32).context(TensorSnafu)?,
-            new_v_flat.cast(DType::Float32).context(TensorSnafu)?,
-        ))
+        Ok((logits, new_k_flat, new_v_flat))
     }
 }
 

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -538,17 +538,11 @@ impl TextDecoder {
             let cq = block.cross_attn.query.forward(&h)?;
             let cq_seq = cq.try_reshape([batch, 1, n_head, d_head]).context(TensorSnafu)?;
 
-            let layer_ck = cross_k
-                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?;
-            let layer_cv = cross_v
-                .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
-                .context(TensorSnafu)?;
-
-            let direct = svod_tk::single_query_attention(
+            let direct = svod_tk::single_query_attention_packed(
                 &cq_seq,
-                &layer_ck,
-                &layer_cv,
+                cross_k,
+                cross_v,
+                lh_start,
                 svod_tk::SqAttentionOpts { split: cross_splits, ..Default::default() },
             )
             .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
@@ -556,6 +550,12 @@ impl TextDecoder {
             let cross_out = match direct {
                 Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
                 None => {
+                    let layer_ck = cross_k
+                        .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                        .context(TensorSnafu)?;
+                    let layer_cv = cross_v
+                        .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                        .context(TensorSnafu)?;
                     let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
                     let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
                     let layer_cv_h = layer_cv.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -13,6 +13,44 @@ use super::blocks::{LayerNormWeights, linear_with_bias};
 use super::config::ModelDimensions;
 use super::error::{Result, TensorSnafu};
 
+#[derive(Clone, Copy)]
+struct StepAttentionConfig {
+    custom_self: bool,
+    custom_cross: bool,
+    cross_splits: Option<usize>,
+}
+
+impl Default for StepAttentionConfig {
+    fn default() -> Self {
+        Self { custom_self: true, custom_cross: true, cross_splits: None }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StepAttentionMode {
+    Generic,
+    CustomSelf,
+    CustomCross { split: usize },
+    CustomBoth { split: usize },
+}
+
+#[cfg(test)]
+impl From<StepAttentionMode> for StepAttentionConfig {
+    fn from(mode: StepAttentionMode) -> Self {
+        match mode {
+            StepAttentionMode::Generic => Self { custom_self: false, custom_cross: false, cross_splits: None },
+            StepAttentionMode::CustomSelf => Self { custom_self: true, custom_cross: false, cross_splits: None },
+            StepAttentionMode::CustomCross { split } => {
+                Self { custom_self: false, custom_cross: true, cross_splits: Some(split) }
+            }
+            StepAttentionMode::CustomBoth { split } => {
+                Self { custom_self: true, custom_cross: true, cross_splits: Some(split) }
+            }
+        }
+    }
+}
+
 pub(crate) fn cached_step_mask(key_lens: &Tensor, batch: usize, key_count: usize) -> Result<Tensor> {
     let range = Tensor::arange(key_count as i64, None, None)
         .context(TensorSnafu)?
@@ -193,20 +231,22 @@ impl TextDecoder {
             .context(TensorSnafu)?;
 
         let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
-        let x = x.cast(xa.uop().dtype()).context(TensorSnafu)?;
+        let x = x.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
+        let xa = xa.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
 
         let mask = causal_mask(seq_len, x.uop().dtype().clone())?;
 
         let mut x = x;
         for block in &self.blocks {
-            x = block.forward(&x, xa, &mask)?;
+            x = block.forward(&x, &xa, &mask)?;
         }
 
         // Final LayerNorm
         let x = self.ln.apply(&x)?;
 
         // Tied output: logits = x @ token_embedding.T  → [B, L, n_vocab]
-        let logits = x.linear().weight(&self.token_embedding).call().context(TensorSnafu)?;
+        let output_weight = self.token_embedding.cast(x.uop().dtype()).context(TensorSnafu)?;
+        let logits = x.linear().weight(&output_weight).call().context(TensorSnafu)?;
         logits.cast(DType::Float32).context(TensorSnafu)
     }
 
@@ -338,7 +378,9 @@ impl TextDecoder {
             .context(TensorSnafu)?;
 
         let x = tok_emb.try_add(&pos_emb).context(TensorSnafu)?;
-        let x = x.cast(cross_k.uop().dtype()).context(TensorSnafu)?;
+        let x = x.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
+        let cross_k = cross_k.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
+        let cross_v = cross_v.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
 
         let mask = causal_mask(seq_len, x.uop().dtype().clone())?;
 
@@ -389,7 +431,7 @@ impl TextDecoder {
         let x = self.ln.apply(&x)?;
         let logits = x
             .linear()
-            .weight(&self.token_embedding)
+            .weight(&self.token_embedding.cast(x.uop().dtype()).context(TensorSnafu)?)
             .call()
             .context(TensorSnafu)?
             .cast(DType::Float32)
@@ -439,6 +481,55 @@ impl TextDecoder {
         cross_v: &Tensor,
         self_key_lens: &Tensor,
     ) -> Result<(Tensor, Tensor, Tensor)> {
+        self.forward_step_with_config(
+            token,
+            pos_emb,
+            self_k_cache,
+            self_v_cache,
+            cross_k,
+            cross_v,
+            self_key_lens,
+            StepAttentionConfig::default(),
+        )
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn forward_step_with_attention_mode(
+        &self,
+        token: &Tensor,
+        pos_emb: &Tensor,
+        self_k_cache: &Tensor,
+        self_v_cache: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
+        self_key_lens: &Tensor,
+        mode: StepAttentionMode,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        self.forward_step_with_config(
+            token,
+            pos_emb,
+            self_k_cache,
+            self_v_cache,
+            cross_k,
+            cross_v,
+            self_key_lens,
+            mode.into(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn forward_step_with_config(
+        &self,
+        token: &Tensor,
+        pos_emb: &Tensor,
+        self_k_cache: &Tensor,
+        self_v_cache: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
+        self_key_lens: &Tensor,
+        attention: StepAttentionConfig,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
         let n_head = self.n_head;
         let n_layer = self.blocks.len();
         let d_head = self.n_state / n_head;
@@ -462,12 +553,14 @@ impl TextDecoder {
                     operation: "forward_step cross cache length".into(),
                 }),
             })?;
-        let cross_splits = if cross_key_count >= 1000 && cross_key_count.is_multiple_of(4) { 4 } else { 1 };
+        let cross_splits = attention
+            .cross_splits
+            .unwrap_or_else(|| if cross_key_count >= 1000 && cross_key_count.is_multiple_of(4) { 4 } else { 1 });
 
         // Embed single token + positional embedding
         let tok_emb = self.token_embedding.embedding(token).context(TensorSnafu)?;
         let x = tok_emb.try_add(pos_emb).context(TensorSnafu)?;
-        let x = x.cast(self_k_cache.uop().dtype()).context(TensorSnafu)?;
+        let x = x.cast(self.activation_dtype.clone()).context(TensorSnafu)?;
 
         let mut x = x;
         let mut new_ks: Vec<Tensor> = Vec::with_capacity(n_layer);
@@ -504,20 +597,36 @@ impl TextDecoder {
             let full_k = Tensor::cat(&[&cached_k, &new_k_seq], 1).context(TensorSnafu)?;
             let full_v = Tensor::cat(&[&cached_v, &new_v_seq], 1).context(TensorSnafu)?;
 
-            let direct = svod_tk::single_query_attention(
-                &q_seq,
-                &full_k,
-                &full_v,
-                svod_tk::SqAttentionOpts { key_lens: Some(self_key_lens), include_last: true, split: 1 },
-            )
-            .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
-            .context(TensorSnafu)?;
+            let direct = if attention.custom_self {
+                svod_tk::single_query_attention(
+                    &q_seq.cast(DType::Float32).context(TensorSnafu)?,
+                    &full_k,
+                    &full_v,
+                    svod_tk::SqAttentionOpts { key_lens: Some(self_key_lens), include_last: true, split: 1 },
+                )
+                .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+                .context(TensorSnafu)?
+            } else {
+                None
+            };
             let attn_out = match direct {
-                Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
+                Some(out) => out
+                    .try_reshape([batch, 1, self.n_state])
+                    .context(TensorSnafu)?
+                    .cast(self.activation_dtype.clone())
+                    .context(TensorSnafu)?,
                 None => {
                     let q_h = q_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-                    let full_k_h = full_k.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
-                    let full_v_h = full_v.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
+                    let full_k_h = full_k
+                        .cast(self.activation_dtype.clone())
+                        .context(TensorSnafu)?
+                        .try_permute(&[0, 2, 1, 3])
+                        .context(TensorSnafu)?;
+                    let full_v_h = full_v
+                        .cast(self.activation_dtype.clone())
+                        .context(TensorSnafu)?
+                        .try_permute(&[0, 2, 1, 3])
+                        .context(TensorSnafu)?;
                     let mask = cached_step_mask(self_key_lens, batch, self_key_count)?;
                     let out = q_h
                         .scaled_dot_product_attention()
@@ -538,23 +647,35 @@ impl TextDecoder {
             let cq = block.cross_attn.query.forward(&h)?;
             let cq_seq = cq.try_reshape([batch, 1, n_head, d_head]).context(TensorSnafu)?;
 
-            let direct = svod_tk::single_query_attention_packed(
-                &cq_seq,
-                cross_k,
-                cross_v,
-                lh_start,
-                svod_tk::SqAttentionOpts { split: cross_splits, ..Default::default() },
-            )
-            .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
-            .context(TensorSnafu)?;
+            let direct = if attention.custom_cross {
+                svod_tk::single_query_attention_packed(
+                    &cq_seq.cast(DType::Float32).context(TensorSnafu)?,
+                    cross_k,
+                    cross_v,
+                    lh_start,
+                    svod_tk::SqAttentionOpts { split: cross_splits, ..Default::default() },
+                )
+                .map_err(|e| svod_tensor::error::Error::IrConstruction { details: e.to_string() })
+                .context(TensorSnafu)?
+            } else {
+                None
+            };
             let cross_out = match direct {
-                Some(out) => out.try_reshape([batch, 1, self.n_state]).context(TensorSnafu)?,
+                Some(out) => out
+                    .try_reshape([batch, 1, self.n_state])
+                    .context(TensorSnafu)?
+                    .cast(self.activation_dtype.clone())
+                    .context(TensorSnafu)?,
                 None => {
                     let layer_ck = cross_k
                         .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                        .context(TensorSnafu)?
+                        .cast(self.activation_dtype.clone())
                         .context(TensorSnafu)?;
                     let layer_cv = cross_v
                         .try_shrink([None, None, Some((lh_start as isize, lh_end as isize)), None])
+                        .context(TensorSnafu)?
+                        .cast(self.activation_dtype.clone())
                         .context(TensorSnafu)?;
                     let cq_h = cq_seq.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
                     let layer_ck_h = layer_ck.try_permute(&[0, 2, 1, 3]).context(TensorSnafu)?;
@@ -614,7 +735,7 @@ impl TextDecoder {
         let x = self.ln.apply(&x)?;
         let logits = x
             .linear()
-            .weight(&self.token_embedding)
+            .weight(&self.token_embedding.cast(x.uop().dtype()).context(TensorSnafu)?)
             .call()
             .context(TensorSnafu)?
             .cast(DType::Float32)

--- a/model/src/whisper/decoder.rs
+++ b/model/src/whisper/decoder.rs
@@ -2,7 +2,7 @@
 
 use snafu::ResultExt;
 use svod_dtype::DType;
-use svod_ir::{ConstValue, SInt};
+use svod_ir::ConstValue;
 use svod_tensor::Tensor;
 
 use crate::init::fan_in_uniform;
@@ -111,66 +111,24 @@ pub struct TextDecoder {
     pub n_state: usize,
     pub n_head: usize,
     pub n_text_ctx: usize,
-    packed_cross_k_weight: Tensor, // [n_layer * D, D]
-    packed_cross_v_weight: Tensor, // [n_layer * D, D]
-    packed_cross_v_bias: Tensor,   // [n_layer * D]
 }
 
 impl TextDecoder {
     pub fn empty(dims: &ModelDimensions) -> Self {
         let n_state = dims.n_text_state;
         let dtype = dims.dtype.clone();
-        let blocks: Vec<_> = (0..dims.n_text_layer)
-            .map(|_| DecoderBlock::empty_dtype(n_state, dims.n_text_head, dtype.clone()))
-            .collect();
-        let (packed_cross_k_weight, packed_cross_v_weight, packed_cross_v_bias) =
-            Self::pack_cross_weights(&blocks).expect("cross-attention weights");
         Self {
             token_embedding: fan_in_uniform(&[dims.n_vocab, n_state], n_state, dtype.clone()),
             positional_embedding: Tensor::zeros(&[dims.n_text_ctx, n_state], dtype.clone())
                 .expect("positional embedding"),
-            blocks,
+            blocks: (0..dims.n_text_layer)
+                .map(|_| DecoderBlock::empty_dtype(n_state, dims.n_text_head, dtype.clone()))
+                .collect(),
             ln: LayerNormWeights::empty_dtype(n_state, dtype),
             n_state,
             n_head: dims.n_text_head,
             n_text_ctx: dims.n_text_ctx,
-            packed_cross_k_weight,
-            packed_cross_v_weight,
-            packed_cross_v_bias,
         }
-    }
-
-    fn pack_cross_weights(
-        blocks: &[DecoderBlock],
-    ) -> std::result::Result<(Tensor, Tensor, Tensor), Box<svod_tensor::error::Error>> {
-        let key_weights: Vec<_> = blocks.iter().map(|block| &block.cross_attn.key.weight).collect();
-        let value_weights: Vec<_> = blocks.iter().map(|block| &block.cross_attn.value.weight).collect();
-        let value_biases: Vec<_> = blocks
-            .iter()
-            .map(|block| block.cross_attn.value.bias.as_ref().expect("Whisper value projection has bias"))
-            .collect();
-        Ok((
-            Tensor::cat(&key_weights, 0).map_err(Box::new)?,
-            Tensor::cat(&value_weights, 0).map_err(Box::new)?,
-            Tensor::cat(&value_biases, 0).map_err(Box::new)?,
-        ))
-    }
-
-    fn rebuild_packed_cross_weights(&mut self) -> std::result::Result<(), Box<svod_tensor::error::Error>> {
-        let (mut key, mut value, mut value_bias) = Self::pack_cross_weights(&self.blocks)?;
-        Tensor::realize_batch([&mut key, &mut value, &mut value_bias]).map_err(Box::new)?;
-
-        for (layer, block) in self.blocks.iter_mut().enumerate() {
-            let start = (layer * self.n_state) as isize;
-            let end = start + self.n_state as isize;
-            block.cross_attn.key.weight = key.try_shrink([Some((start, end)), None]).map_err(Box::new)?;
-            block.cross_attn.value.weight = value.try_shrink([Some((start, end)), None]).map_err(Box::new)?;
-            block.cross_attn.value.bias = Some(value_bias.try_shrink([Some((start, end))]).map_err(Box::new)?);
-        }
-        self.packed_cross_k_weight = key;
-        self.packed_cross_v_weight = value;
-        self.packed_cross_v_bias = value_bias;
-        Ok(())
     }
 
     fn pack_kv(kvs: Vec<Tensor>) -> Result<Tensor> {
@@ -184,23 +142,18 @@ impl TextDecoder {
     /// Project encoder features into the fixed packed cross-attention cache.
     /// This graph is independent of decoder tokens and runs once per window.
     pub fn project_cross_kv(&self, xa: &Tensor) -> Result<(Tensor, Tensor)> {
-        let shape = xa.shape().context(TensorSnafu)?;
-        let cache_shape = [
-            shape[0].clone(),
-            shape[1].clone(),
-            SInt::Const(self.blocks.len() * self.n_head),
-            SInt::Const(self.n_state / self.n_head),
-        ];
-        let k = xa.linear().weight(&self.packed_cross_k_weight).call().context(TensorSnafu)?;
-        let v = xa
-            .linear()
-            .weight(&self.packed_cross_v_weight)
-            .bias(&self.packed_cross_v_bias)
-            .call()
-            .context(TensorSnafu)?;
+        let mut cross_ks = Vec::with_capacity(self.blocks.len());
+        let mut cross_vs = Vec::with_capacity(self.blocks.len());
+        for block in &self.blocks {
+            // Keep each GEMM independent from the final layer/head packing.
+            let k = block.cross_attn.key.forward(xa)?.contiguous();
+            let v = block.cross_attn.value.forward(xa)?.contiguous();
+            cross_ks.push(block.cross_attn.split_heads(&k)?);
+            cross_vs.push(block.cross_attn.split_heads(&v)?);
+        }
         Ok((
-            k.try_reshape(&cache_shape).context(TensorSnafu)?.cast(DType::Float32).context(TensorSnafu)?,
-            v.try_reshape(&cache_shape).context(TensorSnafu)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(cross_ks)?.cast(DType::Float32).context(TensorSnafu)?,
+            Self::pack_kv(cross_vs)?.cast(DType::Float32).context(TensorSnafu)?,
         ))
     }
 
@@ -650,7 +603,6 @@ impl HasStateDict for TextDecoder {
             block.load_state_dict(sd, &prefixed(prefix, &format!("blocks.{i}")))?;
         }
         self.ln.load_state_dict(sd, &prefixed(prefix, "ln"))?;
-        self.rebuild_packed_cross_weights().map_err(|source| state::Error::Tensor { source })?;
         Ok(())
     }
 }

--- a/model/src/whisper/dtw.rs
+++ b/model/src/whisper/dtw.rs
@@ -223,6 +223,80 @@ pub fn find_alignment_path(
     dtw(&negated, text_len, audio_frames)
 }
 
+/// Extract an alignment path from statically packed selected-head raw QK
+/// scores. Compiled strides are separate from the valid unpadded extents.
+#[allow(clippy::too_many_arguments)]
+pub fn find_alignment_path_selected(
+    qk: &[f32],
+    n_heads: usize,
+    text_stride: usize,
+    audio_stride: usize,
+    valid_text: usize,
+    valid_audio: usize,
+    medfilt_width: usize,
+    sot_len: usize,
+) -> (Vec<usize>, Vec<usize>) {
+    let valid_text = valid_text.min(text_stride);
+    let valid_audio = valid_audio.min(audio_stride);
+    if n_heads == 0 || valid_audio == 0 || valid_text <= sot_len + 1 {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut weights = vec![0.0f32; n_heads * valid_text * valid_audio];
+    for head in 0..n_heads {
+        for text in 0..valid_text {
+            let src = (head * text_stride + text) * audio_stride;
+            let dst = (head * valid_text + text) * valid_audio;
+            weights[dst..dst + valid_audio].copy_from_slice(&qk[src..src + valid_audio]);
+        }
+    }
+
+    for row in weights.chunks_exact_mut(valid_audio) {
+        let max = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0;
+        for value in row.iter_mut() {
+            *value = (*value - max).exp();
+            sum += *value;
+        }
+        for value in row.iter_mut() {
+            *value /= sum;
+        }
+    }
+
+    for head in 0..n_heads {
+        for frame in 0..valid_audio {
+            let mean =
+                (0..valid_text).map(|text| weights[(head * valid_text + text) * valid_audio + frame]).sum::<f32>()
+                    / valid_text as f32;
+            let variance = (0..valid_text)
+                .map(|text| {
+                    let delta = weights[(head * valid_text + text) * valid_audio + frame] - mean;
+                    delta * delta
+                })
+                .sum::<f32>()
+                / valid_text as f32;
+            let std = variance.sqrt().max(1e-10);
+            for text in 0..valid_text {
+                let index = (head * valid_text + text) * valid_audio + frame;
+                weights[index] = (weights[index] - mean) / std;
+            }
+        }
+    }
+
+    let filtered = median_filter(&weights, n_heads * valid_text, valid_audio, medfilt_width);
+    let aligned_text = valid_text - sot_len - 1;
+    let mut cost = vec![0.0f32; aligned_text * valid_audio];
+    for text in 0..aligned_text {
+        for frame in 0..valid_audio {
+            let sum = (0..n_heads)
+                .map(|head| filtered[(head * valid_text + text + sot_len) * valid_audio + frame])
+                .sum::<f32>();
+            cost[text * valid_audio + frame] = -(sum / n_heads as f32);
+        }
+    }
+    dtw(&cost, aligned_text, valid_audio)
+}
+
 /// Convert a DTW alignment path into word-level timings.
 ///
 /// `text_indices`, `time_indices`: DTW path. `word_boundaries`: cumulative
@@ -237,7 +311,7 @@ pub fn path_to_word_timings(
     token_probs: &[f32],
     tokens_per_second: f32,
 ) -> Vec<WordTiming> {
-    if word_boundaries.len() <= 1 {
+    if word_boundaries.len() <= 1 || text_indices.is_empty() || time_indices.is_empty() {
         return Vec::new();
     }
 
@@ -255,16 +329,17 @@ pub fn path_to_word_timings(
     let n_words = word_boundaries.len() - 1;
     let mut result = Vec::with_capacity(n_words);
 
+    let last_jump = jump_times.last().copied().unwrap_or(0.0);
     for w in 0..n_words {
-        let start = jump_times.get(word_boundaries[w]).copied().unwrap_or(0.0);
-        let end = jump_times.get(word_boundaries[w + 1]).copied().unwrap_or(start);
+        let start = jump_times.get(word_boundaries[w]).copied().unwrap_or(last_jump);
+        let end = jump_times.get(word_boundaries[w + 1]).copied().unwrap_or(last_jump).max(start);
 
         // Token probabilities for this word
         let tok_start = word_boundaries[w];
         let tok_end = word_boundaries[w + 1];
         let prob = if tok_end > tok_start {
-            let slice = &token_probs[tok_start..tok_end.min(token_probs.len())];
-            slice.iter().sum::<f32>() / slice.len() as f32
+            let slice = token_probs.get(tok_start..tok_end.min(token_probs.len())).unwrap_or_default();
+            if slice.is_empty() { 0.0 } else { slice.iter().sum::<f32>() / slice.len() as f32 }
         } else {
             0.0
         };
@@ -278,5 +353,65 @@ pub fn path_to_word_timings(
         });
     }
 
+    clean_up_word_timings(&mut result);
     result
+}
+
+/// Apply OpenAI Whisper's sentence-boundary duration cleanup and punctuation
+/// attachment to raw DTW timings.
+pub fn clean_up_word_timings(words: &mut [WordTiming]) {
+    let mut durations: Vec<f32> = words
+        .iter()
+        .map(|word| word.end - word.start)
+        .filter(|duration| duration.is_finite() && *duration > 0.0)
+        .collect();
+    durations.sort_by(|a, b| a.total_cmp(b));
+    let median = match durations.len() {
+        0 => 0.0,
+        len if len % 2 == 0 => (durations[len / 2 - 1] + durations[len / 2]) / 2.0,
+        len => durations[len / 2],
+    }
+    .min(0.7);
+    let max_duration = median * 2.0;
+    if max_duration > 0.0 {
+        const SENTENCE_END: &str = ".。!！?？";
+        for index in 1..words.len() {
+            if words[index].end - words[index].start > max_duration {
+                if SENTENCE_END.contains(words[index].word.as_str()) {
+                    words[index].end = words[index].start + max_duration;
+                } else if SENTENCE_END.contains(words[index - 1].word.as_str()) {
+                    words[index].start = words[index].end - max_duration;
+                }
+            }
+        }
+    }
+
+    merge_punctuations(words, "\"'“¿([{-", "\"'.。,，!！?？:：”)]}、");
+}
+
+fn merge_punctuations(words: &mut [WordTiming], prepended: &str, appended: &str) {
+    let mut following = words.len().saturating_sub(1);
+    for previous in (0..words.len().saturating_sub(1)).rev() {
+        if words[previous].word.starts_with(' ') && prepended.contains(words[previous].word.trim()) {
+            let prefix = std::mem::take(&mut words[previous].word);
+            words[following].word.insert_str(0, &prefix);
+            let mut tokens = std::mem::take(&mut words[previous].tokens);
+            tokens.append(&mut words[following].tokens);
+            words[following].tokens = tokens;
+        } else {
+            following = previous;
+        }
+    }
+
+    let mut previous = 0;
+    for following in 1..words.len() {
+        if !words[previous].word.ends_with(' ') && appended.contains(words[following].word.as_str()) {
+            let suffix = std::mem::take(&mut words[following].word);
+            words[previous].word.push_str(&suffix);
+            let tokens = std::mem::take(&mut words[following].tokens);
+            words[previous].tokens.extend(tokens);
+        } else {
+            previous = following;
+        }
+    }
 }

--- a/model/src/whisper/encoder.rs
+++ b/model/src/whisper/encoder.rs
@@ -7,7 +7,7 @@ use svod_tensor::Tensor;
 use crate::init::fan_in_uniform;
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
 
-use super::attention::MultiHeadAttention;
+use super::attention::{MultiHeadAttention, padded_fa_sequence_len};
 use super::blocks::{Conv1dWeights, LayerNormWeights, sinusoids};
 use super::config::ModelDimensions;
 use super::error::{Result, TensorSnafu};
@@ -45,9 +45,13 @@ impl EncoderBlock {
     }
 
     pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        self.forward_with_key_lens(x, None)
+    }
+
+    fn forward_with_key_lens(&self, x: &Tensor, key_lens: Option<&Tensor>) -> Result<Tensor> {
         // Self-attention (pre-norm)
         let h = self.attn_ln.apply(x)?;
-        let attn_out = self.attn.forward(&h, None, None)?;
+        let attn_out = self.attn.forward_with_key_lens(&h, None, None, key_lens)?;
         let x = x.try_add(&attn_out).context(TensorSnafu)?;
 
         // MLP (pre-norm)
@@ -132,10 +136,35 @@ impl AudioEncoder {
         // Add positional embedding [n_audio_ctx, D]
         let x = x.try_add(&self.positional_embedding).context(TensorSnafu)?;
 
+        let shape = x.shape().context(TensorSnafu)?;
+        let concrete = |axis: usize, operation: &str| {
+            shape[axis].as_const().ok_or_else(|| super::error::Error::Tensor {
+                source: Box::new(svod_tensor::error::Error::SymbolicShapeUnsupported { operation: operation.into() }),
+            })
+        };
+        let (batch, sequence, state) = (
+            concrete(0, "Whisper encoder batch")?,
+            concrete(1, "Whisper encoder sequence")?,
+            concrete(2, "Whisper encoder state")?,
+        );
+        let padded_sequence = encoder_padded_sequence_len(&x.device(), sequence);
+        let (mut x, key_lens) = match padded_sequence {
+            Some(padded) => {
+                let x = x.try_pad(&[(0, 0), (0, (padded - sequence) as isize), (0, 0)]).context(TensorSnafu)?;
+                let lens = Tensor::full(&[batch], svod_ir::ConstValue::Int(sequence as i64), DType::Int32)
+                    .context(TensorSnafu)?
+                    .to(x.device());
+                (x, Some(lens))
+            }
+            None => (x, None),
+        };
+
         // Transformer blocks
-        let mut x = x;
         for block in &self.blocks {
-            x = block.forward(&x)?;
+            x = block.forward_with_key_lens(&x, key_lens.as_ref())?;
+        }
+        if padded_sequence.is_some() {
+            x = x.try_shrink([(0, batch), (0, sequence), (0, state)]).context(TensorSnafu)?;
         }
 
         // Final LayerNorm + cast to fp32. The encoder output is consumed by the
@@ -144,6 +173,12 @@ impl AudioEncoder {
         // the host read path works regardless of compute dtype.
         self.ln_post.apply(&x)?.cast(DType::Float32).context(TensorSnafu)
     }
+}
+
+fn encoder_padded_sequence_len(device: &svod_dtype::DeviceSpec, sequence: usize) -> Option<usize> {
+    svod_tk::flash_attention_supported(device)
+        .then(|| padded_fa_sequence_len(false, sequence, sequence, sequence))
+        .flatten()
 }
 
 impl HasStateDict for AudioEncoder {
@@ -168,5 +203,51 @@ impl HasStateDict for AudioEncoder {
         }
         self.ln_post.load_state_dict(sd, &prefixed(prefix, "ln_post"))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use svod_dtype::DeviceSpec;
+
+    use super::*;
+
+    fn encoder_dims(layers: usize) -> ModelDimensions {
+        ModelDimensions {
+            n_mels: 4,
+            n_audio_ctx: 1500,
+            n_audio_state: 128,
+            n_audio_head: 2,
+            n_audio_layer: layers,
+            n_vocab: 16,
+            n_text_ctx: 8,
+            n_text_state: 8,
+            n_text_head: 2,
+            n_text_layer: 1,
+            dtype: DType::Float16,
+        }
+    }
+
+    #[test]
+    fn unsupported_device_keeps_original_encoder_sequence() {
+        assert_eq!(encoder_padded_sequence_len(&DeviceSpec::Cpu, 1500), None);
+
+        let encoder = AudioEncoder::empty(&encoder_dims(1));
+        let mel = Tensor::zeros(&[1, 4, 3000], DType::Float32).unwrap();
+        let out = encoder.forward(&mel).unwrap();
+        assert_eq!(out.shape().unwrap().iter().map(|d| d.as_const().unwrap()).collect::<Vec<_>>(), [1, 1500, 128]);
+    }
+
+    #[test]
+    #[ignore = "GPU: inspect full padded Whisper encoder execution plan"]
+    fn padded_encoder_plan_has_one_flash_attention_per_block() {
+        let encoder = AudioEncoder::empty(&encoder_dims(32));
+        let mel = Tensor::zeros(&[1, 4, 3000], DType::Float32).unwrap();
+        let mut out = encoder.forward(&mel).unwrap();
+        assert_eq!(out.shape().unwrap().iter().map(|d| d.as_const().unwrap()).collect::<Vec<_>>(), [1, 1500, 128]);
+
+        let plan = out.prepare().unwrap();
+        let flash_attention = plan.kernels().filter(|kernel| kernel.entry_point == "flash_attention").count();
+        assert_eq!(flash_attention, 32, "expected one handwritten flash-attention dispatch per encoder block");
     }
 }

--- a/model/src/whisper/encoder.rs
+++ b/model/src/whisper/encoder.rs
@@ -8,7 +8,7 @@ use crate::init::fan_in_uniform;
 use crate::state::{self, HasStateDict, StateDict, get_tensor, prefixed};
 
 use super::attention::{MultiHeadAttention, padded_fa_sequence_len};
-use super::blocks::{Conv1dWeights, LayerNormWeights, sinusoids};
+use super::blocks::{Conv1dWeights, LayerNormWeights, linear_with_bias, sinusoids};
 use super::config::ModelDimensions;
 use super::error::{Result, TensorSnafu};
 
@@ -56,9 +56,9 @@ impl EncoderBlock {
 
         // MLP (pre-norm)
         let h = self.mlp_ln.apply(&x)?;
-        let h = h.linear().weight(&self.mlp0_w).bias(&self.mlp0_b).call().context(TensorSnafu)?;
+        let h = linear_with_bias(&h, &self.mlp0_w, &self.mlp0_b)?;
         let h = h.gelu_exact().context(TensorSnafu)?;
-        let h = h.linear().weight(&self.mlp1_w).bias(&self.mlp1_b).call().context(TensorSnafu)?;
+        let h = linear_with_bias(&h, &self.mlp1_w, &self.mlp1_b)?;
         let x = x.try_add(&h).context(TensorSnafu)?;
         Ok(x)
     }

--- a/model/src/whisper/encoder.rs
+++ b/model/src/whisper/encoder.rs
@@ -124,7 +124,7 @@ impl AudioEncoder {
         // feeds fp32 mel). Matches `model.py:48` weight.to(x.dtype) from the
         // other direction — we cast x to the weight dtype so the graph is uniform.
         let dtype = self.conv1.weight.uop().dtype().clone();
-        let mel = mel.cast(dtype).context(TensorSnafu)?;
+        let mel = mel.cast(dtype.clone()).context(TensorSnafu)?;
         let x = self.conv1.forward(&mel)?;
         let x = x.gelu_exact().context(TensorSnafu)?;
         let x = self.conv2.forward(&x)?;
@@ -134,7 +134,7 @@ impl AudioEncoder {
         let x = x.try_permute(&[0, 2, 1]).context(TensorSnafu)?;
 
         // Add positional embedding [n_audio_ctx, D]
-        let x = x.try_add(&self.positional_embedding).context(TensorSnafu)?;
+        let x = x.try_add(&self.positional_embedding).context(TensorSnafu)?.cast(dtype).context(TensorSnafu)?;
 
         let shape = x.shape().context(TensorSnafu)?;
         let concrete = |axis: usize, operation: &str| {

--- a/model/src/whisper/encoder.rs
+++ b/model/src/whisper/encoder.rs
@@ -27,15 +27,19 @@ pub struct EncoderBlock {
 
 impl EncoderBlock {
     pub fn empty(n_state: usize, n_head: usize) -> Self {
+        Self::empty_dtype(n_state, n_head, DType::Float32)
+    }
+
+    pub fn empty_dtype(n_state: usize, n_head: usize, dtype: DType) -> Self {
         let mlp = n_state * 4;
         Self {
-            attn: MultiHeadAttention::empty(n_state, n_head),
-            attn_ln: LayerNormWeights::empty(n_state),
-            mlp0_w: fan_in_uniform(&[mlp, n_state], n_state, DType::Float32),
-            mlp0_b: fan_in_uniform(&[mlp], n_state, DType::Float32),
-            mlp1_w: fan_in_uniform(&[n_state, mlp], mlp, DType::Float32),
-            mlp1_b: fan_in_uniform(&[n_state], mlp, DType::Float32),
-            mlp_ln: LayerNormWeights::empty(n_state),
+            attn: MultiHeadAttention::empty_dtype(n_state, n_head, dtype.clone()),
+            attn_ln: LayerNormWeights::empty_dtype(n_state, dtype.clone()),
+            mlp0_w: fan_in_uniform(&[mlp, n_state], n_state, dtype.clone()),
+            mlp0_b: fan_in_uniform(&[mlp], n_state, dtype.clone()),
+            mlp1_w: fan_in_uniform(&[n_state, mlp], mlp, dtype.clone()),
+            mlp1_b: fan_in_uniform(&[n_state], mlp, dtype.clone()),
+            mlp_ln: LayerNormWeights::empty_dtype(n_state, dtype),
             n_state,
         }
     }
@@ -96,12 +100,15 @@ pub struct AudioEncoder {
 impl AudioEncoder {
     pub fn empty(dims: &ModelDimensions) -> Self {
         let n_state = dims.n_audio_state;
+        let dtype = dims.dtype.clone();
         Self {
-            conv1: Conv1dWeights::empty(dims.n_mels, n_state, 3, 1, 1, true),
-            conv2: Conv1dWeights::empty(n_state, n_state, 3, 2, 1, true),
+            conv1: Conv1dWeights::empty_dtype(dims.n_mels, n_state, 3, 1, 1, true, dtype.clone()),
+            conv2: Conv1dWeights::empty_dtype(n_state, n_state, 3, 2, 1, true, dtype.clone()),
             positional_embedding: sinusoids(dims.n_audio_ctx, n_state, 10_000.0).expect("sinusoidal embedding"),
-            blocks: (0..dims.n_audio_layer).map(|_| EncoderBlock::empty(n_state, dims.n_audio_head)).collect(),
-            ln_post: LayerNormWeights::empty(n_state),
+            blocks: (0..dims.n_audio_layer)
+                .map(|_| EncoderBlock::empty_dtype(n_state, dims.n_audio_head, dtype.clone()))
+                .collect(),
+            ln_post: LayerNormWeights::empty_dtype(n_state, dtype),
             n_state,
             n_head: dims.n_audio_head,
         }
@@ -109,7 +116,12 @@ impl AudioEncoder {
 
     /// Forward: mel `[B, n_mels, T]` → encoder features `[B, T/2, D]`.
     pub fn forward(&self, mel: &Tensor) -> Result<Tensor> {
-        let x = self.conv1.forward(mel)?;
+        // Cast input to the compute dtype (weights are dims.dtype; the host
+        // feeds fp32 mel). Matches `model.py:48` weight.to(x.dtype) from the
+        // other direction — we cast x to the weight dtype so the graph is uniform.
+        let dtype = self.conv1.weight.uop().dtype().clone();
+        let mel = mel.cast(dtype).context(TensorSnafu)?;
+        let x = self.conv1.forward(&mel)?;
         let x = x.gelu_exact().context(TensorSnafu)?;
         let x = self.conv2.forward(&x)?;
         let x = x.gelu_exact().context(TensorSnafu)?;
@@ -126,8 +138,11 @@ impl AudioEncoder {
             x = block.forward(&x)?;
         }
 
-        // Final LayerNorm
-        self.ln_post.apply(&x)
+        // Final LayerNorm + cast to fp32. The encoder output is consumed by the
+        // host (copyout_prefix into Vec<f32>) and fed to the prefill/step JITs
+        // which cast it back to the compute dtype. Keeping the output fp32 means
+        // the host read path works regardless of compute dtype.
+        self.ln_post.apply(&x)?.cast(DType::Float32).context(TensorSnafu)
     }
 }
 

--- a/model/src/whisper/jit.rs
+++ b/model/src/whisper/jit.rs
@@ -72,8 +72,8 @@ jit_wrapper! {
 }
 
 // Decoder-only JIT for language detection: prepared cross K/V + tokens → logits.
-// The caller writes the current token sequence (padded with EOT to n_text_ctx)
-// and reads logits at the current position.
+// This remains separate from prefill and step because it is prepared for one SOT
+// token and returns exactly one vocabulary row.
 jit_wrapper! {
     WhisperDecoderJit(Whisper) {
         prepared_cross_k: Tensor,

--- a/model/src/whisper/jit.rs
+++ b/model/src/whisper/jit.rs
@@ -2,8 +2,7 @@
 //!
 //! Every wrapper is prepared at a concrete capacity. Recognition projects
 //! encoder features into cross-attention caches once, then reuses them for
-//! language detection, token prefill, and fixed-slot decoder steps. Alignment
-//! uses a separate teacher-forced graph.
+//! language detection, token prefill, fixed-slot decoder steps, and alignment.
 #![allow(clippy::too_many_arguments)]
 
 extern crate self as svod_model;
@@ -25,10 +24,11 @@ impl WhisperAlignmentModel {
 
     fn forward(
         &self,
-        audio_features: &svod_tensor::Tensor,
+        cross_k: &svod_tensor::Tensor,
+        cross_v: &svod_tensor::Tensor,
         tokens: &svod_tensor::Tensor,
     ) -> super::error::Result<svod_tensor::Tensor> {
-        self.model.align(tokens, audio_features, &self.alignment_heads)
+        self.model.align_with_cross_kv(tokens, cross_k, cross_v, &self.alignment_heads)
     }
 }
 
@@ -61,11 +61,12 @@ jit_wrapper! {
 // are fixed at construction; valid token/audio lengths are host metadata.
 jit_wrapper! {
     WhisperAlignmentJit(WhisperAlignmentModel) {
-        audio_features: Tensor,
+        cross_k: Tensor,
+        cross_v: Tensor,
         tokens: Tensor,
 
-        build(audio_features, tokens) {
-            model.forward(audio_features, tokens)
+        build(cross_k, cross_v, tokens) {
+            model.forward(cross_k, cross_v, tokens)
         }
     }
 }

--- a/model/src/whisper/jit.rs
+++ b/model/src/whisper/jit.rs
@@ -106,8 +106,8 @@ jit_wrapper! {
 }
 
 // KV-cached decoder step JIT: single-token forward with K/V cache recycling.
-// Inputs: token [1,1], pos_emb [1,1,D], self/cross K/V caches, attention mask.
-// Outputs: logits [1,n_vocab], new_self_k [1,1,n_layer*H,Dh], new_self_v [...].
+// Inputs: token [B,1], pos_emb [B,1,D], self/cross K/V caches, self key lengths [B].
+// Outputs: logits [B,n_vocab], new_self_k [B,1,n_layer*H,Dh], new_self_v [...].
 // After execute: copy_output_to_self_k_cache/v_cache to append new K/V at pos.
 jit_wrapper! {
     WhisperDecoderStepJit(Whisper) {
@@ -117,12 +117,12 @@ jit_wrapper! {
         self_v_cache: Tensor,
         cross_k: Tensor,
         cross_v: Tensor,
-        self_mask: Tensor,
+        self_key_lens: Tensor,
 
         outputs { logits, new_self_k, new_self_v }
 
-        build(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask) {
-            model.decode_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask)
+        build(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_key_lens) {
+            model.decode_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_key_lens)
         }
     }
 }

--- a/model/src/whisper/jit.rs
+++ b/model/src/whisper/jit.rs
@@ -1,9 +1,9 @@
 //! JIT wrappers for Whisper.
 //!
-//! - `WhisperEncoderJit`: mel → encoder features. Fixed shape [1, n_mels, N_FRAMES].
-//! - `WhisperDecoderJit`: encoder features + tokens → logits. Fixed shape
-//!   [1, n_text_ctx] so the plan compiles once; the caller reads only the
-//!   current position's logits each step.
+//! Every wrapper is prepared at a concrete capacity. Recognition projects
+//! encoder features into cross-attention caches once, then reuses them for
+//! language detection, token prefill, and fixed-slot decoder steps. Alignment
+//! uses a separate teacher-forced graph.
 #![allow(clippy::too_many_arguments)]
 
 extern crate self as svod_model;
@@ -11,6 +11,26 @@ extern crate self as svod_model;
 use svod_macros::jit_wrapper;
 
 use super::model::Whisper;
+
+#[derive(Clone)]
+pub struct WhisperAlignmentModel {
+    model: Whisper,
+    alignment_heads: Vec<(usize, usize)>,
+}
+
+impl WhisperAlignmentModel {
+    pub fn new(model: Whisper, alignment_heads: Vec<(usize, usize)>) -> Self {
+        Self { model, alignment_heads }
+    }
+
+    fn forward(
+        &self,
+        audio_features: &svod_tensor::Tensor,
+        tokens: &svod_tensor::Tensor,
+    ) -> super::error::Result<svod_tensor::Tensor> {
+        self.model.align(tokens, audio_features, &self.alignment_heads)
+    }
+}
 
 // Encoder-only JIT: mel `[B, n_mels, T]` → `[B, T/2, D]`.
 jit_wrapper! {
@@ -23,34 +43,63 @@ jit_wrapper! {
     }
 }
 
-// Decoder-only JIT: audio features + tokens → logits.
-// Prepared at `[1, n_audio_ctx, D]` × `[1, n_text_ctx]`.
-// The caller writes the current token sequence (padded with EOT to n_text_ctx)
-// and reads logits at the current position.
+// Encoder-feature projection JIT. Its concrete packed outputs are reused by
+// every prefill attempt and decoder step for one audio window.
 jit_wrapper! {
-    WhisperDecoderJit(Whisper) {
+    WhisperCrossKvJit(Whisper) {
         audio_features: Tensor,
-        tokens: Tensor,
 
-        build(audio_features, tokens) {
-            model.decode(tokens, audio_features, 0)
+        outputs { cross_k, cross_v }
+
+        build(audio_features) {
+            model.project_cross_kv(audio_features)
         }
     }
 }
 
-// Prefill JIT: initial tokens [1, init_len] + audio features → logits + K/V caches.
-// Outputs: logits [1, init_len, n_vocab], self_k/v per-layer, cross_k/v per-layer.
+// Static teacher-forced alignment replay. The graph shape and selected heads
+// are fixed at construction; valid token/audio lengths are host metadata.
+jit_wrapper! {
+    WhisperAlignmentJit(WhisperAlignmentModel) {
+        audio_features: Tensor,
+        tokens: Tensor,
+
+        build(audio_features, tokens) {
+            model.forward(audio_features, tokens)
+        }
+    }
+}
+
+// Decoder-only JIT for language detection: prepared cross K/V + tokens → logits.
+// The caller writes the current token sequence (padded with EOT to n_text_ctx)
+// and reads logits at the current position.
+jit_wrapper! {
+    WhisperDecoderJit(Whisper) {
+        prepared_cross_k: Tensor,
+        prepared_cross_v: Tensor,
+        tokens: Tensor,
+
+        build(prepared_cross_k, prepared_cross_v, tokens) {
+            model.decode_with_cross_kv(tokens, prepared_cross_k, prepared_cross_v)
+        }
+    }
+}
+
+// Prefill JIT: initial tokens [1, init_len] + prepared cross K/V → logits + caches.
+// Outputs: logits [1, init_len, n_vocab] and packed self K/V. Prepared cross
+// K/V remain in the device-local inputs and are also bound into decoder steps.
 // Compiled once at fixed init_len; the plan owns all buffers, reused per window.
 // No realize() needed — logits read via copyout, K/V copied to step JIT caches.
 jit_wrapper! {
     WhisperPrefillJit(Whisper) {
         tokens: Tensor,
-        audio_features: Tensor,
+        prepared_cross_k: Tensor,
+        prepared_cross_v: Tensor,
 
-        outputs { logits, self_k, self_v, cross_k, cross_v }
+        outputs { logits, self_k, self_v }
 
-        build(tokens, audio_features) {
-            model.decode_prefill(tokens, audio_features, 0)
+        build(tokens, prepared_cross_k, prepared_cross_v) {
+            model.decode_prefill(tokens, prepared_cross_k, prepared_cross_v, 0)
         }
     }
 }
@@ -73,35 +122,6 @@ jit_wrapper! {
 
         build(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask) {
             model.decode_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask)
-        }
-    }
-}
-
-// Continuous-batching step JIT: same single-token forward, but with the batch
-// dimension exposed as a JIT variable `b`. One plan compiled at `max_batch`
-// serves any `b ∈ [1, max_batch]` via `execute_with_vars(&[("b", n)])` — no
-// recompilation per lane count. This is the substrate for batching decode
-// steps across multiple windows/tasks.
-jit_wrapper! {
-    WhisperDecoderStepBatchedJit(Whisper) {
-        token: Tensor,
-        pos_emb: Tensor,
-        self_k_cache: Tensor,
-        self_v_cache: Tensor,
-        cross_k: Tensor,
-        cross_v: Tensor,
-        self_mask: Tensor,
-
-        vars {
-            // Default upper bound; override with `.with_b_bound(max)` after
-            // `new()` to set the real continuous-batching lane capacity.
-            b: (1, 8),
-        }
-
-        outputs { logits, new_self_k, new_self_v }
-
-        build(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask, b) {
-            model.decode_step_batched(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask, &b)
         }
     }
 }

--- a/model/src/whisper/jit.rs
+++ b/model/src/whisper/jit.rs
@@ -76,3 +76,32 @@ jit_wrapper! {
         }
     }
 }
+
+// Continuous-batching step JIT: same single-token forward, but with the batch
+// dimension exposed as a JIT variable `b`. One plan compiled at `max_batch`
+// serves any `b ∈ [1, max_batch]` via `execute_with_vars(&[("b", n)])` — no
+// recompilation per lane count. This is the substrate for batching decode
+// steps across multiple windows/tasks.
+jit_wrapper! {
+    WhisperDecoderStepBatchedJit(Whisper) {
+        token: Tensor,
+        pos_emb: Tensor,
+        self_k_cache: Tensor,
+        self_v_cache: Tensor,
+        cross_k: Tensor,
+        cross_v: Tensor,
+        self_mask: Tensor,
+
+        vars {
+            // Default upper bound; override with `.with_b_bound(max)` after
+            // `new()` to set the real continuous-batching lane capacity.
+            b: (1, 8),
+        }
+
+        outputs { logits, new_self_k, new_self_v }
+
+        build(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask, b) {
+            model.decode_step_batched(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask, &b)
+        }
+    }
+}

--- a/model/src/whisper/loader.rs
+++ b/model/src/whisper/loader.rs
@@ -7,7 +7,6 @@
 use std::path::Path;
 
 use crate::state::{self, HasStateDict, StateDict};
-use svod_dtype::DType;
 
 use super::config::{ModelDimensions, WhisperSize};
 use super::error::{Error, Result};
@@ -17,11 +16,13 @@ impl Whisper {
     /// Load from a safetensors state dict.
     ///
     /// HuggingFace Transformers checkpoints (`model.safetensors`) store the
-    /// weights in Float16; the compute graph is Float32, so every tensor is
-    /// upcast before loading. Int tensors (e.g. embeddings that are already
-    /// integer) are left untouched by [`state::cast_all`].
+    /// weights in Float16; the compute dtype is `dims.dtype` (Float16 by
+    /// default, settable to Float32 for CPU parity). Weights are cast to
+    /// `dims.dtype` before loading; int tensors (e.g. integer embeddings) are
+    /// left untouched by [`state::cast_all`].
     pub fn from_state_dict(sd: &StateDict, dims: ModelDimensions) -> Result<Self> {
-        let sd = state::cast_all(&remap_hf_keys(sd), DType::Float32);
+        let dtype = dims.dtype.clone();
+        let sd = state::cast_all(&remap_hf_keys(sd), dtype);
         let mut model = Self::empty(dims);
         model.load_state_dict(&sd, "").map_err(|e| Error::State { source: e })?;
         Ok(model)

--- a/model/src/whisper/loader.rs
+++ b/model/src/whisper/loader.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use crate::state::{self, HasStateDict, StateDict};
+use svod_dtype::DType;
 
 use super::config::{ModelDimensions, WhisperSize};
 use super::error::{Error, Result};
@@ -14,8 +15,13 @@ use super::model::Whisper;
 
 impl Whisper {
     /// Load from a safetensors state dict.
+    ///
+    /// HuggingFace Transformers checkpoints (`model.safetensors`) store the
+    /// weights in Float16; the compute graph is Float32, so every tensor is
+    /// upcast before loading. Int tensors (e.g. embeddings that are already
+    /// integer) are left untouched by [`state::cast_all`].
     pub fn from_state_dict(sd: &StateDict, dims: ModelDimensions) -> Result<Self> {
-        let sd = remap_hf_keys(sd);
+        let sd = state::cast_all(&remap_hf_keys(sd), DType::Float32);
         let mut model = Self::empty(dims);
         model.load_state_dict(&sd, "").map_err(|e| Error::State { source: e })?;
         Ok(model)

--- a/model/src/whisper/loader.rs
+++ b/model/src/whisper/loader.rs
@@ -15,14 +15,19 @@ use super::model::Whisper;
 impl Whisper {
     /// Load from a safetensors state dict.
     ///
-    /// HuggingFace Transformers checkpoints (`model.safetensors`) store the
-    /// weights in Float16; the compute dtype is `dims.dtype` (Float16 by
-    /// default, settable to Float32 for CPU parity). Weights are cast to
-    /// `dims.dtype` before loading; int tensors (e.g. integer embeddings) are
-    /// left untouched by [`state::cast_all`].
+    /// HuggingFace Transformers checkpoints store weights in Float32. Linear
+    /// and convolution weights are cast to `dims.dtype`, while embeddings and
+    /// LayerNorm affine parameters retain checkpoint precision to match
+    /// OpenAI's mixed-precision forward pass.
     pub fn from_state_dict(sd: &StateDict, dims: ModelDimensions) -> Result<Self> {
         let dtype = dims.dtype.clone();
-        let sd = state::cast_all(&remap_hf_keys(sd), dtype);
+        let remapped = remap_hf_keys(sd);
+        let mut sd = state::cast_all(&remapped, dtype);
+        for (key, tensor) in &remapped {
+            if keeps_checkpoint_dtype(key) {
+                sd.insert(key.clone(), tensor.clone());
+            }
+        }
         let mut model = Self::empty(dims);
         model.load_state_dict(&sd, "").map_err(|e| Error::State { source: e })?;
         Ok(model)
@@ -50,6 +55,15 @@ impl Whisper {
         let repo = format!("openai/whisper-{}", size.name());
         Self::from_hub(&repo, "main", dims)
     }
+}
+
+fn keeps_checkpoint_dtype(key: &str) -> bool {
+    key == "encoder.positional_embedding"
+        || key == "decoder.positional_embedding"
+        || key == "decoder.token_embedding.weight"
+        || key.starts_with("encoder.ln_post.")
+        || key.starts_with("decoder.ln.")
+        || [".attn_ln.", ".cross_attn_ln.", ".mlp_ln."].iter().any(|part| key.contains(part))
 }
 
 /// Remap HuggingFace Transformers keys to the original OpenAI naming

--- a/model/src/whisper/mod.rs
+++ b/model/src/whisper/mod.rs
@@ -37,9 +37,8 @@ pub use attention::{MultiHeadAttention, causal_mask};
 pub use blocks::{Conv1dWeights, LayerNormWeights, LinearWeights, sinusoids};
 pub use config::{ModelDimensions, WhisperSize};
 pub use decode::{
-    DecodeLane, DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, LanguageDetection, WhisperTask,
-    beam_decode_cached, decode_with_fallback_cached, detect_language, greedy_decode_cached, run_batched_decode,
-    split_into_segments,
+    DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, LanguageDetection, WhisperTask, beam_decode_cached,
+    decode_with_fallback_cached, detect_language, greedy_decode_cached, split_into_segments,
 };
 pub use decoder::{DecoderBlock, TextDecoder};
 pub use dtw::{

--- a/model/src/whisper/mod.rs
+++ b/model/src/whisper/mod.rs
@@ -31,6 +31,7 @@ pub mod tokenizer;
 pub mod transcribe;
 
 mod loader;
+mod profile;
 
 pub use aligner::{WhisperAligner, WhisperAlignmentInput};
 pub use attention::{MultiHeadAttention, causal_mask};

--- a/model/src/whisper/mod.rs
+++ b/model/src/whisper/mod.rs
@@ -1,9 +1,9 @@
 //! OpenAI Whisper: encoder-decoder transformer for speech recognition.
 //!
-//! Architecture: Conv-BN frontend → sinusoidal position embeddings → standard
-//! pre-norm transformer encoder; learned-position decoder with self-attention +
-//! cross-attention to encoder output.  Supports DTW word-level alignment via
-//! cross-attention weight extraction.
+//! Architecture: convolutional frontend, sinusoidal encoder positions, and a
+//! pre-norm transformer encoder; the learned-position decoder uses cached
+//! self-attention and cross-attention over encoder features. Selected
+//! cross-attention heads provide DTW word alignment.
 //!
 //! # Quick start
 //!
@@ -14,6 +14,7 @@
 //! let model = Whisper::empty(dims);
 //! ```
 
+pub mod aligner;
 pub mod attention;
 pub mod blocks;
 pub mod config;
@@ -25,27 +26,35 @@ pub mod error;
 pub mod jit;
 pub mod mel;
 pub mod model;
+pub mod plan;
 pub mod tokenizer;
 pub mod transcribe;
 
 mod loader;
 
+pub use aligner::{WhisperAligner, WhisperAlignmentInput};
 pub use attention::{MultiHeadAttention, causal_mask};
 pub use blocks::{Conv1dWeights, LayerNormWeights, LinearWeights, sinusoids};
 pub use config::{ModelDimensions, WhisperSize};
 pub use decode::{
-    DecodeLane, DecodeOptions, DecodeResult, LanguageDetection, beam_decode_cached, decode_with_fallback_cached,
-    detect_language, greedy_decode_cached, greedy_decode_with_alignment, run_batched_decode,
+    DecodeLane, DecodeOptions, DecodeResult, LanguageDetection, WhisperTask, beam_decode_cached,
+    decode_with_fallback_cached, detect_language, greedy_decode_cached, run_batched_decode, split_into_segments,
 };
 pub use decoder::{DecoderBlock, TextDecoder};
-pub use dtw::{WordTiming, dtw, find_alignment_path, median_filter, path_to_word_timings};
+pub use dtw::{
+    WordTiming, dtw, find_alignment_path, find_alignment_path_selected, median_filter, path_to_word_timings,
+};
 pub use encoder::{AudioEncoder, EncoderBlock};
 pub use error::{Error, Result};
-pub use jit::{WhisperDecoderJit, WhisperDecoderStepBatchedJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
+pub use jit::{
+    WhisperAlignmentJit, WhisperAlignmentModel, WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit,
+    WhisperEncoderJit, WhisperPrefillJit,
+};
 pub use mel::WhisperMel;
 pub use model::Whisper;
+pub use plan::WhisperPlan;
 pub use tokenizer::WhisperTokenizer;
-pub use transcribe::{TranscribeError, WhisperTranscriber};
+pub use transcribe::{TranscribeError, WhisperAlignedTranscriber, WhisperRecognizer};
 
 // Re-export audio constants
 pub use config::{

--- a/model/src/whisper/mod.rs
+++ b/model/src/whisper/mod.rs
@@ -34,14 +34,14 @@ pub use attention::{MultiHeadAttention, causal_mask};
 pub use blocks::{Conv1dWeights, LayerNormWeights, LinearWeights, sinusoids};
 pub use config::{ModelDimensions, WhisperSize};
 pub use decode::{
-    DecodeOptions, DecodeResult, LanguageDetection, beam_decode_cached, decode_with_fallback_cached, detect_language,
-    greedy_decode_cached, greedy_decode_with_alignment,
+    DecodeLane, DecodeOptions, DecodeResult, LanguageDetection, beam_decode_cached, decode_with_fallback_cached,
+    detect_language, greedy_decode_cached, greedy_decode_with_alignment, run_batched_decode,
 };
 pub use decoder::{DecoderBlock, TextDecoder};
 pub use dtw::{WordTiming, dtw, find_alignment_path, median_filter, path_to_word_timings};
 pub use encoder::{AudioEncoder, EncoderBlock};
 pub use error::{Error, Result};
-pub use jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
+pub use jit::{WhisperDecoderJit, WhisperDecoderStepBatchedJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 pub use mel::WhisperMel;
 pub use model::Whisper;
 pub use tokenizer::WhisperTokenizer;

--- a/model/src/whisper/mod.rs
+++ b/model/src/whisper/mod.rs
@@ -37,8 +37,9 @@ pub use attention::{MultiHeadAttention, causal_mask};
 pub use blocks::{Conv1dWeights, LayerNormWeights, LinearWeights, sinusoids};
 pub use config::{ModelDimensions, WhisperSize};
 pub use decode::{
-    DecodeLane, DecodeOptions, DecodeResult, LanguageDetection, WhisperTask, beam_decode_cached,
-    decode_with_fallback_cached, detect_language, greedy_decode_cached, run_batched_decode, split_into_segments,
+    DecodeLane, DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, LanguageDetection, WhisperTask,
+    beam_decode_cached, decode_with_fallback_cached, detect_language, greedy_decode_cached, run_batched_decode,
+    split_into_segments,
 };
 pub use decoder::{DecoderBlock, TextDecoder};
 pub use dtw::{

--- a/model/src/whisper/mod.rs
+++ b/model/src/whisper/mod.rs
@@ -37,8 +37,8 @@ pub use attention::{MultiHeadAttention, causal_mask};
 pub use blocks::{Conv1dWeights, LayerNormWeights, LinearWeights, sinusoids};
 pub use config::{ModelDimensions, WhisperSize};
 pub use decode::{
-    DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, LanguageDetection, WhisperTask, beam_decode_cached,
-    decode_with_fallback_cached, detect_language, greedy_decode_cached, split_into_segments,
+    DecodeOptions, DecodeResult, DecodeStrategy, FallbackPolicy, LanguageDetection, WhisperTask, detect_language,
+    split_into_segments,
 };
 pub use decoder::{DecoderBlock, TextDecoder};
 pub use dtw::{

--- a/model/src/whisper/model.rs
+++ b/model/src/whisper/model.rs
@@ -1,5 +1,6 @@
 //! Whisper model composite: encoder + decoder + dimensions.
 
+use svod_dtype::DType;
 use svod_tensor::Tensor;
 
 use crate::state::{self, HasStateDict, StateDict, prefixed};
@@ -46,6 +47,11 @@ impl Whisper {
     /// Project encoder features into packed cross-attention K/V once per window.
     pub fn project_cross_kv(&self, audio_features: &Tensor) -> Result<(Tensor, Tensor)> {
         self.decoder.project_cross_kv(audio_features)
+    }
+
+    /// Dense cross-projection activation/output contract used by cache consumers.
+    pub fn cross_cache_output_dtype(&self) -> Result<DType> {
+        self.decoder.cross_cache_output_dtype()
     }
 
     /// Decode logits using packed cross-attention K/V.

--- a/model/src/whisper/model.rs
+++ b/model/src/whisper/model.rs
@@ -32,14 +32,15 @@ impl Whisper {
         self.decoder.forward(tokens, audio_features, offset)
     }
 
-    /// Teacher-forced alignment pass with a static set of selected heads.
-    pub fn align(
+    /// Teacher-forced alignment using retained packed cross-attention K/V.
+    pub fn align_with_cross_kv(
         &self,
         tokens: &Tensor,
-        audio_features: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
         alignment_heads: &[(usize, usize)],
     ) -> Result<Tensor> {
-        self.decoder.forward_alignment(tokens, audio_features, alignment_heads)
+        self.decoder.forward_alignment(tokens, cross_k, cross_v, alignment_heads)
     }
 
     /// Project encoder features into packed cross-attention K/V once per window.

--- a/model/src/whisper/model.rs
+++ b/model/src/whisper/model.rs
@@ -74,9 +74,9 @@ impl Whisper {
         self_v_cache: &Tensor,
         cross_k: &Tensor,
         cross_v: &Tensor,
-        self_mask: &Tensor,
+        self_key_lens: &Tensor,
     ) -> Result<(Tensor, Tensor, Tensor)> {
-        self.decoder.forward_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask)
+        self.decoder.forward_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_key_lens)
     }
 
     /// Full forward: encode + decode.

--- a/model/src/whisper/model.rs
+++ b/model/src/whisper/model.rs
@@ -1,6 +1,6 @@
 //! Whisper model composite: encoder + decoder + dimensions.
 
-use svod_tensor::{BoundVariable, Tensor};
+use svod_tensor::Tensor;
 
 use crate::state::{self, HasStateDict, StateDict, prefixed};
 
@@ -32,26 +32,35 @@ impl Whisper {
         self.decoder.forward(tokens, audio_features, offset)
     }
 
-    /// Decode with cross-attention weights for DTW alignment.
-    /// Returns `(logits, cross_attn_qk_per_layer)`.
-    pub fn decode_with_alignment(
+    /// Teacher-forced alignment pass with a static set of selected heads.
+    pub fn align(
         &self,
         tokens: &Tensor,
         audio_features: &Tensor,
-        offset: usize,
-    ) -> Result<(Tensor, Vec<Tensor>)> {
-        self.decoder.forward_with_alignment(tokens, audio_features, offset)
+        alignment_heads: &[(usize, usize)],
+    ) -> Result<Tensor> {
+        self.decoder.forward_alignment(tokens, audio_features, alignment_heads)
+    }
+
+    /// Project encoder features into packed cross-attention K/V once per window.
+    pub fn project_cross_kv(&self, audio_features: &Tensor) -> Result<(Tensor, Tensor)> {
+        self.decoder.project_cross_kv(audio_features)
+    }
+
+    /// Decode logits using packed cross-attention K/V.
+    pub fn decode_with_cross_kv(&self, tokens: &Tensor, cross_k: &Tensor, cross_v: &Tensor) -> Result<Tensor> {
+        self.decoder.forward_with_cross_kv(tokens, cross_k, cross_v, 0)
     }
 
     /// Prefill: initial tokens → logits + packed K/V caches.
-    #[allow(clippy::type_complexity)]
     pub fn decode_prefill(
         &self,
         tokens: &Tensor,
-        audio_features: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
         offset: usize,
-    ) -> Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
-        self.decoder.forward_prefill(tokens, audio_features, offset)
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        self.decoder.forward_prefill(tokens, cross_k, cross_v, offset)
     }
 
     /// Single-token step with KV cache → (logits, new_self_k, new_self_v).
@@ -67,25 +76,6 @@ impl Whisper {
         self_mask: &Tensor,
     ) -> Result<(Tensor, Tensor, Tensor)> {
         self.decoder.forward_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask)
-    }
-
-    /// Symbolic-batch single-token step for continuous batching. `b` is a
-    /// JIT variable; the compiled plan is rebound to the live lane count at
-    /// execute time. See [`TextDecoder::forward_step_batched`].
-    #[allow(clippy::too_many_arguments)]
-    pub fn decode_step_batched(
-        &self,
-        token: &Tensor,
-        pos_emb: &Tensor,
-        self_k_cache: &Tensor,
-        self_v_cache: &Tensor,
-        cross_k: &Tensor,
-        cross_v: &Tensor,
-        self_mask: &Tensor,
-        b: &BoundVariable,
-    ) -> Result<(Tensor, Tensor, Tensor)> {
-        self.decoder
-            .forward_step_batched(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask, b)
     }
 
     /// Full forward: encode + decode.

--- a/model/src/whisper/model.rs
+++ b/model/src/whisper/model.rs
@@ -1,6 +1,5 @@
 //! Whisper model composite: encoder + decoder + dimensions.
 
-use svod_dtype::DType;
 use svod_tensor::Tensor;
 
 use crate::state::{self, HasStateDict, StateDict, prefixed};
@@ -47,11 +46,6 @@ impl Whisper {
     /// Project encoder features into packed cross-attention K/V once per window.
     pub fn project_cross_kv(&self, audio_features: &Tensor) -> Result<(Tensor, Tensor)> {
         self.decoder.project_cross_kv(audio_features)
-    }
-
-    /// Dense cross-projection activation/output contract used by cache consumers.
-    pub fn cross_cache_output_dtype(&self) -> Result<DType> {
-        self.decoder.cross_cache_output_dtype()
     }
 
     /// Decode logits using packed cross-attention K/V.

--- a/model/src/whisper/model.rs
+++ b/model/src/whisper/model.rs
@@ -1,6 +1,6 @@
 //! Whisper model composite: encoder + decoder + dimensions.
 
-use svod_tensor::Tensor;
+use svod_tensor::{BoundVariable, Tensor};
 
 use crate::state::{self, HasStateDict, StateDict, prefixed};
 
@@ -67,6 +67,25 @@ impl Whisper {
         self_mask: &Tensor,
     ) -> Result<(Tensor, Tensor, Tensor)> {
         self.decoder.forward_step(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask)
+    }
+
+    /// Symbolic-batch single-token step for continuous batching. `b` is a
+    /// JIT variable; the compiled plan is rebound to the live lane count at
+    /// execute time. See [`TextDecoder::forward_step_batched`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn decode_step_batched(
+        &self,
+        token: &Tensor,
+        pos_emb: &Tensor,
+        self_k_cache: &Tensor,
+        self_v_cache: &Tensor,
+        cross_k: &Tensor,
+        cross_v: &Tensor,
+        self_mask: &Tensor,
+        b: &BoundVariable,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        self.decoder
+            .forward_step_batched(token, pos_emb, self_k_cache, self_v_cache, cross_k, cross_v, self_mask, b)
     }
 
     /// Full forward: encode + decode.

--- a/model/src/whisper/plan.rs
+++ b/model/src/whisper/plan.rs
@@ -1,0 +1,48 @@
+//! Construction-time geometry for prepared Whisper graphs.
+
+use super::config::{ModelDimensions, N_AUDIO_CTX, N_TEXT_CTX, WhisperSize};
+
+/// Static capacities compiled into a Whisper pipeline. Changing this plan
+/// requires constructing a new pipeline; requests never alter graph geometry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WhisperPlan {
+    /// Windows encoded by one encoder dispatch.
+    pub encoder_batch: usize,
+    /// Stable rows compiled into the cached decoder-step graph.
+    pub decoder_slots: usize,
+    /// Windows aligned by one teacher-forced alignment dispatch.
+    pub alignment_batch: usize,
+}
+
+impl WhisperPlan {
+    /// Derive recognition capacities from the model geometry and memory budget.
+    pub fn for_recognizer(dims: &ModelDimensions) -> Self {
+        const ENCODER_SCORES_BUDGET: usize = 512 * 1024 * 1024;
+        let encoder_scores = dims.n_audio_head * N_AUDIO_CTX * N_AUDIO_CTX * std::mem::size_of::<f32>();
+        let encoder_batch = (ENCODER_SCORES_BUDGET / encoder_scores).clamp(1, 8);
+        Self { encoder_batch, decoder_slots: encoder_batch, alignment_batch: 1 }
+    }
+
+    /// Derive recognition and alignment capacities for a model size.
+    pub fn for_model(dims: &ModelDimensions, size: WhisperSize) -> Self {
+        const ALIGNMENT_OUTPUT_BUDGET: usize = 256 * 1024 * 1024;
+        let mut plan = Self::for_recognizer(dims);
+        let alignment_output = size.alignment_heads().len() * N_TEXT_CTX * N_AUDIO_CTX * std::mem::size_of::<f32>();
+        plan.alignment_batch = (ALIGNMENT_OUTPUT_BUDGET / alignment_output).clamp(1, plan.encoder_batch);
+        plan
+    }
+
+    /// Validate that every compiled capacity is nonzero.
+    pub fn validate(&self) -> std::result::Result<(), &'static str> {
+        if self.encoder_batch == 0 {
+            return Err("encoder_batch must be non-zero");
+        }
+        if self.decoder_slots == 0 {
+            return Err("decoder_slots must be non-zero");
+        }
+        if self.alignment_batch == 0 {
+            return Err("alignment_batch must be non-zero");
+        }
+        Ok(())
+    }
+}

--- a/model/src/whisper/plan.rs
+++ b/model/src/whisper/plan.rs
@@ -20,7 +20,9 @@ impl WhisperPlan {
         const ENCODER_SCORES_BUDGET: usize = 512 * 1024 * 1024;
         let encoder_scores = dims.n_audio_head * N_AUDIO_CTX * N_AUDIO_CTX * std::mem::size_of::<f32>();
         let encoder_batch = (ENCODER_SCORES_BUDGET / encoder_scores).clamp(1, 8);
-        Self { encoder_batch, decoder_slots: encoder_batch, alignment_batch: 1 }
+        // Five rows keep the default beam strategy constructible even when the
+        // encoder memory budget selects a smaller batch.
+        Self { encoder_batch, decoder_slots: encoder_batch.max(5), alignment_batch: 1 }
     }
 
     /// Derive recognition and alignment capacities for a model size.

--- a/model/src/whisper/profile.rs
+++ b/model/src/whisper/profile.rs
@@ -1,0 +1,167 @@
+//! Internal Whisper copy profiling.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use snafu::ResultExt;
+use svod_device::Buffer;
+use svod_runtime::StageProfile;
+
+use super::error::{DeviceSnafu, Result};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CopyStats {
+    pub(crate) ops: usize,
+    pub(crate) bytes: usize,
+    pub(crate) wall: Duration,
+}
+
+impl CopyStats {
+    pub(crate) fn add(&mut self, ops: usize, bytes: usize, wall: Duration) {
+        self.ops = self.ops.saturating_add(ops);
+        self.bytes = self.bytes.saturating_add(bytes);
+        self.wall = self.wall.saturating_add(wall);
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.add(other.ops, other.bytes, other.wall);
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct CopyCategory {
+    total: CopyStats,
+    breakdown: BTreeMap<&'static str, CopyStats>,
+}
+
+impl CopyCategory {
+    fn record(&mut self, name: &'static str, ops: usize, bytes: usize, wall: Duration) {
+        self.total.add(ops, bytes, wall);
+        self.breakdown.entry(name).or_default().add(ops, bytes, wall);
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.total.merge(other.total);
+        for (name, stats) in other.breakdown {
+            self.breakdown.entry(name).or_default().merge(stats);
+        }
+    }
+
+    fn stage(&self, name: &str) -> Option<StageProfile> {
+        (self.total.bytes != 0).then(|| {
+            let mut stage = StageProfile::host(name, self.total.wall);
+            stage.meta.insert("ops".into(), self.total.ops.to_string());
+            stage.meta.insert("bytes".into(), self.total.bytes.to_string());
+            let gbps = if self.total.wall.is_zero() {
+                0.0
+            } else {
+                self.total.bytes as f64 / self.total.wall.as_secs_f64() / 1e9
+            };
+            stage.meta.insert("effective_gbps".into(), format!("{gbps:.3}"));
+            let semantics = match name {
+                "copy_d2d" => {
+                    "device synchronized immediately before and after each transfer group; host wall, not hardware DMA timestamps"
+                }
+                "copy_h2d" => {
+                    "prior device work fenced before host-visible writes; synchronized host wall, not hardware DMA timestamps"
+                }
+                _ => {
+                    "producer work fenced before host-visible reads; synchronized host copy wall, not hardware DMA timestamps"
+                }
+            };
+            stage.meta.insert("timing_semantics".into(), semantics.into());
+            for (breakdown, stats) in &self.breakdown {
+                stage.meta.insert(format!("{breakdown}_ops"), stats.ops.to_string());
+                stage.meta.insert(format!("{breakdown}_bytes"), stats.bytes.to_string());
+                stage.meta.insert(format!("{breakdown}_wall_ms"), format!("{:.3}", stats.wall.as_secs_f64() * 1e3));
+                let gbps = if stats.wall.is_zero() {
+                    0.0
+                } else {
+                    stats.bytes as f64 / stats.wall.as_secs_f64() / 1e9
+                };
+                stage.meta.insert(format!("{breakdown}_effective_gbps"), format!("{gbps:.3}"));
+            }
+            stage
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CopyProfile {
+    h2d: CopyCategory,
+    d2d: CopyCategory,
+    d2h: CopyCategory,
+}
+
+impl CopyProfile {
+    pub(crate) fn h2d(&mut self, name: &'static str, ops: usize, bytes: usize, wall: Duration) {
+        self.h2d.record(name, ops, bytes, wall);
+    }
+
+    pub(crate) fn d2d(&mut self, name: &'static str, ops: usize, bytes: usize, wall: Duration) {
+        self.d2d.record(name, ops, bytes, wall);
+    }
+
+    pub(crate) fn d2h(&mut self, name: &'static str, ops: usize, bytes: usize, wall: Duration) {
+        self.d2h.record(name, ops, bytes, wall);
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.h2d.merge(other.h2d);
+        self.d2d.merge(other.d2d);
+        self.d2h.merge(other.d2h);
+    }
+
+    pub(crate) fn stages(&self) -> impl Iterator<Item = StageProfile> + '_ {
+        [self.h2d.stage("copy_h2d"), self.d2d.stage("copy_d2d"), self.d2h.stage("copy_d2h")].into_iter().flatten()
+    }
+}
+
+/// Fence before starting so prior graph work is excluded, then fence after the
+/// final transfer. This measures synchronized group wall, not SDMA timestamps.
+pub(crate) fn timed_d2d<T>(enabled: bool, fence: &Buffer, work: impl FnOnce() -> Result<T>) -> Result<(T, Duration)> {
+    if !enabled {
+        return work().map(|value| (value, Duration::ZERO));
+    }
+    fence.synchronize().context(DeviceSnafu)?;
+    let started = Instant::now();
+    let value = work()?;
+    fence.synchronize().context(DeviceSnafu)?;
+    Ok((value, started.elapsed()))
+}
+
+/// Drain prior device work before timing a host-visible read or write. Without
+/// this fence, the mapping's implicit synchronization is incorrectly charged
+/// to the copy instead of the graph that produced the buffer.
+pub(crate) fn begin_host_copy(enabled: bool, buffer: &Buffer) -> Result<Option<Instant>> {
+    if !enabled {
+        return Ok(None);
+    }
+    buffer.synchronize().context(DeviceSnafu)?;
+    Ok(Some(Instant::now()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_stats_merge_saturates() {
+        let mut stats = CopyStats { ops: usize::MAX, bytes: usize::MAX - 1, wall: Duration::MAX };
+        stats.merge(CopyStats { ops: 1, bytes: 4, wall: Duration::from_nanos(1) });
+        assert_eq!(stats, CopyStats { ops: usize::MAX, bytes: usize::MAX, wall: Duration::MAX });
+    }
+
+    #[test]
+    fn copy_stage_formats_totals_and_breakdown() {
+        let mut profile = CopyProfile::default();
+        profile.d2d("cache_append", 2, 1024, Duration::from_micros(2));
+        let stage = profile.stages().next().unwrap();
+        assert_eq!(stage.name, "copy_d2d");
+        assert_eq!(stage.meta["ops"], "2");
+        assert_eq!(stage.meta["bytes"], "1024");
+        assert_eq!(stage.meta["effective_gbps"], "0.512");
+        assert_eq!(stage.meta["cache_append_bytes"], "1024");
+        assert!(stage.meta["timing_semantics"].contains("not hardware DMA timestamps"));
+    }
+}

--- a/model/src/whisper/profile.rs
+++ b/model/src/whisper/profile.rs
@@ -5,9 +5,47 @@ use std::time::{Duration, Instant};
 
 use snafu::ResultExt;
 use svod_device::Buffer;
-use svod_runtime::StageProfile;
+use svod_runtime::{KernelProfile, StageProfile};
 
 use super::error::{DeviceSnafu, Result};
+
+#[derive(Debug, Default)]
+pub(crate) struct GraphProfile {
+    pub(crate) wall: Duration,
+    pub(crate) executions: usize,
+    pub(crate) kernels: Vec<KernelProfile>,
+}
+
+impl GraphProfile {
+    pub(crate) fn record(&mut self, wall: Duration, kernels: Vec<KernelProfile>) {
+        self.wall = self.wall.saturating_add(wall);
+        self.executions = self.executions.saturating_add(1);
+        self.kernels.extend(kernels);
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.wall = self.wall.saturating_add(other.wall);
+        self.executions = self.executions.saturating_add(other.executions);
+        self.kernels.extend(other.kernels);
+    }
+
+    pub(crate) fn stage(self, name: &str) -> StageProfile {
+        let kernel_dispatches = self.kernels.len();
+        let average_wall_ms =
+            if self.executions == 0 { 0.0 } else { self.wall.as_secs_f64() * 1e3 / self.executions as f64 };
+        let mut stage = StageProfile::gpu(name, self.wall, self.kernels);
+        stage.meta.insert("executions".into(), self.executions.to_string());
+        stage.meta.insert("kernel_dispatches".into(), kernel_dispatches.to_string());
+        stage.meta.insert("accumulated_wall_ms".into(), format!("{:.3}", self.wall.as_secs_f64() * 1e3));
+        stage.meta.insert("average_execution_wall_ms".into(), format!("{average_wall_ms:.3}"));
+        stage.meta.insert(
+            "timing_semantics".into(),
+            "accumulated host wall per execution from profiled submission through explicit output synchronization"
+                .into(),
+        );
+        stage
+    }
+}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct CopyStats {
@@ -163,5 +201,22 @@ mod tests {
         assert_eq!(stage.meta["effective_gbps"], "0.512");
         assert_eq!(stage.meta["cache_append_bytes"], "1024");
         assert!(stage.meta["timing_semantics"].contains("not hardware DMA timestamps"));
+    }
+
+    #[test]
+    fn graph_profile_accumulates_execution_wall_and_metadata() {
+        let mut profile = GraphProfile::default();
+        profile.record(Duration::from_millis(2), Vec::new());
+        let mut other = GraphProfile::default();
+        other.record(Duration::from_millis(3), Vec::new());
+        profile.merge(other);
+
+        let stage = profile.stage("graph");
+        assert_eq!(stage.wall, Duration::from_millis(5));
+        assert_eq!(stage.meta["executions"], "2");
+        assert_eq!(stage.meta["kernel_dispatches"], "0");
+        assert_eq!(stage.meta["accumulated_wall_ms"], "5.000");
+        assert_eq!(stage.meta["average_execution_wall_ms"], "2.500");
+        assert!(stage.meta["timing_semantics"].contains("output synchronization"));
     }
 }

--- a/model/src/whisper/tokenizer.rs
+++ b/model/src/whisper/tokenizer.rs
@@ -125,8 +125,6 @@ pub struct WhisperTokenizer {
     bpe: CoreBPE,
     /// Special token strings → ids.
     special_tokens: HashMap<String, u32>,
-    /// Base vocabulary size (before special tokens).
-    n_vocab_base: usize,
     /// Whether this is a multilingual model.
     pub multilingual: bool,
     /// Number of languages supported.
@@ -169,7 +167,6 @@ impl WhisperTokenizer {
         Ok(Self {
             bpe,
             special_tokens,
-            n_vocab_base,
             multilingual,
             num_languages,
             language: language.map(|s| s.to_string()),
@@ -235,7 +232,7 @@ impl WhisperTokenizer {
         self.special_tokens["<|0.00|>"]
     }
 
-    /// SOT sequence: [sot, [language], [task]]
+    /// SOT sequence: `[sot, language, task]`.
     pub fn sot_sequence(&self) -> Vec<u32> {
         let mut seq = vec![self.sot()];
         if let Some(lang) = &self.language
@@ -323,54 +320,56 @@ impl WhisperTokenizer {
     /// Split tokens into words and their constituent token lists.
     /// Uses CoreBPE's `decode_bytes` for accurate per-token byte mapping.
     pub fn split_to_word_tokens(&self, tokens: &[u32]) -> (Vec<String>, Vec<Vec<u32>>) {
-        let ts_begin = self.timestamp_begin();
-        let eot = self.eot();
+        self.split_to_word_tokens_for_language(tokens, self.language.as_deref())
+    }
+
+    /// OpenAI-compatible word grouping for a resolved language. Languages
+    /// without reliable spaces split at valid Unicode boundaries instead.
+    pub fn split_to_word_tokens_for_language(
+        &self,
+        tokens: &[u32],
+        language: Option<&str>,
+    ) -> (Vec<String>, Vec<Vec<u32>>) {
+        let (subwords, subword_tokens) = self.split_tokens_on_unicode(tokens);
+        if matches!(language, Some("zh" | "ja" | "th" | "lo" | "my" | "yue")) {
+            return (subwords, subword_tokens);
+        }
 
         let mut words: Vec<String> = Vec::new();
         let mut word_tokens: Vec<Vec<u32>> = Vec::new();
-        let mut current_chars = String::new();
-        let mut current_tokens = Vec::new();
-
-        for &tok in tokens {
-            current_tokens.push(tok);
-
-            // Timestamp / EOT token: commit current word, push special as its own
-            if tok >= ts_begin || tok == eot {
-                if !current_chars.is_empty() {
-                    words.push(std::mem::take(&mut current_chars));
-                    word_tokens.push(current_tokens[..current_tokens.len() - 1].to_vec());
-                }
-                if tok < eot {
-                    words.push(format!("<|{:.2}|>", (tok - ts_begin) as f32 / super::config::TOKENS_PER_SECOND));
-                } else {
-                    words.push("<|endoftext|>".to_string());
-                }
-                word_tokens.push(vec![tok]);
-                current_tokens.clear();
-                continue;
-            }
-
-            // Decode this single token to check for word boundaries
-            if tok < self.n_vocab_base as u32
-                && let Ok(decoded) = self.bpe.decode(&[tok])
-            {
-                let starts_new = decoded.starts_with(' ') && !current_chars.is_empty();
-                if starts_new {
-                    words.push(std::mem::take(&mut current_chars));
-                    word_tokens.push(current_tokens[..current_tokens.len() - 1].to_vec());
-                    current_tokens.clear();
-                    current_tokens.push(tok);
-                    current_chars.push_str(&decoded[1..]);
-                } else {
-                    current_chars.push_str(&decoded);
-                }
+        for (subword, tokens) in subwords.into_iter().zip(subword_tokens) {
+            let special = tokens.first().is_some_and(|&token| token >= self.eot());
+            let follows_special =
+                word_tokens.last().and_then(|tokens| tokens.first()).is_some_and(|&token| token >= self.eot());
+            let punctuation =
+                !subword.trim().is_empty() && "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".contains(subword.trim());
+            if words.is_empty() || special || follows_special || subword.starts_with(' ') || punctuation {
+                words.push(subword);
+                word_tokens.push(tokens);
+            } else {
+                words.last_mut().unwrap().push_str(&subword);
+                word_tokens.last_mut().unwrap().extend(tokens);
             }
         }
-        if !current_chars.is_empty() {
-            words.push(std::mem::take(&mut current_chars));
-            word_tokens.push(std::mem::take(&mut current_tokens));
-        }
+        (words, word_tokens)
+    }
 
+    fn split_tokens_on_unicode(&self, tokens: &[u32]) -> (Vec<String>, Vec<Vec<u32>>) {
+        let mut words = Vec::new();
+        let mut word_tokens = Vec::new();
+        let mut current = Vec::new();
+        for &token in tokens {
+            current.push(token);
+            if let Ok(decoded) = self.bpe.decode(&current) {
+                words.push(decoded);
+                word_tokens.push(std::mem::take(&mut current));
+            }
+        }
+        if !current.is_empty() {
+            let decoded = self.bpe.decode(&current).unwrap_or_default();
+            words.push(decoded);
+            word_tokens.push(current);
+        }
         (words, word_tokens)
     }
 

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -16,8 +16,8 @@ use svod_tensor::PrepareConfig;
 use crate::jit::InputSpec;
 
 use super::config::{N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, SAMPLE_RATE};
-use super::decode::DecodeOptions;
-use super::jit::{WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
+use super::decode::{DecodeLane, DecodeOptions, run_batched_decode};
+use super::jit::{WhisperDecoderJit, WhisperDecoderStepBatchedJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 use super::mel::WhisperMel;
 use super::model::Whisper;
 use super::tokenizer::WhisperTokenizer;
@@ -59,6 +59,10 @@ pub struct WhisperTranscriber {
     decoder_jit: WhisperDecoderJit,
     prefill_jit: WhisperPrefillJit,
     step_jits: rustc_hash::FxHashMap<usize, WhisperDecoderStepJit>,
+    /// Continuous-batching step JIT: one plan compiled at `max_lanes`, rebound
+    /// to the live lane count each dispatch via `execute_with_vars`. Substrate
+    /// for [`Self::transcribe_windows_batched`] and the soroka scheduler.
+    batched_step_jit: WhisperDecoderStepBatchedJit,
     tokenizer: WhisperTokenizer,
     options: DecodeOptions,
     alignment_heads: Vec<(usize, usize)>,
@@ -68,6 +72,8 @@ pub struct WhisperTranscriber {
     n_text_ctx: usize,
     n_text_head: usize,
     max_batch: usize,
+    /// Max concurrent decode lanes in the batched step JIT.
+    max_lanes: usize,
     pos_embedding: Vec<f32>,
 }
 
@@ -159,6 +165,24 @@ impl WhisperTranscriber {
             step_jits.insert(bs, sj);
         }
 
+        // Batched step JIT: one plan at max_lanes, rebound per dispatch.
+        // Same shapes as the per-beam step JITs but with the batch dimension
+        // symbolic (`b`), compiled once for continuous batching.
+        let max_lanes = max_batch; // reuse the encoder's memory-budgeted cap
+        let mut batched_step_jit = WhisperDecoderStepBatchedJit::new(model.clone()).with_b_bound(max_lanes);
+        batched_step_jit
+            .prepare_with_config(
+                InputSpec::i32(&[max_lanes, 1]),
+                InputSpec::f32(&[max_lanes, 1, n_text_state]),
+                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]),
+                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]),
+                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]),
+                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]),
+                InputSpec::f32(&[max_lanes, 1, 1, N_TEXT_CTX + 1]),
+                &prepare_config,
+            )
+            .context(JitSnafu)?;
+
         // Read positional embedding eagerly (static weight, reused every window)
         let mut pe = model.decoder.positional_embedding.clone();
         pe.realize().map_err(|e| TranscribeError::Tensor { source: Box::new(e) })?;
@@ -176,6 +200,7 @@ impl WhisperTranscriber {
             decoder_jit,
             prefill_jit,
             step_jits,
+            batched_step_jit,
             tokenizer,
             options,
             alignment_heads,
@@ -185,8 +210,156 @@ impl WhisperTranscriber {
             n_text_ctx,
             n_text_head,
             max_batch,
+            max_lanes,
             pos_embedding,
         })
+    }
+
+    /// Override the decode language (`None` ⇒ auto-detect) for subsequent
+    /// [`Transcriber::transcribe_windows`] calls. Lets a reusable transcriber
+    /// serve requests with differing languages without rebuilding the JITs.
+    pub fn set_language(&mut self, language: Option<String>) {
+        self.options.language = language;
+    }
+
+    /// Max concurrent decode lanes the batched step JIT was compiled for.
+    /// The scheduler treats this as the GPU concurrency bound.
+    pub fn max_lanes(&self) -> usize {
+        self.max_lanes
+    }
+
+    /// Batched decode path: all `windows` are decoded together via a
+    /// step-locked loop over the single `batched_step_jit` (one dispatch per
+    /// token step across all active lanes). This is the continuous-batching
+    /// entry point — throughput-oriented, replacing the per-window serial
+    /// decode of [`Transcriber::transcribe_windows`].
+    ///
+    /// Encoder + prefill still run per-window (the encoder is already
+    /// batched within `max_batch`; prefill is a single 4-token forward).
+    /// Temperature fallback is disabled (`temperature_inc = 0`), so the
+    /// schedule collapses to a single greedy pass per window.
+    pub fn transcribe_windows_batched(
+        &mut self,
+        windows: &[&[f32]],
+    ) -> Result<Vec<Transcript>, TranscribeError> {
+        if windows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let n_mels = self.n_mels;
+        let d = self.n_audio_state;
+        let mel_stride = n_mels * N_FRAMES;
+        let item_stride = N_AUDIO_CTX * d;
+        let max_batch = self.max_batch;
+        let n_vocab = self.n_vocab;
+        let n_text_ctx = self.n_text_ctx;
+
+        // Batched-path options: disable temperature fallback so the schedule
+        // collapses to a single greedy pass. Lane state is step-locked; no
+        // async restarts.
+        let mut batched_opts = self.options.clone();
+        batched_opts.temperature_inc = 0.0;
+        batched_opts.beam_size = None; // greedy-only in the batched path
+
+        let mut transcripts = Vec::with_capacity(windows.len());
+        let mut lanes: Vec<(DecodeLane, DecodeOptions)> = Vec::with_capacity(windows.len());
+
+        // Encode + prefill in encoder-sized batches, building one DecodeLane
+        // per window. The encoder already handles up to max_batch windows per
+        // dispatch; prefill runs per-window on the resulting audio features.
+        for batch_start in (0..windows.len()).step_by(max_batch) {
+            let b = (windows.len() - batch_start).min(max_batch);
+
+            // ── Mel: compute + pack into [b, n_mels, N_FRAMES] ──────────
+            let batch_mels: Vec<Vec<f32>> =
+                (0..b).map(|bi| self.compute_mel(windows[batch_start + bi])).collect();
+            {
+                let mel_buf = self.encoder_jit.mel_mut().context(JitSnafu)?;
+                let mut packed = vec![0f32; max_batch * mel_stride];
+                for bi in 0..b {
+                    packed[bi * mel_stride..(bi + 1) * mel_stride].copy_from_slice(&batch_mels[bi][..mel_stride]);
+                }
+                let dst = mel_buf.as_host_bytes_mut().context(DeviceSnafu)?;
+                let src_bytes: &[u8] = bytemuck::cast_slice(&packed);
+                dst[..src_bytes.len()].copy_from_slice(src_bytes);
+            }
+
+            // ── Encode: one dispatch for b windows ───────────────────────
+            self.encoder_jit.execute().context(JitSnafu)?;
+            let out_buf = self.encoder_jit.output().context(JitSnafu)?;
+            let mut raw = vec![0f32; b * item_stride];
+            out_buf.copyout_prefix(bytemuck::cast_slice_mut(&mut raw)).context(DeviceSnafu)?;
+
+            // ── Prefill: per-window, build a DecodeLane ──────────────────
+            for bi in 0..b {
+                let base = bi * item_stride;
+                // Resolve language for this window (auto-detect if unset).
+                let mut lane_opts = batched_opts.clone();
+                if lane_opts.language.is_none() {
+                    // Load this window's audio features into the uncached
+                    // decoder JIT for language detection.
+                    {
+                        let buf = self.decoder_jit.audio_features_mut().context(JitSnafu)?;
+                        let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
+                        let src_bytes: &[u8] = bytemuck::cast_slice(&raw[base..base + item_stride]);
+                        dst[..src_bytes.len()].copy_from_slice(src_bytes);
+                    }
+                    let detection = super::decode::detect_language(
+                        &mut self.decoder_jit,
+                        n_text_ctx,
+                        n_vocab,
+                        &self.tokenizer,
+                    )
+                    .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+                    lane_opts.language = Some(detection.language);
+                }
+
+                // Load this window's audio features into prefill JIT.
+                {
+                    let buf = self.prefill_jit.audio_features_mut().context(JitSnafu)?;
+                    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
+                    let src_bytes: &[u8] = bytemuck::cast_slice(&raw[base..base + item_stride]);
+                    dst[..src_bytes.len()].copy_from_slice(src_bytes);
+                }
+
+                let lane = DecodeLane::prefill(
+                    &mut self.prefill_jit,
+                    &self.tokenizer,
+                    &lane_opts,
+                    n_text_ctx,
+                    n_vocab,
+                    &self.pos_embedding,
+                    self.n_audio_state,
+                )
+                .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+
+                lanes.push((lane, lane_opts));
+            }
+        }
+
+        // ── Batched step-locked decode ───────────────────────────────────
+        // Run all lanes together: one JIT dispatch per token step, rebound
+        // to the active lane count. Lanes drop out on EOT.
+        let mut lane_states: Vec<DecodeLane> = lanes.into_iter().map(|(l, _)| l).collect();
+        run_batched_decode(
+            &mut lane_states,
+            &mut self.batched_step_jit,
+            &self.tokenizer,
+            &batched_opts,
+            n_text_ctx,
+            n_vocab,
+        )
+        .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+
+        // ── Collect transcripts ──────────────────────────────────────────
+        for lane in lane_states {
+            let result = lane
+                .finish(&self.tokenizer, &batched_opts)
+                .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+            transcripts.push(Transcript { text: result.text, words: Vec::new(), language: result.language });
+        }
+
+        Ok(transcripts)
     }
 
     /// Compute mel spectrogram for a window, padded/trimmed to N_FRAMES.
@@ -394,7 +567,7 @@ impl Transcriber for WhisperTranscriber {
                     Vec::new()
                 };
 
-                transcripts.push(Transcript { text: result.text, words });
+                transcripts.push(Transcript { text: result.text, words, language: result.language });
             }
         }
 

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -451,8 +451,8 @@ impl WhisperRecognizer {
             let mut decode_options = Vec::with_capacity(b);
 
             // Cross projection and token prefill remain per-window. Their
-            // immutable host seeds are retained until the shared scheduler
-            // accepts a primary or fallback attempt.
+            // immutable device-local seeds are retained until the shared
+            // scheduler accepts a primary or fallback attempt.
             for bi in 0..b {
                 let base = bi * item_stride;
 

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -16,7 +16,7 @@ use crate::jit::InputSpec;
 
 use super::aligner::{WhisperAligner, WhisperAlignmentInput};
 use super::config::{N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, SAMPLE_RATE};
-use super::decode::{DecodeLane, DecodeOptions, run_batched_decode};
+use super::decode::{DecodeLane, DecodeOptions, DecodeStrategy, run_batched_decode};
 use super::jit::{WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 use super::mel::WhisperMel;
 use super::model::Whisper;
@@ -102,6 +102,9 @@ impl WhisperRecognizer {
         plan.validate().map_err(|message| TranscribeError::Model {
             source: Box::new(super::error::Error::Decode { msg: message.to_string() }),
         })?;
+        options.validate().map_err(|message| TranscribeError::Model {
+            source: Box::new(super::error::Error::Decode { msg: message.to_string() }),
+        })?;
         let n_mels = model.dims.n_mels;
         let n_audio_state = model.dims.n_audio_state;
         let n_vocab = model.dims.n_vocab;
@@ -165,16 +168,23 @@ impl WhisperRecognizer {
             )
             .context(JitSnafu)?;
 
-        // Step JITs: one per beam_size needed (beam_size from options + 1 for greedy).
-        // Compiled once at construction, reused every step.
+        // Prepare only the concrete row counts required by the primary strategy
+        // and optional sampling fallback.
         let n_text_head_local = n_text_head;
         let mut step_jits: rustc_hash::FxHashMap<usize, WhisperDecoderStepJit> = rustc_hash::FxHashMap::default();
 
         let beam_sizes: std::collections::HashSet<usize> = {
             let mut s = std::collections::HashSet::new();
-            s.insert(1); // greedy (always needed for temperature fallback)
-            if let Some(bs) = options.beam_size {
-                s.insert(bs);
+            match options.strategy {
+                DecodeStrategy::Beam { size } => {
+                    s.insert(size);
+                }
+                DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => {
+                    s.insert(1);
+                }
+            }
+            if options.fallback.is_some() {
+                s.insert(1);
             }
             s
         };
@@ -282,8 +292,7 @@ impl WhisperRecognizer {
     ///
     /// Encoder + prefill still run per-window (the encoder is already
     /// batched within `max_batch`; prefill is a single 4-token forward).
-    /// Temperature fallback is disabled (`temperature_inc = 0`), so the
-    /// schedule collapses to a single greedy pass per window.
+    /// Fallback is disabled, so the schedule is one greedy pass per window.
     fn recognize_windows_batched_greedy(
         &mut self,
         windows: &[&[f32]],
@@ -300,12 +309,10 @@ impl WhisperRecognizer {
         let n_vocab = self.n_vocab;
         let n_text_ctx = self.n_text_ctx;
 
-        // Batched-path options: disable temperature fallback so the schedule
-        // collapses to a single greedy pass. Lane state is step-locked; no
-        // async restarts.
+        // The fixed-slot API is explicitly greedy and has no retry attempts.
         let mut batched_opts = self.options.clone();
-        batched_opts.temperature_inc = 0.0;
-        batched_opts.beam_size = None; // greedy-only in the batched path
+        batched_opts.strategy = DecodeStrategy::Greedy;
+        batched_opts.fallback = None;
 
         let mut recognized = Vec::with_capacity(windows.len());
         let mut lanes: Vec<(DecodeLane, DecodeOptions)> = Vec::with_capacity(windows.len());

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -292,10 +292,14 @@ impl Transcriber for WhisperRecognizer {
         windows: &[&[f32]],
         profile: bool,
     ) -> Result<(Vec<Transcript>, Option<RunProfile>), Self::Error> {
-        let (recognized, mut profile_result, copies) = self.recognize_windows(windows, profile)?;
-        let transcripts = recognized
-            .into_iter()
-            .map(|recognized| {
+        let mut transcripts = Vec::with_capacity(windows.len());
+        let mut profile_result = profile.then(RunProfile::default);
+        // Recognized windows own device-resident cross K/V snapshots. Consume
+        // them one encoder batch at a time instead of retaining one pair for
+        // every window in a long recording.
+        for batch in bounded_window_batches(windows, self.max_batch) {
+            let (recognized, mut batch_profile, copies) = self.recognize_windows(batch, profile)?;
+            transcripts.extend(recognized.into_iter().map(|recognized| {
                 let segments = super::decode::split_into_segments(
                     &recognized.result.tokens,
                     &self.tokenizer,
@@ -307,11 +311,14 @@ impl Transcriber for WhisperRecognizer {
                     segments,
                     language: recognized.result.language,
                 }
-            })
-            .collect();
-        if let Some(profile) = &mut profile_result {
-            for stage in copies.stages() {
-                profile.push(stage);
+            }));
+            if let Some(batch_profile) = &mut batch_profile {
+                for stage in copies.stages() {
+                    batch_profile.push(stage);
+                }
+            }
+            if let (Some(profile_result), Some(batch_profile)) = (&mut profile_result, batch_profile) {
+                profile_result.merge(batch_profile);
             }
         }
         Ok((transcripts, profile_result))
@@ -417,17 +424,29 @@ impl Transcriber for WhisperAlignedTranscriber {
         windows: &[&[f32]],
         profile: bool,
     ) -> Result<(Vec<Transcript>, Option<RunProfile>), Self::Error> {
-        let (recognized, mut profile_result, mut copies) = self.recognizer.recognize_windows(windows, profile)?;
-        let (transcripts, alignment) = self.align_recognized(recognized, profile, &mut copies)?;
-        if let Some(profile) = &mut profile_result {
-            profile.push(alignment.graph.stage("alignment_graph"));
-            profile.push(StageProfile::host("alignment_cpu_dtw", alignment.cpu_dtw_wall));
-            for stage in copies.stages() {
-                profile.push(stage);
+        let mut transcripts = Vec::with_capacity(windows.len());
+        let mut profile_result = profile.then(RunProfile::default);
+        for batch in bounded_window_batches(windows, self.recognizer.max_batch) {
+            let (recognized, mut batch_profile, mut copies) = self.recognizer.recognize_windows(batch, profile)?;
+            let (batch_transcripts, alignment) = self.align_recognized(recognized, profile, &mut copies)?;
+            transcripts.extend(batch_transcripts);
+            if let Some(batch_profile) = &mut batch_profile {
+                batch_profile.push(alignment.graph.stage("alignment_graph"));
+                batch_profile.push(StageProfile::host("alignment_cpu_dtw", alignment.cpu_dtw_wall));
+                for stage in copies.stages() {
+                    batch_profile.push(stage);
+                }
+            }
+            if let (Some(profile_result), Some(batch_profile)) = (&mut profile_result, batch_profile) {
+                profile_result.merge(batch_profile);
             }
         }
         Ok((transcripts, profile_result))
     }
+}
+
+pub(crate) fn bounded_window_batches<T>(windows: &[T], batch_size: usize) -> impl Iterator<Item = &[T]> {
+    windows.chunks(batch_size.max(1))
 }
 
 impl WhisperRecognizer {

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -415,6 +415,7 @@ impl WhisperRecognizer {
         let mut recognized = Vec::with_capacity(windows.len());
         let mut prof = profile.then(RunProfile::default);
         let mut encoder_kernels = Vec::new();
+        let mut decode_kernels = Vec::new();
         let mut decode_stats = DecodeScheduleStats::default();
         let (mut t_mel, mut t_encoder, mut t_decode) = (Duration::ZERO, Duration::ZERO, Duration::ZERO);
 
@@ -529,7 +530,7 @@ impl WhisperRecognizer {
             }
 
             let t = Instant::now();
-            let (results, batch_stats) = run_fixed_slot_decode(
+            let (results, batch_stats, batch_kernels) = run_fixed_slot_decode(
                 &seeds,
                 &decode_options,
                 &mut self.batched_step_jit,
@@ -537,9 +538,13 @@ impl WhisperRecognizer {
                 &self.tokenizer,
                 n_text_ctx,
                 n_vocab,
+                profile && decode_kernels.is_empty(),
             )
             .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
             decode_stats.merge(batch_stats);
+            if decode_kernels.is_empty() {
+                decode_kernels = batch_kernels;
+            }
             t_decode += t.elapsed();
 
             for (bi, ((mut result, options), audio_features)) in
@@ -559,7 +564,7 @@ impl WhisperRecognizer {
         if let Some(p) = &mut prof {
             p.push(StageProfile::host("mel", t_mel));
             p.push(StageProfile::gpu("encoder", t_encoder, encoder_kernels));
-            let mut decode = StageProfile::host("decode", t_decode);
+            let mut decode = StageProfile::gpu("decode", t_decode, decode_kernels);
             decode.meta.insert("dispatches".into(), decode_stats.dispatches.to_string());
             decode.meta.insert("active_row_steps".into(), decode_stats.active_row_steps.to_string());
             decode.meta.insert("reserved_row_steps".into(), decode_stats.reserved_row_steps.to_string());

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -164,6 +164,15 @@ impl WhisperRecognizer {
         let n_text_state = model.dims.n_text_state;
         let n_text_layer = model.dims.n_text_layer;
         let d_head = n_text_state / n_text_head;
+        let cross_cache_spec = InputSpec::f32(&[1, N_AUDIO_CTX, n_text_layer * n_text_head, d_head]).device_local();
+
+        // Cache-consuming decoder used for language detection.
+        let mut decoder_jit = WhisperDecoderJit::new(model.clone());
+        let tokens_spec = InputSpec::i32(&[1, 1]);
+        decoder_jit
+            .prepare_with_config(cross_cache_spec.clone(), cross_cache_spec.clone(), tokens_spec, &prepare_config)
+            .context(JitSnafu)?;
+
         // Cross-attention K/V projection is token-independent. Compile it once
         // and execute it once per encoder window, before any fallback attempts.
         let mut cross_kv_jit = WhisperCrossKvJit::new(model.clone());
@@ -171,24 +180,6 @@ impl WhisperRecognizer {
         cross_config.device_local_outputs = true;
         cross_kv_jit
             .prepare_with_config(InputSpec::f32(&[1, N_AUDIO_CTX, model.dims.n_text_state]), &cross_config)
-            .context(JitSnafu)?;
-        let cross_k_dtype = cross_kv_jit.cross_k().context(JitSnafu)?.dtype().clone();
-        let cross_v_dtype = cross_kv_jit.cross_v().context(JitSnafu)?.dtype().clone();
-        if cross_k_dtype != cross_v_dtype {
-            return Err(TranscribeError::Model {
-                source: Box::new(super::error::Error::Decode {
-                    msg: "prepared cross K/V producers have different dtypes".to_string(),
-                }),
-            });
-        }
-        let cross_cache_spec =
-            InputSpec::new(&[1, N_AUDIO_CTX, n_text_layer * n_text_head, d_head], cross_k_dtype.clone()).device_local();
-
-        // Cache-consuming decoder used for language detection.
-        let mut decoder_jit = WhisperDecoderJit::new(model.clone());
-        let tokens_spec = InputSpec::i32(&[1, 1]);
-        decoder_jit
-            .prepare_with_config(cross_cache_spec.clone(), cross_cache_spec.clone(), tokens_spec, &prepare_config)
             .context(JitSnafu)?;
 
         // Timestamp-enabled prefill has a structural, model-specific prefix:
@@ -204,15 +195,6 @@ impl WhisperRecognizer {
                 &prepare_config,
             )
             .context(JitSnafu)?;
-        let self_k_dtype = prefill_jit.self_k().context(JitSnafu)?.dtype().clone();
-        let self_v_dtype = prefill_jit.self_v().context(JitSnafu)?.dtype().clone();
-        if self_k_dtype != self_v_dtype {
-            return Err(TranscribeError::Model {
-                source: Box::new(super::error::Error::Decode {
-                    msg: "prepared self K/V producers have different dtypes".to_string(),
-                }),
-            });
-        }
 
         let n_text_head_local = n_text_head;
 
@@ -224,21 +206,11 @@ impl WhisperRecognizer {
             .prepare_with_config(
                 InputSpec::i32(&[max_lanes, 1]),
                 InputSpec::f32(&[max_lanes, 1, n_text_state]),
-                InputSpec::new(
-                    &[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head],
-                    self_k_dtype.clone(),
-                )
-                .device_local(),
-                InputSpec::new(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head], self_k_dtype)
-                    .device_local(),
-                InputSpec::new(
-                    &[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head],
-                    cross_k_dtype.clone(),
-                )
-                .device_local(),
-                InputSpec::new(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head], cross_k_dtype)
-                    .device_local(),
-                InputSpec::new(&[max_lanes, 1, 1, N_TEXT_CTX + 1], svod_dtype::DType::Bool),
+                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, 1, 1, N_TEXT_CTX + 1]),
                 &prepare_config,
             )
             .context(JitSnafu)?;

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -210,7 +210,7 @@ impl WhisperRecognizer {
                 InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
                 InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
                 InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
-                InputSpec::f32(&[max_lanes, 1, 1, N_TEXT_CTX + 1]),
+                InputSpec::i32(&[max_lanes]),
                 &prepare_config,
             )
             .context(JitSnafu)?;

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -164,15 +164,6 @@ impl WhisperRecognizer {
         let n_text_state = model.dims.n_text_state;
         let n_text_layer = model.dims.n_text_layer;
         let d_head = n_text_state / n_text_head;
-        let cross_cache_spec = InputSpec::f32(&[1, N_AUDIO_CTX, n_text_layer * n_text_head, d_head]).device_local();
-
-        // Cache-consuming decoder used for language detection.
-        let mut decoder_jit = WhisperDecoderJit::new(model.clone());
-        let tokens_spec = InputSpec::i32(&[1, 1]);
-        decoder_jit
-            .prepare_with_config(cross_cache_spec.clone(), cross_cache_spec.clone(), tokens_spec, &prepare_config)
-            .context(JitSnafu)?;
-
         // Cross-attention K/V projection is token-independent. Compile it once
         // and execute it once per encoder window, before any fallback attempts.
         let mut cross_kv_jit = WhisperCrossKvJit::new(model.clone());
@@ -180,6 +171,24 @@ impl WhisperRecognizer {
         cross_config.device_local_outputs = true;
         cross_kv_jit
             .prepare_with_config(InputSpec::f32(&[1, N_AUDIO_CTX, model.dims.n_text_state]), &cross_config)
+            .context(JitSnafu)?;
+        let cross_k_dtype = cross_kv_jit.cross_k().context(JitSnafu)?.dtype().clone();
+        let cross_v_dtype = cross_kv_jit.cross_v().context(JitSnafu)?.dtype().clone();
+        if cross_k_dtype != cross_v_dtype {
+            return Err(TranscribeError::Model {
+                source: Box::new(super::error::Error::Decode {
+                    msg: "prepared cross K/V producers have different dtypes".to_string(),
+                }),
+            });
+        }
+        let cross_cache_spec =
+            InputSpec::new(&[1, N_AUDIO_CTX, n_text_layer * n_text_head, d_head], cross_k_dtype.clone()).device_local();
+
+        // Cache-consuming decoder used for language detection.
+        let mut decoder_jit = WhisperDecoderJit::new(model.clone());
+        let tokens_spec = InputSpec::i32(&[1, 1]);
+        decoder_jit
+            .prepare_with_config(cross_cache_spec.clone(), cross_cache_spec.clone(), tokens_spec, &prepare_config)
             .context(JitSnafu)?;
 
         // Timestamp-enabled prefill has a structural, model-specific prefix:
@@ -195,6 +204,15 @@ impl WhisperRecognizer {
                 &prepare_config,
             )
             .context(JitSnafu)?;
+        let self_k_dtype = prefill_jit.self_k().context(JitSnafu)?.dtype().clone();
+        let self_v_dtype = prefill_jit.self_v().context(JitSnafu)?.dtype().clone();
+        if self_k_dtype != self_v_dtype {
+            return Err(TranscribeError::Model {
+                source: Box::new(super::error::Error::Decode {
+                    msg: "prepared self K/V producers have different dtypes".to_string(),
+                }),
+            });
+        }
 
         let n_text_head_local = n_text_head;
 
@@ -206,11 +224,21 @@ impl WhisperRecognizer {
             .prepare_with_config(
                 InputSpec::i32(&[max_lanes, 1]),
                 InputSpec::f32(&[max_lanes, 1, n_text_state]),
-                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
-                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
-                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
-                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
-                InputSpec::f32(&[max_lanes, 1, 1, N_TEXT_CTX + 1]),
+                InputSpec::new(
+                    &[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head],
+                    self_k_dtype.clone(),
+                )
+                .device_local(),
+                InputSpec::new(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head], self_k_dtype)
+                    .device_local(),
+                InputSpec::new(
+                    &[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head],
+                    cross_k_dtype.clone(),
+                )
+                .device_local(),
+                InputSpec::new(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head], cross_k_dtype)
+                    .device_local(),
+                InputSpec::new(&[max_lanes, 1, 1, N_TEXT_CTX + 1], svod_dtype::DType::Bool),
                 &prepare_config,
             )
             .context(JitSnafu)?;

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -78,7 +78,8 @@ pub struct WhisperRecognizer {
 
 struct RecognizedWindow {
     result: super::decode::DecodeResult,
-    audio_features: svod_device::Buffer,
+    cross_k: svod_device::Buffer,
+    cross_v: svod_device::Buffer,
     audio_samples: usize,
 }
 
@@ -342,7 +343,8 @@ impl WhisperAlignedTranscriber {
             let inputs: Vec<_> = chunk
                 .iter()
                 .map(|recognized| WhisperAlignmentInput {
-                    audio_features: &recognized.audio_features,
+                    cross_k: &recognized.cross_k,
+                    cross_v: &recognized.cross_v,
                     decoded_tokens: &recognized.result.tokens,
                     token_probs: &recognized.result.token_probs,
                     language: recognized.result.language.as_deref(),
@@ -445,14 +447,11 @@ impl WhisperRecognizer {
                 self.encoder_jit.execute().context(JitSnafu)?;
             }
 
-            // Encoder output remains device-local. Each valid lane is retained
-            // as an owned snapshot for the later alignment stage.
             let out_buf = self.encoder_jit.output().context(JitSnafu)?;
             t_encoder += t.elapsed();
 
             let mut seeds = Vec::with_capacity(b);
             let mut decode_options = Vec::with_capacity(b);
-            let mut alignment_audio = Vec::with_capacity(b);
 
             // Cross projection and token prefill remain per-window. Their
             // immutable device-local seeds are retained until the shared
@@ -522,11 +521,6 @@ impl WhisperRecognizer {
                 t_decode += t.elapsed();
                 seeds.push(seed);
                 decode_options.push(options);
-                alignment_audio.push(snapshot_device_region(
-                    out_buf,
-                    base * std::mem::size_of::<f32>(),
-                    item_stride * std::mem::size_of::<f32>(),
-                )?);
             }
 
             let t = Instant::now();
@@ -547,15 +541,15 @@ impl WhisperRecognizer {
             }
             t_decode += t.elapsed();
 
-            for (bi, ((mut result, options), audio_features)) in
-                results.into_iter().zip(&decode_options).zip(alignment_audio).enumerate()
-            {
+            for (bi, ((mut result, options), seed)) in results.into_iter().zip(&decode_options).zip(seeds).enumerate() {
                 if result.should_skip(options) {
                     result.clear_speech();
                 }
+                let (cross_k, cross_v) = seed.into_cross_kv();
                 recognized.push(RecognizedWindow {
                     result,
-                    audio_features,
+                    cross_k,
+                    cross_v,
                     audio_samples: windows[batch_start + bi].len(),
                 });
             }
@@ -584,28 +578,4 @@ impl WhisperRecognizer {
 
         Ok((recognized, prof))
     }
-}
-
-fn snapshot_device_region(
-    src: &svod_device::Buffer,
-    src_offset: usize,
-    len: usize,
-) -> Result<svod_device::Buffer, TranscribeError> {
-    let dtype = src.dtype();
-    if dtype != svod_dtype::DType::Float32 || len == 0 || !len.is_multiple_of(dtype.bytes()) {
-        return Err(TranscribeError::Model {
-            source: Box::new(super::error::Error::Decode {
-                msg: "encoder feature snapshot has invalid dtype or size".to_string(),
-            }),
-        });
-    }
-    let mut snapshot = svod_device::Buffer::allocate(
-        src.allocator_arc(),
-        dtype.clone(),
-        vec![len / dtype.bytes()],
-        svod_device::BufferSpec { cpu_access: false, ..Default::default() },
-    )
-    .context(DeviceSnafu)?;
-    snapshot.copy_region_from(0, src, src_offset, len).context(DeviceSnafu)?;
-    Ok(snapshot)
 }

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -144,12 +144,18 @@ impl WhisperTranscriber {
             }
             s
         };
+        // Device-local cache inputs: the KV caches live on-device and are
+        // recycled via SDMA copy (the RN-T block decoder / firered-vad idiom).
+        // The host never reads/writes cache floats — only integer offsets and
+        // the logits output. This unblocks low-precision compute: the cache
+        // dtype is a device-side decision, not pinned to the host Vec type.
         for &bs in &beam_sizes {
             let mut sj = WhisperDecoderStepJit::new(model.clone());
             let token_spec = InputSpec::i32(&[bs, 1]);
             let pos_emb_spec = InputSpec::f32(&[bs, 1, n_text_state]);
-            let self_cache_spec = InputSpec::f32(&[bs, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]);
-            let cross_cache_spec = InputSpec::f32(&[bs, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]);
+            let self_cache_spec = InputSpec::f32(&[bs, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
+            let cross_cache_spec =
+                InputSpec::f32(&[bs, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
             let mask_spec = InputSpec::f32(&[bs, 1, 1, N_TEXT_CTX + 1]);
             sj.prepare_with_config(
                 token_spec,
@@ -174,17 +180,20 @@ impl WhisperTranscriber {
             .prepare_with_config(
                 InputSpec::i32(&[max_lanes, 1]),
                 InputSpec::f32(&[max_lanes, 1, n_text_state]),
-                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]),
-                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]),
-                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]),
-                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]),
+                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
+                InputSpec::f32(&[max_lanes, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local(),
                 InputSpec::f32(&[max_lanes, 1, 1, N_TEXT_CTX + 1]),
                 &prepare_config,
             )
             .context(JitSnafu)?;
 
-        // Read positional embedding eagerly (static weight, reused every window)
-        let mut pe = model.decoder.positional_embedding.clone();
+        // Read positional embedding eagerly (static weight, reused every window).
+        // Cast to fp32 — the host decode math (pos_embedding slicing in decode.rs)
+        // operates on Vec<f32>, while the weight loads at dims.dtype (fp16).
+        let mut pe = model.decoder.positional_embedding.cast(svod_dtype::DType::Float32)
+            .map_err(|e| TranscribeError::Tensor { source: Box::new(e) })?;
         pe.realize().map_err(|e| TranscribeError::Tensor { source: Box::new(e) })?;
         let pos_embedding = pe
             .as_ndarray::<f32>()
@@ -513,10 +522,12 @@ impl Transcriber for WhisperTranscriber {
                     )
                     .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
 
-                    // Extract per-layer cross-attention weights as flat f32 vectors
+                    // Extract per-layer cross-attention weights as flat f32 vectors.
+                    // Cast to fp32 — the weights are computed at dims.dtype (fp16),
+                    // but DTW reads them as f32.
                     let mut qk_flat: Vec<Vec<f32>> = Vec::with_capacity(qk_weights.len());
                     for qk in &qk_weights {
-                        let mut qk_t = qk.clone();
+                        let mut qk_t = qk.cast(svod_dtype::DType::Float32).context(TensorSnafu)?;
                         qk_t.realize().context(TensorSnafu)?;
                         let arr = qk_t.as_ndarray::<f32>().context(TensorSnafu)?;
                         qk_flat.push(arr.as_slice().expect("contiguous qk").to_vec());

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -76,7 +76,7 @@ pub struct WhisperRecognizer {
 
 struct RecognizedWindow {
     result: super::decode::DecodeResult,
-    audio_features: Vec<f32>,
+    audio_features: svod_device::Buffer,
     audio_samples: usize,
 }
 
@@ -441,14 +441,14 @@ impl WhisperRecognizer {
                 self.encoder_jit.execute().context(JitSnafu)?;
             }
 
-            // Device-local output → SDMA copyout of only the b valid lanes
+            // Encoder output remains device-local. Each valid lane is retained
+            // as an owned snapshot for the later alignment stage.
             let out_buf = self.encoder_jit.output().context(JitSnafu)?;
-            let mut raw = vec![0f32; b * item_stride];
-            out_buf.copyout_prefix(bytemuck::cast_slice_mut(&mut raw)).context(DeviceSnafu)?;
             t_encoder += t.elapsed();
 
             let mut seeds = Vec::with_capacity(b);
             let mut decode_options = Vec::with_capacity(b);
+            let mut alignment_audio = Vec::with_capacity(b);
 
             // Cross projection and token prefill remain per-window. Their
             // immutable device-local seeds are retained until the shared
@@ -518,6 +518,11 @@ impl WhisperRecognizer {
                 t_decode += t.elapsed();
                 seeds.push(seed);
                 decode_options.push(options);
+                alignment_audio.push(snapshot_device_region(
+                    out_buf,
+                    base * std::mem::size_of::<f32>(),
+                    item_stride * std::mem::size_of::<f32>(),
+                )?);
             }
 
             let t = Instant::now();
@@ -533,14 +538,15 @@ impl WhisperRecognizer {
             .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
             t_decode += t.elapsed();
 
-            for (bi, (mut result, options)) in results.into_iter().zip(&decode_options).enumerate() {
+            for (bi, ((mut result, options), audio_features)) in
+                results.into_iter().zip(&decode_options).zip(alignment_audio).enumerate()
+            {
                 if result.should_skip(options) {
                     result.clear_speech();
                 }
-                let base = bi * item_stride;
                 recognized.push(RecognizedWindow {
                     result,
-                    audio_features: raw[base..base + item_stride].to_vec(),
+                    audio_features,
                     audio_samples: windows[batch_start + bi].len(),
                 });
             }
@@ -554,4 +560,28 @@ impl WhisperRecognizer {
 
         Ok((recognized, prof))
     }
+}
+
+fn snapshot_device_region(
+    src: &svod_device::Buffer,
+    src_offset: usize,
+    len: usize,
+) -> Result<svod_device::Buffer, TranscribeError> {
+    let dtype = src.dtype();
+    if dtype != svod_dtype::DType::Float32 || len == 0 || !len.is_multiple_of(dtype.bytes()) {
+        return Err(TranscribeError::Model {
+            source: Box::new(super::error::Error::Decode {
+                msg: "encoder feature snapshot has invalid dtype or size".to_string(),
+            }),
+        });
+    }
+    let mut snapshot = svod_device::Buffer::allocate(
+        src.allocator_arc(),
+        dtype.clone(),
+        vec![len / dtype.bytes()],
+        svod_device::BufferSpec { cpu_access: false, ..Default::default() },
+    )
+    .context(DeviceSnafu)?;
+    snapshot.copy_region_from(0, src, src_offset, len).context(DeviceSnafu)?;
+    Ok(snapshot)
 }

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -24,7 +24,7 @@ use super::jit::{WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit, Wh
 use super::mel::WhisperMel;
 use super::model::Whisper;
 use super::plan::WhisperPlan;
-use super::profile::{CopyProfile, begin_host_copy};
+use super::profile::{CopyProfile, GraphProfile, begin_host_copy};
 use super::tokenizer::WhisperTokenizer;
 
 pub use svod_arch::rnnt::Word;
@@ -386,8 +386,7 @@ impl WhisperAlignedTranscriber {
                 .aligner
                 .align_batch_profiled(&inputs, tokenizer, profile.then_some(&mut *copies))
                 .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
-            alignment_profile.graph_wall += batch_profile.graph_wall;
-            alignment_profile.cpu_dtw_wall += batch_profile.cpu_dtw_wall;
+            alignment_profile.merge(batch_profile);
             for (recognized, words) in chunk.iter().zip(words) {
                 let segments = super::decode::split_into_segments(
                     &recognized.result.tokens,
@@ -421,12 +420,7 @@ impl Transcriber for WhisperAlignedTranscriber {
         let (recognized, mut profile_result, mut copies) = self.recognizer.recognize_windows(windows, profile)?;
         let (transcripts, alignment) = self.align_recognized(recognized, profile, &mut copies)?;
         if let Some(profile) = &mut profile_result {
-            let mut graph = StageProfile::host("alignment_graph", alignment.graph_wall);
-            graph.meta.insert(
-                "timing_semantics".into(),
-                "synchronized host wall from graph submission through GPU completion; not a hardware timestamp".into(),
-            );
-            profile.push(graph);
+            profile.push(alignment.graph.stage("alignment_graph"));
             profile.push(StageProfile::host("alignment_cpu_dtw", alignment.cpu_dtw_wall));
             for stage in copies.stages() {
                 profile.push(stage);
@@ -456,11 +450,14 @@ impl WhisperRecognizer {
 
         let mut recognized = Vec::with_capacity(windows.len());
         let mut prof = profile.then(RunProfile::default);
-        let mut encoder_kernels = Vec::new();
-        let mut decode_kernels = Vec::new();
+        let mut encoder_profile = GraphProfile::default();
+        let mut cross_kv_profile = GraphProfile::default();
+        let mut language_profile = GraphProfile::default();
+        let mut prefill_profile = GraphProfile::default();
+        let mut decoder_step_profile = GraphProfile::default();
         let mut decode_stats = DecodeScheduleStats::default();
         let mut copies = CopyProfile::default();
-        let (mut t_mel, mut t_encoder, mut t_decode) = (Duration::ZERO, Duration::ZERO, Duration::ZERO);
+        let (mut t_mel, mut t_decoder_scheduler) = (Duration::ZERO, Duration::ZERO);
 
         for batch_start in (0..windows.len()).step_by(max_batch) {
             let b = (windows.len() - batch_start).min(max_batch);
@@ -486,15 +483,16 @@ impl WhisperRecognizer {
             t_mel += t.elapsed();
 
             // ── Encode: one dispatch for b windows ───────────────────────────
-            let t = Instant::now();
-            if profile && batch_start == 0 {
-                encoder_kernels = self.encoder_jit.execute_profiled().context(JitSnafu)?;
+            if profile {
+                let graph_started = Instant::now();
+                let kernels = self.encoder_jit.execute_profiled().context(JitSnafu)?;
+                self.encoder_jit.output().context(JitSnafu)?.synchronize().context(DeviceSnafu)?;
+                encoder_profile.record(graph_started.elapsed(), kernels);
             } else {
                 self.encoder_jit.execute().context(JitSnafu)?;
             }
 
             let out_buf = self.encoder_jit.output().context(JitSnafu)?;
-            t_encoder += t.elapsed();
 
             let mut seeds = Vec::with_capacity(b);
             let mut decode_options = Vec::with_capacity(b);
@@ -504,8 +502,6 @@ impl WhisperRecognizer {
             // scheduler accepts a primary or fallback attempt.
             for bi in 0..b {
                 let base = bi * item_stride;
-
-                let t = Instant::now();
 
                 // Project encoder features once for all fallback prefills.
                 let (_, projection_wall) = timed_d2d(profile, out_buf, || {
@@ -522,7 +518,14 @@ impl WhisperRecognizer {
                 if profile {
                     copies.d2d("projection_input", 1, item_stride * std::mem::size_of::<f32>(), projection_wall);
                 }
-                self.cross_kv_jit.execute().context(JitSnafu)?;
+                if profile {
+                    let graph_started = Instant::now();
+                    let kernels = self.cross_kv_jit.execute_profiled().context(JitSnafu)?;
+                    self.cross_kv_jit.cross_k().context(JitSnafu)?.synchronize().context(DeviceSnafu)?;
+                    cross_kv_profile.record(graph_started.elapsed(), kernels);
+                } else {
+                    self.cross_kv_jit.execute().context(JitSnafu)?;
+                }
                 let cross_k_fence = self.cross_kv_jit.cross_k().context(JitSnafu)?.clone();
                 let mut fanout_bytes = 0usize;
                 let (_, fanout_wall) = timed_d2d(profile, &cross_k_fence, || {
@@ -566,6 +569,7 @@ impl WhisperRecognizer {
                         n_vocab,
                         &self.tokenizer,
                         profile.then_some(&mut copies),
+                        profile.then_some(&mut language_profile),
                     )
                     .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
                     options.language = Some(detection.language);
@@ -580,15 +584,15 @@ impl WhisperRecognizer {
                     &self.pos_embedding,
                     self.n_audio_state,
                     profile.then_some(&mut copies),
+                    profile.then_some(&mut prefill_profile),
                 )
                 .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
-                t_decode += t.elapsed();
                 seeds.push(seed);
                 decode_options.push(options);
             }
 
             let t = Instant::now();
-            let (results, batch_stats, batch_kernels) = run_fixed_slot_decode(
+            let (results, batch_stats, batch_graph_profile) = run_fixed_slot_decode(
                 &seeds,
                 &decode_options,
                 &mut self.batched_step_jit,
@@ -597,14 +601,11 @@ impl WhisperRecognizer {
                 n_text_ctx,
                 n_vocab,
                 profile,
-                profile && decode_kernels.is_empty(),
             )
             .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
             decode_stats.merge(batch_stats);
-            if decode_kernels.is_empty() {
-                decode_kernels = batch_kernels;
-            }
-            t_decode += t.elapsed();
+            decoder_step_profile.merge(batch_graph_profile);
+            t_decoder_scheduler += t.elapsed();
 
             for (bi, ((mut result, options), seed)) in results.into_iter().zip(&decode_options).zip(seeds).enumerate() {
                 if result.should_skip(options) {
@@ -621,24 +622,38 @@ impl WhisperRecognizer {
         }
 
         if let Some(p) = &mut prof {
+            let encoder_executions = encoder_profile.executions;
             p.push(StageProfile::host("mel", t_mel));
-            p.push(StageProfile::gpu("encoder", t_encoder, encoder_kernels));
-            let mut decode = StageProfile::gpu("decode", t_decode, decode_kernels);
-            decode.meta.insert("dispatches".into(), decode_stats.dispatches.to_string());
-            decode.meta.insert("active_row_steps".into(), decode_stats.active_row_steps.to_string());
-            decode.meta.insert("reserved_row_steps".into(), decode_stats.reserved_row_steps.to_string());
-            decode.meta.insert("capacity_row_steps".into(), decode_stats.capacity_row_steps.to_string());
-            decode.meta.insert("cache_clone_ops".into(), decode_stats.cache_clone_ops.to_string());
-            decode.meta.insert("cache_clone_bytes".into(), decode_stats.cache_clone_bytes.to_string());
-            decode.meta.insert("attempts".into(), decode_stats.attempts.to_string());
-            decode.meta.insert("fallback_attempts".into(), decode_stats.fallback_attempts.to_string());
+            p.push(encoder_profile.stage("encoder"));
+            p.push(cross_kv_profile.stage("cross_kv_projection"));
+            if language_profile.executions != 0 {
+                p.push(language_profile.stage("language_detection"));
+            }
+            p.push(prefill_profile.stage("prefill"));
+            let mut decoder_step = decoder_step_profile.stage("decoder_step");
+            decoder_step.meta.insert("dispatches".into(), decode_stats.dispatches.to_string());
+            decoder_step.meta.insert("dispatch_semantics".into(), "logical decoder graph executions".into());
+            decoder_step.meta.insert("active_row_steps".into(), decode_stats.active_row_steps.to_string());
+            decoder_step.meta.insert("reserved_row_steps".into(), decode_stats.reserved_row_steps.to_string());
+            decoder_step.meta.insert("capacity_row_steps".into(), decode_stats.capacity_row_steps.to_string());
+            decoder_step.meta.insert("cache_clone_ops".into(), decode_stats.cache_clone_ops.to_string());
+            decoder_step.meta.insert("cache_clone_bytes".into(), decode_stats.cache_clone_bytes.to_string());
+            decoder_step.meta.insert("attempts".into(), decode_stats.attempts.to_string());
+            decoder_step.meta.insert("fallback_attempts".into(), decode_stats.fallback_attempts.to_string());
             let utilization = if decode_stats.capacity_row_steps == 0 {
                 0.0
             } else {
                 decode_stats.active_row_steps as f64 / decode_stats.capacity_row_steps as f64
             };
-            decode.meta.insert("row_utilization".into(), format!("{utilization:.4}"));
-            p.push(decode);
+            decoder_step.meta.insert("row_utilization".into(), format!("{utilization:.4}"));
+            p.push(decoder_step);
+            let mut scheduler = StageProfile::host("decoder_scheduler_total", t_decoder_scheduler);
+            scheduler.meta.insert(
+                "timing_semantics".into(),
+                "non-additive end-to-end control-loop wall including host work, decoder_step waits, and synchronized cache/control copies".into(),
+            );
+            scheduler.meta.insert("batches".into(), encoder_executions.to_string());
+            p.push(scheduler);
         }
 
         copies.merge(decode_stats.copies.clone());

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -1,10 +1,9 @@
-//! WhisperTranscriber: implements the arch `Transcriber` trait for long-form ASR.
+//! Prepared Whisper recognition and aligned-transcription stages.
 //!
-//! Each decode-window (≤30s) is: mel → encoder JIT → greedy decode.
-//! The encoder JIT is batched `[max_batch, n_mels, N_FRAMES]` with device-local
-//! output (SDMA copyout). The decoder JIT is compiled once at `[1, n_text_ctx]`;
-//! each step writes the growing token sequence (EOT-padded) and reads only the
-//! current position's logits — one compiled plan, zero recompilation.
+//! Each decode window runs through a concrete-capacity encoder, one reusable
+//! cross-K/V projection, token prefill, and fixed-slot cached decoding. The
+//! independent aligner replays finalized tokens through a teacher-forced graph
+//! and computes word timings on the host.
 
 use std::time::{Duration, Instant};
 
@@ -15,11 +14,13 @@ use svod_tensor::PrepareConfig;
 
 use crate::jit::InputSpec;
 
+use super::aligner::{WhisperAligner, WhisperAlignmentInput};
 use super::config::{N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, SAMPLE_RATE};
 use super::decode::{DecodeLane, DecodeOptions, run_batched_decode};
-use super::jit::{WhisperDecoderJit, WhisperDecoderStepBatchedJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
+use super::jit::{WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 use super::mel::WhisperMel;
 use super::model::Whisper;
+use super::plan::WhisperPlan;
 use super::tokenizer::WhisperTokenizer;
 
 pub use svod_arch::rnnt::Word;
@@ -49,56 +50,76 @@ pub enum TranscribeError {
     },
 }
 
-/// Per-window Whisper transcriber: mel frontend + batched encoder JIT +
-/// compile-once decoder JIT + greedy decoder.  Produces word-level
-/// timestamps via DTW on cross-attention weights (eager alignment pass).
-pub struct WhisperTranscriber {
-    model: Whisper,
+/// Prepared timestamp-enabled recognizer. It owns only recognition graphs;
+/// word alignment is a separate [`WhisperAligner`] stage.
+pub struct WhisperRecognizer {
     mel: WhisperMel,
     encoder_jit: WhisperEncoderJit,
     decoder_jit: WhisperDecoderJit,
+    cross_kv_jit: WhisperCrossKvJit,
     prefill_jit: WhisperPrefillJit,
     step_jits: rustc_hash::FxHashMap<usize, WhisperDecoderStepJit>,
-    /// Continuous-batching step JIT: one plan compiled at `max_lanes`, rebound
-    /// to the live lane count each dispatch via `execute_with_vars`. Substrate
-    /// for [`Self::transcribe_windows_batched`] and the soroka scheduler.
-    batched_step_jit: WhisperDecoderStepBatchedJit,
+    /// Concrete fixed-capacity step graph. Requests keep stable row ownership;
+    /// inactive rows execute with ignored outputs.
+    batched_step_jit: WhisperDecoderStepJit,
     tokenizer: WhisperTokenizer,
     options: DecodeOptions,
-    alignment_heads: Vec<(usize, usize)>,
     n_mels: usize,
     n_audio_state: usize,
     n_vocab: usize,
     n_text_ctx: usize,
-    n_text_head: usize,
     max_batch: usize,
     /// Max concurrent decode lanes in the batched step JIT.
     max_lanes: usize,
+    plan: WhisperPlan,
     pos_embedding: Vec<f32>,
 }
 
-impl WhisperTranscriber {
+struct RecognizedWindow {
+    result: super::decode::DecodeResult,
+    audio_features: Vec<f32>,
+    audio_samples: usize,
+}
+
+impl WhisperRecognizer {
     pub fn new(
         model: Whisper,
         tokenizer: WhisperTokenizer,
         options: DecodeOptions,
-        size: super::config::WhisperSize,
-        _max_chunk_samples: usize,
+        max_chunk_samples: usize,
     ) -> Result<Self, TranscribeError> {
+        let plan = WhisperPlan::for_recognizer(&model.dims);
+        Self::new_with_plan(model, tokenizer, options, max_chunk_samples, plan)
+    }
+
+    pub fn new_with_plan(
+        model: Whisper,
+        tokenizer: WhisperTokenizer,
+        options: DecodeOptions,
+        max_chunk_samples: usize,
+        plan: WhisperPlan,
+    ) -> Result<Self, TranscribeError> {
+        plan.validate().map_err(|message| TranscribeError::Model {
+            source: Box::new(super::error::Error::Decode { msg: message.to_string() }),
+        })?;
         let n_mels = model.dims.n_mels;
         let n_audio_state = model.dims.n_audio_state;
         let n_vocab = model.dims.n_vocab;
         let n_text_ctx = model.dims.n_text_ctx;
         let n_text_head = model.dims.n_text_head;
-        let alignment_heads = size.alignment_heads().to_vec();
+        if max_chunk_samples > super::config::N_SAMPLES {
+            return Err(TranscribeError::Model {
+                source: Box::new(super::error::Error::Decode {
+                    msg: format!(
+                        "Whisper decode windows are limited to {} samples, got {max_chunk_samples}",
+                        super::config::N_SAMPLES
+                    ),
+                }),
+            });
+        }
         let mel = WhisperMel::new(n_mels);
 
-        // Budget encoder SDPA scores [B, n_head, N_AUDIO_CTX, N_AUDIO_CTX].
-        // Whisper's 1500×1500 attention is the binding memory constraint.
-        const MAX_SCORES_BYTES: usize = 512 * 1024 * 1024;
-        let n_head = model.dims.n_audio_head;
-        let scores_per_window = n_head * N_AUDIO_CTX * N_AUDIO_CTX * std::mem::size_of::<f32>();
-        let max_batch = (MAX_SCORES_BYTES / scores_per_window).clamp(1, 8);
+        let max_batch = plan.encoder_batch;
 
         let prepare_config = PrepareConfig::from_env();
 
@@ -109,31 +130,44 @@ impl WhisperTranscriber {
         enc_config.device_local_outputs = true;
         encoder_jit.prepare_with_config(mel_spec, &enc_config).context(JitSnafu)?;
 
-        // Decoder JIT: [1, N_AUDIO_CTX, D] × [1, N_TEXT_CTX], compiled once.
-        // Used for language detection (auto-detect path).
-        let mut decoder_jit = WhisperDecoderJit::new(model.clone());
-        let audio_spec = InputSpec::f32(&[1, N_AUDIO_CTX, n_audio_state]);
-        let tokens_spec = InputSpec::i32(&[1, N_TEXT_CTX]);
-        decoder_jit.prepare_with_config(audio_spec, tokens_spec, &prepare_config).context(JitSnafu)?;
-
-        // Prefill JIT: [1, 4] tokens × [1, N_AUDIO_CTX, D] → logits + K/V caches.
-        // Compiled once at construction, reused every window.
-        let init_len = 4; // SOT + lang + task + notimestamps
         let n_text_state = model.dims.n_text_state;
+        let n_text_layer = model.dims.n_text_layer;
+        let d_head = n_text_state / n_text_head;
+        let cross_cache_spec = InputSpec::f32(&[1, N_AUDIO_CTX, n_text_layer * n_text_head, d_head]).device_local();
+
+        // Cache-consuming decoder used for language detection.
+        let mut decoder_jit = WhisperDecoderJit::new(model.clone());
+        let tokens_spec = InputSpec::i32(&[1, N_TEXT_CTX]);
+        decoder_jit
+            .prepare_with_config(cross_cache_spec.clone(), cross_cache_spec.clone(), tokens_spec, &prepare_config)
+            .context(JitSnafu)?;
+
+        // Cross-attention K/V projection is token-independent. Compile it once
+        // and execute it once per encoder window, before any fallback attempts.
+        let mut cross_kv_jit = WhisperCrossKvJit::new(model.clone());
+        let mut cross_config = prepare_config.clone();
+        cross_config.device_local_outputs = true;
+        cross_kv_jit
+            .prepare_with_config(InputSpec::f32(&[1, N_AUDIO_CTX, model.dims.n_text_state]), &cross_config)
+            .context(JitSnafu)?;
+
+        // Timestamp-enabled prefill has a structural, model-specific prefix:
+        // multilingual [SOT, language, task], English-only [SOT].
+        // Compiled once at construction, reused every window.
+        let init_len = if model.is_multilingual() { 3 } else { 1 };
         let mut prefill_jit = WhisperPrefillJit::new(model.clone());
         prefill_jit
             .prepare_with_config(
                 InputSpec::i32(&[1, init_len]),
-                InputSpec::f32(&[1, N_AUDIO_CTX, n_text_state]),
+                cross_cache_spec.clone(),
+                cross_cache_spec,
                 &prepare_config,
             )
             .context(JitSnafu)?;
 
         // Step JITs: one per beam_size needed (beam_size from options + 1 for greedy).
         // Compiled once at construction, reused every step.
-        let n_text_layer = model.dims.n_text_layer;
         let n_text_head_local = n_text_head;
-        let d_head = n_text_state / n_text_head_local;
         let mut step_jits: rustc_hash::FxHashMap<usize, WhisperDecoderStepJit> = rustc_hash::FxHashMap::default();
 
         let beam_sizes: std::collections::HashSet<usize> = {
@@ -153,7 +187,8 @@ impl WhisperTranscriber {
             let mut sj = WhisperDecoderStepJit::new(model.clone());
             let token_spec = InputSpec::i32(&[bs, 1]);
             let pos_emb_spec = InputSpec::f32(&[bs, 1, n_text_state]);
-            let self_cache_spec = InputSpec::f32(&[bs, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
+            let self_cache_spec =
+                InputSpec::f32(&[bs, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
             let cross_cache_spec =
                 InputSpec::f32(&[bs, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
             let mask_spec = InputSpec::f32(&[bs, 1, 1, N_TEXT_CTX + 1]);
@@ -171,11 +206,10 @@ impl WhisperTranscriber {
             step_jits.insert(bs, sj);
         }
 
-        // Batched step JIT: one plan at max_lanes, rebound per dispatch.
-        // Same shapes as the per-beam step JITs but with the batch dimension
-        // symbolic (`b`), compiled once for continuous batching.
-        let max_lanes = max_batch; // reuse the encoder's memory-budgeted cap
-        let mut batched_step_jit = WhisperDecoderStepBatchedJit::new(model.clone()).with_b_bound(max_lanes);
+        // Fixed concrete batch keeps tensor-core dimensions static and avoids
+        // cache movement when lanes finish.
+        let max_lanes = plan.decoder_slots;
+        let mut batched_step_jit = WhisperDecoderStepJit::new(model.clone());
         batched_step_jit
             .prepare_with_config(
                 InputSpec::i32(&[max_lanes, 1]),
@@ -192,7 +226,10 @@ impl WhisperTranscriber {
         // Read positional embedding eagerly (static weight, reused every window).
         // Cast to fp32 — the host decode math (pos_embedding slicing in decode.rs)
         // operates on Vec<f32>, while the weight loads at dims.dtype (fp16).
-        let mut pe = model.decoder.positional_embedding.cast(svod_dtype::DType::Float32)
+        let mut pe = model
+            .decoder
+            .positional_embedding
+            .cast(svod_dtype::DType::Float32)
             .map_err(|e| TranscribeError::Tensor { source: Box::new(e) })?;
         pe.realize().map_err(|e| TranscribeError::Tensor { source: Box::new(e) })?;
         let pos_embedding = pe
@@ -203,23 +240,22 @@ impl WhisperTranscriber {
             .to_vec();
 
         Ok(Self {
-            model,
             mel,
             encoder_jit,
             decoder_jit,
+            cross_kv_jit,
             prefill_jit,
             step_jits,
             batched_step_jit,
             tokenizer,
             options,
-            alignment_heads,
             n_mels,
             n_audio_state,
             n_vocab,
             n_text_ctx,
-            n_text_head,
             max_batch,
             max_lanes,
+            plan,
             pos_embedding,
         })
     }
@@ -237,20 +273,21 @@ impl WhisperTranscriber {
         self.max_lanes
     }
 
-    /// Batched decode path: all `windows` are decoded together via a
-    /// step-locked loop over the single `batched_step_jit` (one dispatch per
-    /// token step across all active lanes). This is the continuous-batching
-    /// entry point — throughput-oriented, replacing the per-window serial
-    /// decode of [`Transcriber::transcribe_windows`].
+    pub fn plan(&self) -> &WhisperPlan {
+        &self.plan
+    }
+
+    /// Greedy throughput path that decodes windows through stable fixed slots,
+    /// refilling each slot as its current request finishes.
     ///
     /// Encoder + prefill still run per-window (the encoder is already
     /// batched within `max_batch`; prefill is a single 4-token forward).
     /// Temperature fallback is disabled (`temperature_inc = 0`), so the
     /// schedule collapses to a single greedy pass per window.
-    pub fn transcribe_windows_batched(
+    fn recognize_windows_batched_greedy(
         &mut self,
         windows: &[&[f32]],
-    ) -> Result<Vec<Transcript>, TranscribeError> {
+    ) -> Result<Vec<RecognizedWindow>, TranscribeError> {
         if windows.is_empty() {
             return Ok(Vec::new());
         }
@@ -270,8 +307,9 @@ impl WhisperTranscriber {
         batched_opts.temperature_inc = 0.0;
         batched_opts.beam_size = None; // greedy-only in the batched path
 
-        let mut transcripts = Vec::with_capacity(windows.len());
+        let mut recognized = Vec::with_capacity(windows.len());
         let mut lanes: Vec<(DecodeLane, DecodeOptions)> = Vec::with_capacity(windows.len());
+        let mut alignment_audio = Vec::with_capacity(windows.len());
 
         // Encode + prefill in encoder-sized batches, building one DecodeLane
         // per window. The encoder already handles up to max_batch windows per
@@ -280,8 +318,7 @@ impl WhisperTranscriber {
             let b = (windows.len() - batch_start).min(max_batch);
 
             // ── Mel: compute + pack into [b, n_mels, N_FRAMES] ──────────
-            let batch_mels: Vec<Vec<f32>> =
-                (0..b).map(|bi| self.compute_mel(windows[batch_start + bi])).collect();
+            let batch_mels: Vec<Vec<f32>> = (0..b).map(|bi| self.compute_mel(windows[batch_start + bi])).collect();
             {
                 let mel_buf = self.encoder_jit.mel_mut().context(JitSnafu)?;
                 let mut packed = vec![0f32; max_batch * mel_stride];
@@ -302,33 +339,52 @@ impl WhisperTranscriber {
             // ── Prefill: per-window, build a DecodeLane ──────────────────
             for bi in 0..b {
                 let base = bi * item_stride;
+                // Project this window once, then bind the packed caches into
+                // both language detection and token prefill.
+                {
+                    let buf = self.cross_kv_jit.audio_features_mut().context(JitSnafu)?;
+                    buf.copy_region_from(
+                        0,
+                        out_buf,
+                        base * std::mem::size_of::<f32>(),
+                        item_stride * std::mem::size_of::<f32>(),
+                    )
+                    .context(DeviceSnafu)?;
+                }
+                self.cross_kv_jit.execute().context(JitSnafu)?;
+                {
+                    let src = self.cross_kv_jit.cross_k().context(JitSnafu)?;
+                    self.prefill_jit
+                        .prepared_cross_k_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                    self.decoder_jit
+                        .prepared_cross_k_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                    let src = self.cross_kv_jit.cross_v().context(JitSnafu)?;
+                    self.prefill_jit
+                        .prepared_cross_v_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                    self.decoder_jit
+                        .prepared_cross_v_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                }
                 // Resolve language for this window (auto-detect if unset).
                 let mut lane_opts = batched_opts.clone();
-                if lane_opts.language.is_none() {
-                    // Load this window's audio features into the uncached
-                    // decoder JIT for language detection.
-                    {
-                        let buf = self.decoder_jit.audio_features_mut().context(JitSnafu)?;
-                        let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-                        let src_bytes: &[u8] = bytemuck::cast_slice(&raw[base..base + item_stride]);
-                        dst[..src_bytes.len()].copy_from_slice(src_bytes);
-                    }
-                    let detection = super::decode::detect_language(
-                        &mut self.decoder_jit,
-                        n_text_ctx,
-                        n_vocab,
-                        &self.tokenizer,
-                    )
-                    .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+                if !self.tokenizer.multilingual {
+                    lane_opts.language = Some("en".to_string());
+                } else if lane_opts.language.is_none() {
+                    let detection =
+                        super::decode::detect_language(&mut self.decoder_jit, n_text_ctx, n_vocab, &self.tokenizer)
+                            .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
                     lane_opts.language = Some(detection.language);
-                }
-
-                // Load this window's audio features into prefill JIT.
-                {
-                    let buf = self.prefill_jit.audio_features_mut().context(JitSnafu)?;
-                    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-                    let src_bytes: &[u8] = bytemuck::cast_slice(&raw[base..base + item_stride]);
-                    dst[..src_bytes.len()].copy_from_slice(src_bytes);
                 }
 
                 let lane = DecodeLane::prefill(
@@ -342,17 +398,19 @@ impl WhisperTranscriber {
                 )
                 .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
 
+                alignment_audio.push(raw[base..base + item_stride].to_vec());
                 lanes.push((lane, lane_opts));
             }
         }
 
         // ── Batched step-locked decode ───────────────────────────────────
-        // Run all lanes together: one JIT dispatch per token step, rebound
-        // to the active lane count. Lanes drop out on EOT.
-        let mut lane_states: Vec<DecodeLane> = lanes.into_iter().map(|(l, _)| l).collect();
+        // Run one concrete max-lane dispatch per token step. Finished rows stay
+        // inactive until their stable slots are reused.
+        let (mut lane_states, lane_options): (Vec<DecodeLane>, Vec<DecodeOptions>) = lanes.into_iter().unzip();
         run_batched_decode(
             &mut lane_states,
             &mut self.batched_step_jit,
+            self.max_lanes,
             &self.tokenizer,
             &batched_opts,
             n_text_ctx,
@@ -360,15 +418,22 @@ impl WhisperTranscriber {
         )
         .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
 
-        // ── Collect transcripts ──────────────────────────────────────────
-        for lane in lane_states {
-            let result = lane
-                .finish(&self.tokenizer, &batched_opts)
-                .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-            transcripts.push(Transcript { text: result.text, words: Vec::new(), language: result.language });
+        // ── Collect finalized recognition artifacts ──────────────────────
+        for (index, (lane, lane_opts)) in lane_states.into_iter().zip(lane_options).enumerate() {
+            let mut result =
+                lane.finish(&self.tokenizer, &lane_opts).map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+            if result.should_skip(&lane_opts) {
+                result.clear_speech();
+            }
+
+            recognized.push(RecognizedWindow {
+                result,
+                audio_features: std::mem::take(&mut alignment_audio[index]),
+                audio_samples: windows[index].len(),
+            });
         }
 
-        Ok(transcripts)
+        Ok(recognized)
     }
 
     /// Compute mel spectrogram for a window, padded/trimmed to N_FRAMES.
@@ -383,7 +448,7 @@ impl WhisperTranscriber {
     }
 }
 
-impl Transcriber for WhisperTranscriber {
+impl Transcriber for WhisperRecognizer {
     type Error = TranscribeError;
 
     fn sample_rate(&self) -> u32 {
@@ -395,6 +460,147 @@ impl Transcriber for WhisperTranscriber {
         windows: &[&[f32]],
         profile: bool,
     ) -> Result<(Vec<Transcript>, Option<RunProfile>), Self::Error> {
+        let (recognized, profile) = self.recognize_windows(windows, profile)?;
+        let transcripts = recognized
+            .into_iter()
+            .map(|recognized| {
+                let segments = super::decode::split_into_segments(
+                    &recognized.result.tokens,
+                    &self.tokenizer,
+                    recognized.audio_samples as f32 / SAMPLE_RATE as f32,
+                );
+                Transcript {
+                    text: recognized.result.text,
+                    words: Vec::new(),
+                    segments,
+                    language: recognized.result.language,
+                }
+            })
+            .collect();
+        Ok((transcripts, profile))
+    }
+}
+
+/// Timestamp-enabled recognizer composed with the independent, fixed-shape
+/// word aligner. Every call returns DTW-aligned words; there is no feature flag
+/// that changes the prepared recognition graph.
+pub struct WhisperAlignedTranscriber {
+    recognizer: WhisperRecognizer,
+    aligner: WhisperAligner,
+}
+
+impl WhisperAlignedTranscriber {
+    pub fn new(
+        model: Whisper,
+        tokenizer: WhisperTokenizer,
+        options: DecodeOptions,
+        size: super::config::WhisperSize,
+        max_chunk_samples: usize,
+    ) -> Result<Self, TranscribeError> {
+        let plan = WhisperPlan::for_model(&model.dims, size);
+        Self::new_with_plan(model, tokenizer, options, size, max_chunk_samples, plan)
+    }
+
+    pub fn new_with_plan(
+        model: Whisper,
+        tokenizer: WhisperTokenizer,
+        options: DecodeOptions,
+        size: super::config::WhisperSize,
+        max_chunk_samples: usize,
+        plan: WhisperPlan,
+    ) -> Result<Self, TranscribeError> {
+        plan.validate().map_err(|message| TranscribeError::Model {
+            source: Box::new(super::error::Error::Decode { msg: message.to_string() }),
+        })?;
+        let aligner = WhisperAligner::new(model.clone(), size, plan.alignment_batch)
+            .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+        let recognizer = WhisperRecognizer::new_with_plan(model, tokenizer, options, max_chunk_samples, plan)?;
+        Ok(Self { recognizer, aligner })
+    }
+
+    pub fn set_language(&mut self, language: Option<String>) {
+        self.recognizer.set_language(language);
+    }
+
+    /// Decode windows with the concrete fixed-slot scheduler.
+    ///
+    /// This throughput-oriented path uses greedy decoding and disables
+    /// temperature fallback. Use [`Transcriber::transcribe_windows`] when beam
+    /// search and fallback policy are required.
+    pub fn transcribe_windows_batched_greedy(
+        &mut self,
+        windows: &[&[f32]],
+    ) -> Result<Vec<Transcript>, TranscribeError> {
+        let recognized = self.recognizer.recognize_windows_batched_greedy(windows)?;
+        self.align_recognized(recognized)
+    }
+
+    fn align_recognized(&mut self, recognized: Vec<RecognizedWindow>) -> Result<Vec<Transcript>, TranscribeError> {
+        let task = self.recognizer.options.task;
+        let tokenizer = &self.recognizer.tokenizer;
+        let mut transcripts = Vec::with_capacity(recognized.len());
+        for chunk in recognized.chunks(self.recognizer.plan.alignment_batch) {
+            let inputs: Vec<_> = chunk
+                .iter()
+                .map(|recognized| WhisperAlignmentInput {
+                    audio_features: &recognized.audio_features,
+                    decoded_tokens: &recognized.result.tokens,
+                    token_probs: &recognized.result.token_probs,
+                    language: recognized.result.language.as_deref(),
+                    task,
+                    audio_samples: recognized.audio_samples,
+                })
+                .collect();
+            let words = self
+                .aligner
+                .align_batch(&inputs, tokenizer)
+                .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+            for (recognized, words) in chunk.iter().zip(words) {
+                let segments = super::decode::split_into_segments(
+                    &recognized.result.tokens,
+                    tokenizer,
+                    recognized.audio_samples as f32 / SAMPLE_RATE as f32,
+                );
+                transcripts.push(Transcript {
+                    text: recognized.result.text.clone(),
+                    words,
+                    segments,
+                    language: recognized.result.language.clone(),
+                });
+            }
+        }
+        Ok(transcripts)
+    }
+}
+
+impl Transcriber for WhisperAlignedTranscriber {
+    type Error = TranscribeError;
+
+    fn sample_rate(&self) -> u32 {
+        SAMPLE_RATE as u32
+    }
+
+    fn transcribe_windows(
+        &mut self,
+        windows: &[&[f32]],
+        profile: bool,
+    ) -> Result<(Vec<Transcript>, Option<RunProfile>), Self::Error> {
+        let (recognized, mut profile_result) = self.recognizer.recognize_windows(windows, profile)?;
+        let started = Instant::now();
+        let transcripts = self.align_recognized(recognized)?;
+        if let Some(profile) = &mut profile_result {
+            profile.push(StageProfile::host("alignment", started.elapsed()));
+        }
+        Ok((transcripts, profile_result))
+    }
+}
+
+impl WhisperRecognizer {
+    fn recognize_windows(
+        &mut self,
+        windows: &[&[f32]],
+        profile: bool,
+    ) -> Result<(Vec<RecognizedWindow>, Option<RunProfile>), TranscribeError> {
         if windows.is_empty() {
             return Ok((Vec::new(), profile.then(RunProfile::default)));
         }
@@ -407,8 +613,9 @@ impl Transcriber for WhisperTranscriber {
         let n_vocab = self.n_vocab;
         let n_text_ctx = self.n_text_ctx;
 
-        let mut transcripts = Vec::with_capacity(windows.len());
+        let mut recognized = Vec::with_capacity(windows.len());
         let mut prof = profile.then(RunProfile::default);
+        let mut encoder_kernels = Vec::new();
         let (mut t_mel, mut t_encoder, mut t_decode) = (Duration::ZERO, Duration::ZERO, Duration::ZERO);
 
         for batch_start in (0..windows.len()).step_by(max_batch) {
@@ -432,15 +639,7 @@ impl Transcriber for WhisperTranscriber {
             // ── Encode: one dispatch for b windows ───────────────────────────
             let t = Instant::now();
             if profile && batch_start == 0 {
-                let kernels = self.encoder_jit.execute_profiled().context(JitSnafu)?;
-                eprintln!("Encoder kernels (first window):");
-                for k in &kernels {
-                    eprintln!("  {:>50} {:>8.3}ms", k.kernel.entry_point, k.wall.as_secs_f64() * 1000.0);
-                }
-                eprintln!(
-                    "  encoder total: {:.3}ms",
-                    kernels.iter().map(|k| k.wall.as_secs_f64() * 1000.0).sum::<f64>()
-                );
+                encoder_kernels = self.encoder_jit.execute_profiled().context(JitSnafu)?;
             } else {
                 self.encoder_jit.execute().context(JitSnafu)?;
             }
@@ -457,39 +656,44 @@ impl Transcriber for WhisperTranscriber {
 
                 let t = Instant::now();
 
-                // Kernel-level profiling (first window only)
-                if profile && batch_start == 0 && bi == 0 {
-                    let kernels = self.prefill_jit.execute_profiled().context(JitSnafu)?;
-                    eprintln!("Prefill kernels:");
-                    for k in &kernels {
-                        eprintln!("  {:>50} {:>8.3}ms", k.kernel.entry_point, k.wall.as_secs_f64() * 1000.0);
-                    }
-                    eprintln!(
-                        "  prefill total: {:.3}ms",
-                        kernels.iter().map(|k| k.wall.as_secs_f64() * 1000.0).sum::<f64>()
-                    );
-
-                    let bs = if self.options.beam_size.unwrap_or(0) > 0 { self.options.beam_size.unwrap() } else { 1 };
-                    let kernels = self.step_jits.get_mut(&bs).unwrap().execute_profiled().context(JitSnafu)?;
-                    eprintln!("Step JIT kernels (beam={bs}):");
-                    for k in &kernels {
-                        eprintln!("  {:>50} {:>8.3}ms", k.kernel.entry_point, k.wall.as_secs_f64() * 1000.0);
-                    }
-                    eprintln!(
-                        "  step total: {:.3}ms",
-                        kernels.iter().map(|k| k.wall.as_secs_f64() * 1000.0).sum::<f64>()
-                    );
-                }
-
-                // Load audio features into prefill JIT
+                // Project encoder features once for all fallback prefills.
                 {
-                    let buf = self.prefill_jit.audio_features_mut().context(JitSnafu)?;
-                    let dst = buf.as_host_bytes_mut().context(DeviceSnafu)?;
-                    let src_bytes: &[u8] = bytemuck::cast_slice(&raw[base..base + item_stride]);
-                    dst[..src_bytes.len()].copy_from_slice(src_bytes);
+                    let buf = self.cross_kv_jit.audio_features_mut().context(JitSnafu)?;
+                    buf.copy_region_from(
+                        0,
+                        out_buf,
+                        base * std::mem::size_of::<f32>(),
+                        item_stride * std::mem::size_of::<f32>(),
+                    )
+                    .context(DeviceSnafu)?;
+                }
+                self.cross_kv_jit.execute().context(JitSnafu)?;
+                {
+                    let src = self.cross_kv_jit.cross_k().context(JitSnafu)?;
+                    self.prefill_jit
+                        .prepared_cross_k_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                    self.decoder_jit
+                        .prepared_cross_k_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                    let src = self.cross_kv_jit.cross_v().context(JitSnafu)?;
+                    self.prefill_jit
+                        .prepared_cross_v_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
+                    self.decoder_jit
+                        .prepared_cross_v_mut()
+                        .context(JitSnafu)?
+                        .copy_region_from(0, src, 0, src.size())
+                        .context(DeviceSnafu)?;
                 }
 
-                let result = {
+                let mut result = {
                     super::decode::decode_with_fallback_cached(
                         &mut self.prefill_jit,
                         &mut self.step_jits,
@@ -498,96 +702,30 @@ impl Transcriber for WhisperTranscriber {
                         n_vocab,
                         &self.tokenizer,
                         &self.options,
-                        &raw[base..base + item_stride],
                         &self.pos_embedding,
                         self.n_audio_state,
                     )
                 }
                 .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
+                if result.should_skip(&self.options) {
+                    result.clear_speech();
+                }
                 t_decode += t.elapsed();
 
-                // DTW word-level alignment: eager decoder pass with cross-attention
-                // weight extraction, then DTW on alignment heads.
-                let words = if !result.tokens.is_empty() && !self.alignment_heads.is_empty() {
-                    let audio_features = svod_tensor::Tensor::from_slice(&raw[base..base + item_stride])
-                        .try_reshape([1usize, N_AUDIO_CTX, d])
-                        .context(TensorSnafu)?;
-
-                    let (qk_weights, sot_len) = super::decode::greedy_decode_with_alignment(
-                        &self.model,
-                        &audio_features,
-                        &self.tokenizer,
-                        &self.options,
-                        &result.tokens,
-                    )
-                    .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-
-                    // Extract per-layer cross-attention weights as flat f32 vectors.
-                    // Cast to fp32 — the weights are computed at dims.dtype (fp16),
-                    // but DTW reads them as f32.
-                    let mut qk_flat: Vec<Vec<f32>> = Vec::with_capacity(qk_weights.len());
-                    for qk in &qk_weights {
-                        let mut qk_t = qk.cast(svod_dtype::DType::Float32).context(TensorSnafu)?;
-                        qk_t.realize().context(TensorSnafu)?;
-                        let arr = qk_t.as_ndarray::<f32>().context(TensorSnafu)?;
-                        qk_flat.push(arr.as_slice().expect("contiguous qk").to_vec());
-                    }
-
-                    // DTW alignment
-                    let s_text = result.tokens.len() + sot_len + 1; // +1 for EOT
-                    let (text_indices, time_indices) = super::dtw::find_alignment_path(
-                        &qk_flat,
-                        1, // batch
-                        self.n_text_head,
-                        s_text,
-                        N_AUDIO_CTX,
-                        &self.alignment_heads,
-                        N_AUDIO_CTX,
-                        7, // medfilt_width
-                        sot_len,
-                    );
-
-                    // Map to word timings
-                    let (word_strings, word_token_lists) = self.tokenizer.split_to_word_tokens(&result.tokens);
-                    let word_boundaries: Vec<usize> = {
-                        let mut acc = 0usize;
-                        let mut bounds = vec![0usize];
-                        for tokens in &word_token_lists {
-                            acc += tokens.len();
-                            bounds.push(acc);
-                        }
-                        bounds
-                    };
-
-                    let token_probs: Vec<f32> = vec![0.5; result.tokens.len()];
-
-                    super::dtw::path_to_word_timings(
-                        &text_indices,
-                        &time_indices,
-                        &word_boundaries,
-                        &word_strings,
-                        &word_token_lists,
-                        &token_probs,
-                        super::config::TOKENS_PER_SECOND,
-                    )
-                    .into_iter()
-                    .filter(|w| !w.word.trim().is_empty())
-                    .map(|w| Word { text: w.word, start: w.start, end: w.end })
-                    .collect()
-                } else {
-                    Vec::new()
-                };
-
-                transcripts.push(Transcript { text: result.text, words, language: result.language });
+                recognized.push(RecognizedWindow {
+                    result,
+                    audio_features: raw[base..base + item_stride].to_vec(),
+                    audio_samples: windows[batch_start + bi].len(),
+                });
             }
         }
 
         if let Some(p) = &mut prof {
             p.push(StageProfile::host("mel", t_mel));
-            p.push(StageProfile::host("encoder", t_encoder));
+            p.push(StageProfile::gpu("encoder", t_encoder, encoder_kernels));
             p.push(StageProfile::host("decode", t_decode));
         }
 
-        Ok((transcripts, prof))
+        Ok((recognized, prof))
     }
 }

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -14,18 +14,37 @@ use svod_tensor::PrepareConfig;
 
 use crate::jit::InputSpec;
 
-use super::aligner::{WhisperAligner, WhisperAlignmentInput};
+use super::aligner::{AlignmentProfile, WhisperAligner, WhisperAlignmentInput};
 use super::config::{N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, SAMPLE_RATE};
 use super::decode::{
-    DecodeOptions, DecodeScheduleStats, attempt_strategies, prefill_decode_seed, run_fixed_slot_decode, strategy_width,
+    DecodeOptions, DecodeScheduleStats, attempt_strategies, detect_language_profile, prefill_decode_seed,
+    run_fixed_slot_decode, strategy_width,
 };
 use super::jit::{WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 use super::mel::WhisperMel;
 use super::model::Whisper;
 use super::plan::WhisperPlan;
+use super::profile::{CopyProfile, begin_host_copy};
 use super::tokenizer::WhisperTokenizer;
 
 pub use svod_arch::rnnt::Word;
+
+fn timed_d2d<T>(
+    enabled: bool,
+    fence: &svod_device::Buffer,
+    work: impl FnOnce() -> Result<T, TranscribeError>,
+) -> Result<(T, Duration), TranscribeError> {
+    if !enabled {
+        return work().map(|value| (value, Duration::ZERO));
+    }
+    // Exclude prior graph work, then wait for the complete async transfer group.
+    // This is synchronized host wall, not a hardware SDMA timestamp.
+    fence.synchronize().context(DeviceSnafu)?;
+    let started = Instant::now();
+    let value = work()?;
+    fence.synchronize().context(DeviceSnafu)?;
+    Ok((value, started.elapsed()))
+}
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
@@ -273,7 +292,7 @@ impl Transcriber for WhisperRecognizer {
         windows: &[&[f32]],
         profile: bool,
     ) -> Result<(Vec<Transcript>, Option<RunProfile>), Self::Error> {
-        let (recognized, profile) = self.recognize_windows(windows, profile)?;
+        let (recognized, mut profile_result, copies) = self.recognize_windows(windows, profile)?;
         let transcripts = recognized
             .into_iter()
             .map(|recognized| {
@@ -290,7 +309,12 @@ impl Transcriber for WhisperRecognizer {
                 }
             })
             .collect();
-        Ok((transcripts, profile))
+        if let Some(profile) = &mut profile_result {
+            for stage in copies.stages() {
+                profile.push(stage);
+            }
+        }
+        Ok((transcripts, profile_result))
     }
 }
 
@@ -335,10 +359,16 @@ impl WhisperAlignedTranscriber {
         self.recognizer.set_language(language);
     }
 
-    fn align_recognized(&mut self, recognized: Vec<RecognizedWindow>) -> Result<Vec<Transcript>, TranscribeError> {
+    fn align_recognized(
+        &mut self,
+        recognized: Vec<RecognizedWindow>,
+        profile: bool,
+        copies: &mut CopyProfile,
+    ) -> Result<(Vec<Transcript>, AlignmentProfile), TranscribeError> {
         let task = self.recognizer.options.task;
         let tokenizer = &self.recognizer.tokenizer;
         let mut transcripts = Vec::with_capacity(recognized.len());
+        let mut alignment_profile = AlignmentProfile::default();
         for chunk in recognized.chunks(self.recognizer.plan.alignment_batch) {
             let inputs: Vec<_> = chunk
                 .iter()
@@ -352,10 +382,12 @@ impl WhisperAlignedTranscriber {
                     audio_samples: recognized.audio_samples,
                 })
                 .collect();
-            let words = self
+            let (words, batch_profile) = self
                 .aligner
-                .align_batch(&inputs, tokenizer)
+                .align_batch_profiled(&inputs, tokenizer, profile.then_some(&mut *copies))
                 .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+            alignment_profile.graph_wall += batch_profile.graph_wall;
+            alignment_profile.cpu_dtw_wall += batch_profile.cpu_dtw_wall;
             for (recognized, words) in chunk.iter().zip(words) {
                 let segments = super::decode::split_into_segments(
                     &recognized.result.tokens,
@@ -370,7 +402,7 @@ impl WhisperAlignedTranscriber {
                 });
             }
         }
-        Ok(transcripts)
+        Ok((transcripts, alignment_profile))
     }
 }
 
@@ -386,11 +418,19 @@ impl Transcriber for WhisperAlignedTranscriber {
         windows: &[&[f32]],
         profile: bool,
     ) -> Result<(Vec<Transcript>, Option<RunProfile>), Self::Error> {
-        let (recognized, mut profile_result) = self.recognizer.recognize_windows(windows, profile)?;
-        let started = Instant::now();
-        let transcripts = self.align_recognized(recognized)?;
+        let (recognized, mut profile_result, mut copies) = self.recognizer.recognize_windows(windows, profile)?;
+        let (transcripts, alignment) = self.align_recognized(recognized, profile, &mut copies)?;
         if let Some(profile) = &mut profile_result {
-            profile.push(StageProfile::host("alignment", started.elapsed()));
+            let mut graph = StageProfile::host("alignment_graph", alignment.graph_wall);
+            graph.meta.insert(
+                "timing_semantics".into(),
+                "synchronized host wall from graph submission through GPU completion; not a hardware timestamp".into(),
+            );
+            profile.push(graph);
+            profile.push(StageProfile::host("alignment_cpu_dtw", alignment.cpu_dtw_wall));
+            for stage in copies.stages() {
+                profile.push(stage);
+            }
         }
         Ok((transcripts, profile_result))
     }
@@ -401,9 +441,9 @@ impl WhisperRecognizer {
         &mut self,
         windows: &[&[f32]],
         profile: bool,
-    ) -> Result<(Vec<RecognizedWindow>, Option<RunProfile>), TranscribeError> {
+    ) -> Result<(Vec<RecognizedWindow>, Option<RunProfile>, CopyProfile), TranscribeError> {
         if windows.is_empty() {
-            return Ok((Vec::new(), profile.then(RunProfile::default)));
+            return Ok((Vec::new(), profile.then(RunProfile::default), CopyProfile::default()));
         }
 
         let n_mels = self.n_mels;
@@ -419,6 +459,7 @@ impl WhisperRecognizer {
         let mut encoder_kernels = Vec::new();
         let mut decode_kernels = Vec::new();
         let mut decode_stats = DecodeScheduleStats::default();
+        let mut copies = CopyProfile::default();
         let (mut t_mel, mut t_encoder, mut t_decode) = (Duration::ZERO, Duration::ZERO, Duration::ZERO);
 
         for batch_start in (0..windows.len()).step_by(max_batch) {
@@ -433,9 +474,14 @@ impl WhisperRecognizer {
                 for bi in 0..b {
                     packed[bi * mel_stride..(bi + 1) * mel_stride].copy_from_slice(&batch_mels[bi][..mel_stride]);
                 }
+                let copy_started = begin_host_copy(profile, mel_buf)
+                    .map_err(|source| TranscribeError::Model { source: Box::new(source) })?;
                 let dst = mel_buf.as_host_bytes_mut().context(DeviceSnafu)?;
                 let src_bytes: &[u8] = bytemuck::cast_slice(&packed);
                 dst[..src_bytes.len()].copy_from_slice(src_bytes);
+                if let Some(started) = copy_started {
+                    copies.h2d("mel_input", 1, src_bytes.len(), started.elapsed());
+                }
             }
             t_mel += t.elapsed();
 
@@ -462,7 +508,7 @@ impl WhisperRecognizer {
                 let t = Instant::now();
 
                 // Project encoder features once for all fallback prefills.
-                {
+                let (_, projection_wall) = timed_d2d(profile, out_buf, || {
                     let buf = self.cross_kv_jit.audio_features_mut().context(JitSnafu)?;
                     buf.copy_region_from(
                         0,
@@ -471,10 +517,17 @@ impl WhisperRecognizer {
                         item_stride * std::mem::size_of::<f32>(),
                     )
                     .context(DeviceSnafu)?;
+                    Ok(())
+                })?;
+                if profile {
+                    copies.d2d("projection_input", 1, item_stride * std::mem::size_of::<f32>(), projection_wall);
                 }
                 self.cross_kv_jit.execute().context(JitSnafu)?;
-                {
+                let cross_k_fence = self.cross_kv_jit.cross_k().context(JitSnafu)?.clone();
+                let mut fanout_bytes = 0usize;
+                let (_, fanout_wall) = timed_d2d(profile, &cross_k_fence, || {
                     let src = self.cross_kv_jit.cross_k().context(JitSnafu)?;
+                    fanout_bytes = fanout_bytes.saturating_add(src.size().saturating_mul(2));
                     self.prefill_jit
                         .prepared_cross_k_mut()
                         .context(JitSnafu)?
@@ -486,6 +539,7 @@ impl WhisperRecognizer {
                         .copy_region_from(0, src, 0, src.size())
                         .context(DeviceSnafu)?;
                     let src = self.cross_kv_jit.cross_v().context(JitSnafu)?;
+                    fanout_bytes = fanout_bytes.saturating_add(src.size().saturating_mul(2));
                     self.prefill_jit
                         .prepared_cross_v_mut()
                         .context(JitSnafu)?
@@ -496,15 +550,24 @@ impl WhisperRecognizer {
                         .context(JitSnafu)?
                         .copy_region_from(0, src, 0, src.size())
                         .context(DeviceSnafu)?;
+                    Ok(())
+                })?;
+                if profile {
+                    copies.d2d("cross_fanout", 4, fanout_bytes, fanout_wall);
                 }
 
                 let mut options = self.options.clone();
                 if !self.tokenizer.multilingual {
                     options.language = Some("en".to_string());
                 } else if options.language.is_none() {
-                    let detection =
-                        super::decode::detect_language(&mut self.decoder_jit, n_text_ctx, n_vocab, &self.tokenizer)
-                            .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+                    let detection = detect_language_profile(
+                        &mut self.decoder_jit,
+                        n_text_ctx,
+                        n_vocab,
+                        &self.tokenizer,
+                        profile.then_some(&mut copies),
+                    )
+                    .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
                     options.language = Some(detection.language);
                 }
 
@@ -516,6 +579,7 @@ impl WhisperRecognizer {
                     n_vocab,
                     &self.pos_embedding,
                     self.n_audio_state,
+                    profile.then_some(&mut copies),
                 )
                 .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
                 t_decode += t.elapsed();
@@ -532,6 +596,7 @@ impl WhisperRecognizer {
                 &self.tokenizer,
                 n_text_ctx,
                 n_vocab,
+                profile,
                 profile && decode_kernels.is_empty(),
             )
             .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
@@ -576,6 +641,7 @@ impl WhisperRecognizer {
             p.push(decode);
         }
 
-        Ok((recognized, prof))
+        copies.merge(decode_stats.copies.clone());
+        Ok((recognized, prof, copies))
     }
 }

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -168,7 +168,7 @@ impl WhisperRecognizer {
 
         // Cache-consuming decoder used for language detection.
         let mut decoder_jit = WhisperDecoderJit::new(model.clone());
-        let tokens_spec = InputSpec::i32(&[1, N_TEXT_CTX]);
+        let tokens_spec = InputSpec::i32(&[1, 1]);
         decoder_jit
             .prepare_with_config(cross_cache_spec.clone(), cross_cache_spec.clone(), tokens_spec, &prepare_config)
             .context(JitSnafu)?;
@@ -565,7 +565,6 @@ impl WhisperRecognizer {
                 } else if options.language.is_none() {
                     let detection = detect_language_profile(
                         &mut self.decoder_jit,
-                        n_text_ctx,
                         n_vocab,
                         &self.tokenizer,
                         profile.then_some(&mut copies),

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -16,7 +16,7 @@ use crate::jit::InputSpec;
 
 use super::aligner::{WhisperAligner, WhisperAlignmentInput};
 use super::config::{N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, SAMPLE_RATE};
-use super::decode::{DecodeLane, DecodeOptions, DecodeStrategy, run_batched_decode};
+use super::decode::{DecodeOptions, attempt_strategies, prefill_decode_seed, run_fixed_slot_decode, strategy_width};
 use super::jit::{WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 use super::mel::WhisperMel;
 use super::model::Whisper;
@@ -58,7 +58,6 @@ pub struct WhisperRecognizer {
     decoder_jit: WhisperDecoderJit,
     cross_kv_jit: WhisperCrossKvJit,
     prefill_jit: WhisperPrefillJit,
-    step_jits: rustc_hash::FxHashMap<usize, WhisperDecoderStepJit>,
     /// Concrete fixed-capacity step graph. Requests keep stable row ownership;
     /// inactive rows execute with ignored outputs.
     batched_step_jit: WhisperDecoderStepJit,
@@ -105,6 +104,13 @@ impl WhisperRecognizer {
         options.validate().map_err(|message| TranscribeError::Model {
             source: Box::new(super::error::Error::Decode { msg: message.to_string() }),
         })?;
+        if attempt_strategies(&options).into_iter().any(|strategy| strategy_width(strategy) > plan.decoder_slots) {
+            return Err(TranscribeError::Model {
+                source: Box::new(super::error::Error::Decode {
+                    msg: "configured decode beam width exceeds decoder_slots".to_string(),
+                }),
+            });
+        }
         let n_mels = model.dims.n_mels;
         let n_audio_state = model.dims.n_audio_state;
         let n_vocab = model.dims.n_vocab;
@@ -168,53 +174,7 @@ impl WhisperRecognizer {
             )
             .context(JitSnafu)?;
 
-        // Prepare only the concrete row counts required by the primary strategy
-        // and optional sampling fallback.
         let n_text_head_local = n_text_head;
-        let mut step_jits: rustc_hash::FxHashMap<usize, WhisperDecoderStepJit> = rustc_hash::FxHashMap::default();
-
-        let beam_sizes: std::collections::HashSet<usize> = {
-            let mut s = std::collections::HashSet::new();
-            match options.strategy {
-                DecodeStrategy::Beam { size } => {
-                    s.insert(size);
-                }
-                DecodeStrategy::Greedy | DecodeStrategy::Sample { .. } => {
-                    s.insert(1);
-                }
-            }
-            if options.fallback.is_some() {
-                s.insert(1);
-            }
-            s
-        };
-        // Device-local cache inputs: the KV caches live on-device and are
-        // recycled via SDMA copy (the RN-T block decoder / firered-vad idiom).
-        // The host never reads/writes cache floats — only integer offsets and
-        // the logits output. This unblocks low-precision compute: the cache
-        // dtype is a device-side decision, not pinned to the host Vec type.
-        for &bs in &beam_sizes {
-            let mut sj = WhisperDecoderStepJit::new(model.clone());
-            let token_spec = InputSpec::i32(&[bs, 1]);
-            let pos_emb_spec = InputSpec::f32(&[bs, 1, n_text_state]);
-            let self_cache_spec =
-                InputSpec::f32(&[bs, N_TEXT_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
-            let cross_cache_spec =
-                InputSpec::f32(&[bs, N_AUDIO_CTX, n_text_layer * n_text_head_local, d_head]).device_local();
-            let mask_spec = InputSpec::f32(&[bs, 1, 1, N_TEXT_CTX + 1]);
-            sj.prepare_with_config(
-                token_spec,
-                pos_emb_spec,
-                self_cache_spec.clone(),
-                self_cache_spec,
-                cross_cache_spec.clone(),
-                cross_cache_spec,
-                mask_spec,
-                &prepare_config,
-            )
-            .context(JitSnafu)?;
-            step_jits.insert(bs, sj);
-        }
 
         // Fixed concrete batch keeps tensor-core dimensions static and avoids
         // cache movement when lanes finish.
@@ -255,7 +215,6 @@ impl WhisperRecognizer {
             decoder_jit,
             cross_kv_jit,
             prefill_jit,
-            step_jits,
             batched_step_jit,
             tokenizer,
             options,
@@ -285,162 +244,6 @@ impl WhisperRecognizer {
 
     pub fn plan(&self) -> &WhisperPlan {
         &self.plan
-    }
-
-    /// Greedy throughput path that decodes windows through stable fixed slots,
-    /// refilling each slot as its current request finishes.
-    ///
-    /// Encoder + prefill still run per-window (the encoder is already
-    /// batched within `max_batch`; prefill is a single 4-token forward).
-    /// Fallback is disabled, so the schedule is one greedy pass per window.
-    fn recognize_windows_batched_greedy(
-        &mut self,
-        windows: &[&[f32]],
-    ) -> Result<Vec<RecognizedWindow>, TranscribeError> {
-        if windows.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let n_mels = self.n_mels;
-        let d = self.n_audio_state;
-        let mel_stride = n_mels * N_FRAMES;
-        let item_stride = N_AUDIO_CTX * d;
-        let max_batch = self.max_batch;
-        let n_vocab = self.n_vocab;
-        let n_text_ctx = self.n_text_ctx;
-
-        // The fixed-slot API is explicitly greedy and has no retry attempts.
-        let mut batched_opts = self.options.clone();
-        batched_opts.strategy = DecodeStrategy::Greedy;
-        batched_opts.fallback = None;
-
-        let mut recognized = Vec::with_capacity(windows.len());
-        let mut lanes: Vec<(DecodeLane, DecodeOptions)> = Vec::with_capacity(windows.len());
-        let mut alignment_audio = Vec::with_capacity(windows.len());
-
-        // Encode + prefill in encoder-sized batches, building one DecodeLane
-        // per window. The encoder already handles up to max_batch windows per
-        // dispatch; prefill runs per-window on the resulting audio features.
-        for batch_start in (0..windows.len()).step_by(max_batch) {
-            let b = (windows.len() - batch_start).min(max_batch);
-
-            // ── Mel: compute + pack into [b, n_mels, N_FRAMES] ──────────
-            let batch_mels: Vec<Vec<f32>> = (0..b).map(|bi| self.compute_mel(windows[batch_start + bi])).collect();
-            {
-                let mel_buf = self.encoder_jit.mel_mut().context(JitSnafu)?;
-                let mut packed = vec![0f32; max_batch * mel_stride];
-                for bi in 0..b {
-                    packed[bi * mel_stride..(bi + 1) * mel_stride].copy_from_slice(&batch_mels[bi][..mel_stride]);
-                }
-                let dst = mel_buf.as_host_bytes_mut().context(DeviceSnafu)?;
-                let src_bytes: &[u8] = bytemuck::cast_slice(&packed);
-                dst[..src_bytes.len()].copy_from_slice(src_bytes);
-            }
-
-            // ── Encode: one dispatch for b windows ───────────────────────
-            self.encoder_jit.execute().context(JitSnafu)?;
-            let out_buf = self.encoder_jit.output().context(JitSnafu)?;
-            let mut raw = vec![0f32; b * item_stride];
-            out_buf.copyout_prefix(bytemuck::cast_slice_mut(&mut raw)).context(DeviceSnafu)?;
-
-            // ── Prefill: per-window, build a DecodeLane ──────────────────
-            for bi in 0..b {
-                let base = bi * item_stride;
-                // Project this window once, then bind the packed caches into
-                // both language detection and token prefill.
-                {
-                    let buf = self.cross_kv_jit.audio_features_mut().context(JitSnafu)?;
-                    buf.copy_region_from(
-                        0,
-                        out_buf,
-                        base * std::mem::size_of::<f32>(),
-                        item_stride * std::mem::size_of::<f32>(),
-                    )
-                    .context(DeviceSnafu)?;
-                }
-                self.cross_kv_jit.execute().context(JitSnafu)?;
-                {
-                    let src = self.cross_kv_jit.cross_k().context(JitSnafu)?;
-                    self.prefill_jit
-                        .prepared_cross_k_mut()
-                        .context(JitSnafu)?
-                        .copy_region_from(0, src, 0, src.size())
-                        .context(DeviceSnafu)?;
-                    self.decoder_jit
-                        .prepared_cross_k_mut()
-                        .context(JitSnafu)?
-                        .copy_region_from(0, src, 0, src.size())
-                        .context(DeviceSnafu)?;
-                    let src = self.cross_kv_jit.cross_v().context(JitSnafu)?;
-                    self.prefill_jit
-                        .prepared_cross_v_mut()
-                        .context(JitSnafu)?
-                        .copy_region_from(0, src, 0, src.size())
-                        .context(DeviceSnafu)?;
-                    self.decoder_jit
-                        .prepared_cross_v_mut()
-                        .context(JitSnafu)?
-                        .copy_region_from(0, src, 0, src.size())
-                        .context(DeviceSnafu)?;
-                }
-                // Resolve language for this window (auto-detect if unset).
-                let mut lane_opts = batched_opts.clone();
-                if !self.tokenizer.multilingual {
-                    lane_opts.language = Some("en".to_string());
-                } else if lane_opts.language.is_none() {
-                    let detection =
-                        super::decode::detect_language(&mut self.decoder_jit, n_text_ctx, n_vocab, &self.tokenizer)
-                            .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-                    lane_opts.language = Some(detection.language);
-                }
-
-                let lane = DecodeLane::prefill(
-                    &mut self.prefill_jit,
-                    &self.tokenizer,
-                    &lane_opts,
-                    n_text_ctx,
-                    n_vocab,
-                    &self.pos_embedding,
-                    self.n_audio_state,
-                )
-                .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-
-                alignment_audio.push(raw[base..base + item_stride].to_vec());
-                lanes.push((lane, lane_opts));
-            }
-        }
-
-        // ── Batched step-locked decode ───────────────────────────────────
-        // Run one concrete max-lane dispatch per token step. Finished rows stay
-        // inactive until their stable slots are reused.
-        let (mut lane_states, lane_options): (Vec<DecodeLane>, Vec<DecodeOptions>) = lanes.into_iter().unzip();
-        run_batched_decode(
-            &mut lane_states,
-            &mut self.batched_step_jit,
-            self.max_lanes,
-            &self.tokenizer,
-            &batched_opts,
-            n_text_ctx,
-            n_vocab,
-        )
-        .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-
-        // ── Collect finalized recognition artifacts ──────────────────────
-        for (index, (lane, lane_opts)) in lane_states.into_iter().zip(lane_options).enumerate() {
-            let mut result =
-                lane.finish(&self.tokenizer, &lane_opts).map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-            if result.should_skip(&lane_opts) {
-                result.clear_speech();
-            }
-
-            recognized.push(RecognizedWindow {
-                result,
-                audio_features: std::mem::take(&mut alignment_audio[index]),
-                audio_samples: windows[index].len(),
-            });
-        }
-
-        Ok(recognized)
     }
 
     /// Compute mel spectrogram for a window, padded/trimmed to N_FRAMES.
@@ -527,19 +330,6 @@ impl WhisperAlignedTranscriber {
 
     pub fn set_language(&mut self, language: Option<String>) {
         self.recognizer.set_language(language);
-    }
-
-    /// Decode windows with the concrete fixed-slot scheduler.
-    ///
-    /// This throughput-oriented path uses greedy decoding and disables
-    /// temperature fallback. Use [`Transcriber::transcribe_windows`] when beam
-    /// search and fallback policy are required.
-    pub fn transcribe_windows_batched_greedy(
-        &mut self,
-        windows: &[&[f32]],
-    ) -> Result<Vec<Transcript>, TranscribeError> {
-        let recognized = self.recognizer.recognize_windows_batched_greedy(windows)?;
-        self.align_recognized(recognized)
     }
 
     fn align_recognized(&mut self, recognized: Vec<RecognizedWindow>) -> Result<Vec<Transcript>, TranscribeError> {
@@ -657,7 +447,12 @@ impl WhisperRecognizer {
             out_buf.copyout_prefix(bytemuck::cast_slice_mut(&mut raw)).context(DeviceSnafu)?;
             t_encoder += t.elapsed();
 
-            // ── Decode: per-window decode ──────────────────────────────────
+            let mut seeds = Vec::with_capacity(b);
+            let mut decode_options = Vec::with_capacity(b);
+
+            // Cross projection and token prefill remain per-window. Their
+            // immutable host seeds are retained until the shared scheduler
+            // accepts a primary or fallback attempt.
             for bi in 0..b {
                 let base = bi * item_stride;
 
@@ -700,25 +495,49 @@ impl WhisperRecognizer {
                         .context(DeviceSnafu)?;
                 }
 
-                let mut result = {
-                    super::decode::decode_with_fallback_cached(
-                        &mut self.prefill_jit,
-                        &mut self.step_jits,
-                        &mut self.decoder_jit,
-                        n_text_ctx,
-                        n_vocab,
-                        &self.tokenizer,
-                        &self.options,
-                        &self.pos_embedding,
-                        self.n_audio_state,
-                    )
+                let mut options = self.options.clone();
+                if !self.tokenizer.multilingual {
+                    options.language = Some("en".to_string());
+                } else if options.language.is_none() {
+                    let detection =
+                        super::decode::detect_language(&mut self.decoder_jit, n_text_ctx, n_vocab, &self.tokenizer)
+                            .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+                    options.language = Some(detection.language);
                 }
-                .map_err(|e| TranscribeError::Model { source: Box::new(e) })?;
-                if result.should_skip(&self.options) {
+
+                let seed = prefill_decode_seed(
+                    &mut self.prefill_jit,
+                    &self.tokenizer,
+                    &options,
+                    n_text_ctx,
+                    n_vocab,
+                    &self.pos_embedding,
+                    self.n_audio_state,
+                )
+                .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+                t_decode += t.elapsed();
+                seeds.push(seed);
+                decode_options.push(options);
+            }
+
+            let t = Instant::now();
+            let results = run_fixed_slot_decode(
+                &seeds,
+                &decode_options,
+                &mut self.batched_step_jit,
+                self.max_lanes,
+                &self.tokenizer,
+                n_text_ctx,
+                n_vocab,
+            )
+            .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+            t_decode += t.elapsed();
+
+            for (bi, (mut result, options)) in results.into_iter().zip(&decode_options).enumerate() {
+                if result.should_skip(options) {
                     result.clear_speech();
                 }
-                t_decode += t.elapsed();
-
+                let base = bi * item_stride;
                 recognized.push(RecognizedWindow {
                     result,
                     audio_features: raw[base..base + item_stride].to_vec(),

--- a/model/src/whisper/transcribe.rs
+++ b/model/src/whisper/transcribe.rs
@@ -16,7 +16,9 @@ use crate::jit::InputSpec;
 
 use super::aligner::{WhisperAligner, WhisperAlignmentInput};
 use super::config::{N_AUDIO_CTX, N_FRAMES, N_TEXT_CTX, SAMPLE_RATE};
-use super::decode::{DecodeOptions, attempt_strategies, prefill_decode_seed, run_fixed_slot_decode, strategy_width};
+use super::decode::{
+    DecodeOptions, DecodeScheduleStats, attempt_strategies, prefill_decode_seed, run_fixed_slot_decode, strategy_width,
+};
 use super::jit::{WhisperCrossKvJit, WhisperDecoderJit, WhisperDecoderStepJit, WhisperEncoderJit, WhisperPrefillJit};
 use super::mel::WhisperMel;
 use super::model::Whisper;
@@ -413,6 +415,7 @@ impl WhisperRecognizer {
         let mut recognized = Vec::with_capacity(windows.len());
         let mut prof = profile.then(RunProfile::default);
         let mut encoder_kernels = Vec::new();
+        let mut decode_stats = DecodeScheduleStats::default();
         let (mut t_mel, mut t_encoder, mut t_decode) = (Duration::ZERO, Duration::ZERO, Duration::ZERO);
 
         for batch_start in (0..windows.len()).step_by(max_batch) {
@@ -526,7 +529,7 @@ impl WhisperRecognizer {
             }
 
             let t = Instant::now();
-            let results = run_fixed_slot_decode(
+            let (results, batch_stats) = run_fixed_slot_decode(
                 &seeds,
                 &decode_options,
                 &mut self.batched_step_jit,
@@ -536,6 +539,7 @@ impl WhisperRecognizer {
                 n_vocab,
             )
             .map_err(|error| TranscribeError::Model { source: Box::new(error) })?;
+            decode_stats.merge(batch_stats);
             t_decode += t.elapsed();
 
             for (bi, ((mut result, options), audio_features)) in
@@ -555,7 +559,22 @@ impl WhisperRecognizer {
         if let Some(p) = &mut prof {
             p.push(StageProfile::host("mel", t_mel));
             p.push(StageProfile::gpu("encoder", t_encoder, encoder_kernels));
-            p.push(StageProfile::host("decode", t_decode));
+            let mut decode = StageProfile::host("decode", t_decode);
+            decode.meta.insert("dispatches".into(), decode_stats.dispatches.to_string());
+            decode.meta.insert("active_row_steps".into(), decode_stats.active_row_steps.to_string());
+            decode.meta.insert("reserved_row_steps".into(), decode_stats.reserved_row_steps.to_string());
+            decode.meta.insert("capacity_row_steps".into(), decode_stats.capacity_row_steps.to_string());
+            decode.meta.insert("cache_clone_ops".into(), decode_stats.cache_clone_ops.to_string());
+            decode.meta.insert("cache_clone_bytes".into(), decode_stats.cache_clone_bytes.to_string());
+            decode.meta.insert("attempts".into(), decode_stats.attempts.to_string());
+            decode.meta.insert("fallback_attempts".into(), decode_stats.fallback_attempts.to_string());
+            let utilization = if decode_stats.capacity_row_steps == 0 {
+                0.0
+            } else {
+                decode_stats.active_row_steps as f64 / decode_stats.capacity_row_steps as f64
+            };
+            decode.meta.insert("row_utilization".into(), format!("{utilization:.4}"));
+            p.push(decode);
         }
 
         Ok((recognized, prof))

--- a/runtime/src/execution_plan.rs
+++ b/runtime/src/execution_plan.rs
@@ -723,7 +723,13 @@ impl ExecutionPlan {
         let src_index = *self.output_buffer_indices.get(out_pos).ok_or_else(|| crate::error::Error::Execution {
             reason: format!("copy_output_region_to_buffer: output {out_pos} out of range"),
         })?;
-        if src_index == dst_index {
+        let src = self.buffers.get(src_index).ok_or_else(|| crate::error::Error::Execution {
+            reason: format!("copy_output_region_to_buffer: source buffer {src_index} out of range"),
+        })?;
+        let dst = self.buffers.get(dst_index).ok_or_else(|| crate::error::Error::Execution {
+            reason: format!("copy_output_region_to_buffer: destination buffer {dst_index} out of range"),
+        })?;
+        if src.storage_id() == dst.storage_id() {
             return Err(crate::error::Error::Execution {
                 reason: "copy_output_region_to_buffer: output aliases destination".into(),
             });

--- a/runtime/src/test/unit/execution_plan.rs
+++ b/runtime/src/test/unit/execution_plan.rs
@@ -31,6 +31,30 @@ fn test_empty_plan_output_buffer_returns_none() {
 }
 
 #[test]
+fn test_copy_output_region_to_buffer() {
+    let alloc = svod_device::registry::cpu().expect("cpu allocator");
+    let mut output = Buffer::new(alloc.clone(), DType::UInt8, vec![8], Default::default());
+    let mut destination = Buffer::new(alloc, DType::UInt8, vec![8], Default::default());
+    output.copyin(&[0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
+    destination.copyin(&[9; 8]).unwrap();
+
+    let mut builder = ExecutionPlanBuilder::new(DeviceSpec::Cpu);
+    let output_idx = builder.add_buffer(1, output);
+    let destination_idx = builder.add_buffer(2, destination);
+    builder.set_output_buffer(output_idx);
+    let mut plan = builder.build().unwrap();
+
+    plan.copy_output_region_to_buffer(0, destination_idx, 2, 3, 3).unwrap();
+    let mut actual = [0; 8];
+    plan.buffers()[destination_idx].copyout(&mut actual).unwrap();
+    assert_eq!(actual, [9, 9, 3, 4, 5, 9, 9, 9]);
+
+    assert!(plan.copy_output_region_to_buffer(1, destination_idx, 0, 0, 1).is_err());
+    assert!(plan.copy_output_region_to_buffer(0, 99, 0, 0, 1).is_err());
+    assert!(plan.copy_output_region_to_buffer(0, output_idx, 0, 0, 1).is_err());
+}
+
+#[test]
 fn test_builder_map_buffer_alias() {
     let alloc = svod_device::registry::cpu().expect("cpu allocator");
     let buf = Buffer::new(alloc, svod_dtype::DType::Float32, vec![8], Default::default());

--- a/tensor/src/test/unit/transformer.rs
+++ b/tensor/src/test/unit/transformer.rs
@@ -190,37 +190,6 @@ crate::codegen_tests! {
         }
     }
 
-    fn test_sdpa_float16_uses_float32_softmax_and_preserves_output_dtype(config) {
-        let q = Tensor::from_ndarray(&array![[[[8.0f32, -7.0], [3.5, 2.0]]]])
-            .cast(crate::DType::Float16)
-            .unwrap();
-        let k = Tensor::from_ndarray(&array![[[[1.5f32, -2.0], [-3.0, 4.0], [0.5, 1.0]]]])
-            .cast(crate::DType::Float16)
-            .unwrap();
-        let v = Tensor::from_ndarray(&array![[[[2.0f32, -1.0], [0.5, 3.0], [-4.0, 2.5]]]])
-            .cast(crate::DType::Float16)
-            .unwrap();
-
-        let result = q.scaled_dot_product_attention().key(&k).value(&v).call().unwrap();
-        assert_eq!(result.uop().dtype(), crate::DType::Float16);
-
-        let q32 = q.cast(crate::DType::Float32).unwrap();
-        let k32 = k.cast(crate::DType::Float32).unwrap();
-        let v32 = v.cast(crate::DType::Float32).unwrap();
-        let scale = Tensor::const_(1.0 / 2.0f64.sqrt(), crate::DType::Float32);
-        let scores = q32.matmul(&k32.try_transpose(-1, -2).unwrap()).unwrap().try_mul(&scale).unwrap();
-        let reference = scores.softmax(-1isize).unwrap().matmul(&v32).unwrap();
-
-        let mut actual = result.cast(crate::DType::Float32).unwrap();
-        let mut reference = reference;
-        Tensor::realize_batch_with([&mut actual, &mut reference], &config).unwrap();
-        let actual = actual.as_vec::<f32>().unwrap();
-        let reference = reference.as_vec::<f32>().unwrap();
-        for (actual, expected) in actual.iter().zip(reference) {
-            assert!((actual - expected).abs() < 5e-3, "float16 SDPA {actual} != fp32-softmax reference {expected}");
-        }
-    }
-
     fn test_sdpa_rejects_non_float_qkv(_config) {
         let qf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0]]]]);
         let kf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0], [0.0, 1.0]]]]);

--- a/tensor/src/test/unit/transformer.rs
+++ b/tensor/src/test/unit/transformer.rs
@@ -190,6 +190,37 @@ crate::codegen_tests! {
         }
     }
 
+    fn test_sdpa_float16_uses_float32_softmax_and_preserves_output_dtype(config) {
+        let q = Tensor::from_ndarray(&array![[[[8.0f32, -7.0], [3.5, 2.0]]]])
+            .cast(crate::DType::Float16)
+            .unwrap();
+        let k = Tensor::from_ndarray(&array![[[[1.5f32, -2.0], [-3.0, 4.0], [0.5, 1.0]]]])
+            .cast(crate::DType::Float16)
+            .unwrap();
+        let v = Tensor::from_ndarray(&array![[[[2.0f32, -1.0], [0.5, 3.0], [-4.0, 2.5]]]])
+            .cast(crate::DType::Float16)
+            .unwrap();
+
+        let result = q.scaled_dot_product_attention().key(&k).value(&v).call().unwrap();
+        assert_eq!(result.uop().dtype(), crate::DType::Float16);
+
+        let q32 = q.cast(crate::DType::Float32).unwrap();
+        let k32 = k.cast(crate::DType::Float32).unwrap();
+        let v32 = v.cast(crate::DType::Float32).unwrap();
+        let scale = Tensor::const_(1.0 / 2.0f64.sqrt(), crate::DType::Float32);
+        let scores = q32.matmul(&k32.try_transpose(-1, -2).unwrap()).unwrap().try_mul(&scale).unwrap();
+        let reference = scores.softmax(-1isize).unwrap().matmul(&v32).unwrap();
+
+        let mut actual = result.cast(crate::DType::Float32).unwrap();
+        let mut reference = reference;
+        Tensor::realize_batch_with([&mut actual, &mut reference], &config).unwrap();
+        let actual = actual.as_vec::<f32>().unwrap();
+        let reference = reference.as_vec::<f32>().unwrap();
+        for (actual, expected) in actual.iter().zip(reference) {
+            assert!((actual - expected).abs() < 5e-3, "float16 SDPA {actual} != fp32-softmax reference {expected}");
+        }
+    }
+
     fn test_sdpa_rejects_non_float_qkv(_config) {
         let qf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0]]]]);
         let kf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0], [0.0, 1.0]]]]);

--- a/tensor/src/test/unit/transformer.rs
+++ b/tensor/src/test/unit/transformer.rs
@@ -221,6 +221,33 @@ crate::codegen_tests! {
         }
     }
 
+    fn test_sdpa_float16_prescales_before_dot_product(config) {
+        let q = Tensor::from_slice(vec![40.0f32; 64])
+            .try_reshape([1usize, 1, 1, 64])
+            .unwrap()
+            .cast(crate::DType::Float16)
+            .unwrap();
+        let mut keys = vec![40.0f32; 64];
+        keys.extend(vec![-40.0f32; 64]);
+        let k = Tensor::from_slice(keys)
+            .try_reshape([1usize, 1, 2, 64])
+            .unwrap()
+            .cast(crate::DType::Float16)
+            .unwrap();
+        let v = Tensor::from_slice([1.0f32, 2.0])
+            .try_reshape([1usize, 1, 2, 1])
+            .unwrap()
+            .cast(crate::DType::Float16)
+            .unwrap();
+
+        let result = q.scaled_dot_product_attention().key(&k).value(&v).call().unwrap();
+        let mut result = result.cast(crate::DType::Float32).unwrap();
+        result.realize_with(&config).unwrap();
+        let value = result.as_vec::<f32>().unwrap()[0];
+        assert!(value.is_finite(), "low-precision attention overflowed before scaling");
+        assert!((value - 1.0).abs() < 1e-3, "unexpected prescaled attention output {value}");
+    }
+
     fn test_sdpa_rejects_non_float_qkv(_config) {
         let qf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0]]]]);
         let kf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0], [0.0, 1.0]]]]);

--- a/tensor/src/test/unit/transformer.rs
+++ b/tensor/src/test/unit/transformer.rs
@@ -221,33 +221,6 @@ crate::codegen_tests! {
         }
     }
 
-    fn test_sdpa_float16_prescales_before_dot_product(config) {
-        let q = Tensor::from_slice(vec![40.0f32; 64])
-            .try_reshape([1usize, 1, 1, 64])
-            .unwrap()
-            .cast(crate::DType::Float16)
-            .unwrap();
-        let mut keys = vec![40.0f32; 64];
-        keys.extend(vec![-40.0f32; 64]);
-        let k = Tensor::from_slice(keys)
-            .try_reshape([1usize, 1, 2, 64])
-            .unwrap()
-            .cast(crate::DType::Float16)
-            .unwrap();
-        let v = Tensor::from_slice([1.0f32, 2.0])
-            .try_reshape([1usize, 1, 2, 1])
-            .unwrap()
-            .cast(crate::DType::Float16)
-            .unwrap();
-
-        let result = q.scaled_dot_product_attention().key(&k).value(&v).call().unwrap();
-        let mut result = result.cast(crate::DType::Float32).unwrap();
-        result.realize_with(&config).unwrap();
-        let value = result.as_vec::<f32>().unwrap()[0];
-        assert!(value.is_finite(), "low-precision attention overflowed before scaling");
-        assert!((value - 1.0).abs() < 1e-3, "unexpected prescaled attention output {value}");
-    }
-
     fn test_sdpa_rejects_non_float_qkv(_config) {
         let qf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0]]]]);
         let kf = Tensor::from_ndarray(&array![[[[1.0f32, 0.0], [0.0, 1.0]]]]);

--- a/tensor/src/transformer.rs
+++ b/tensor/src/transformer.rs
@@ -234,7 +234,12 @@ impl Tensor {
         // Softmax + output. Re-zero out-of-band weights so a fully-masked row
         // (whose softmax would otherwise be uniform over the masked keys)
         // produces exact zeros rather than `1/k_len` leakage.
-        let mut attn_weights = scores.softmax(-1isize)?;
+        let low_precision_scores = scores.uop().dtype() == DType::Float16 || scores.uop().dtype() == DType::BFloat16;
+        let mut attn_weights = if low_precision_scores {
+            scores.cast(DType::Float32)?.softmax(-1isize)?.cast(scores_dtype.clone())?
+        } else {
+            scores.softmax(-1isize)?
+        };
         if let Some(keep) = keep_mask.as_ref() {
             let zero = Tensor::const_(ConstValue::zero(scores_dtype.base()), scores_dtype);
             let masked_out = keep.logical_not()?;

--- a/tensor/src/transformer.rs
+++ b/tensor/src/transformer.rs
@@ -234,12 +234,7 @@ impl Tensor {
         // Softmax + output. Re-zero out-of-band weights so a fully-masked row
         // (whose softmax would otherwise be uniform over the masked keys)
         // produces exact zeros rather than `1/k_len` leakage.
-        let low_precision_scores = scores.uop().dtype() == DType::Float16 || scores.uop().dtype() == DType::BFloat16;
-        let mut attn_weights = if low_precision_scores {
-            scores.cast(DType::Float32)?.softmax(-1isize)?.cast(scores_dtype.clone())?
-        } else {
-            scores.softmax(-1isize)?
-        };
+        let mut attn_weights = scores.softmax(-1isize)?;
         if let Some(keep) = keep_mask.as_ref() {
             let zero = Tensor::const_(ConstValue::zero(scores_dtype.base()), scores_dtype);
             let masked_out = keep.logical_not()?;

--- a/tensor/src/transformer.rs
+++ b/tensor/src/transformer.rs
@@ -149,15 +149,24 @@ impl Tensor {
             .context(SymbolicShapeUnsupportedSnafu { operation: "scaled_dot_product_attention" })?;
         let scale_val = scale.unwrap_or(1.0 / (head_dim as f64).sqrt());
 
-        let scores_dtype = self.uop().dtype();
+        let query_dtype = self.uop().dtype();
 
-        // Q @ K^T
-        let kt = key.try_transpose(-1, -2)?;
-        let mut scores = self.matmul(&kt)?;
-
-        // Scale
-        let scale_t = Tensor::const_(scale_val, scores_dtype.clone());
-        scores = scores.try_mul(&scale_t)?;
+        // Pre-scale low-precision Q/K so the unscaled dot product cannot
+        // overflow or discard precision before the usual 1/sqrt(D) factor is
+        // applied. This matches Whisper's explicit D^-1/4 formulation.
+        let low_precision_scores =
+            (query_dtype == DType::Float16 || query_dtype == DType::BFloat16) && key.uop().dtype() == query_dtype;
+        let mut scores = if low_precision_scores {
+            let prescale = Tensor::const_(scale_val.sqrt(), query_dtype.clone());
+            let q = self.try_mul(&prescale)?;
+            let k = key.try_mul(&prescale)?;
+            q.matmul_with().other(&k.try_transpose(-1, -2)?).dtype(DType::Float32).call()?
+        } else {
+            let scores = self.matmul(&key.try_transpose(-1, -2)?)?;
+            let scale_t = Tensor::const_(scale_val, scores.uop().dtype());
+            scores.try_mul(&scale_t)?
+        };
+        let scores_dtype = scores.uop().dtype();
 
         // Build a boolean "keep" mask that ANDs together the causal constraint,
         // the optional sliding-window band, and the user-supplied `attn_mask`.
@@ -234,16 +243,14 @@ impl Tensor {
         // Softmax + output. Re-zero out-of-band weights so a fully-masked row
         // (whose softmax would otherwise be uniform over the masked keys)
         // produces exact zeros rather than `1/k_len` leakage.
-        let low_precision_scores = scores.uop().dtype() == DType::Float16 || scores.uop().dtype() == DType::BFloat16;
-        let mut attn_weights = if low_precision_scores {
-            scores.cast(DType::Float32)?.softmax(-1isize)?.cast(scores_dtype.clone())?
-        } else {
-            scores.softmax(-1isize)?
-        };
+        let mut attn_weights = scores.softmax(-1isize)?;
         if let Some(keep) = keep_mask.as_ref() {
             let zero = Tensor::const_(ConstValue::zero(scores_dtype.base()), scores_dtype);
             let masked_out = keep.logical_not()?;
             attn_weights = zero.where_(&masked_out, &attn_weights)?;
+        }
+        if low_precision_scores {
+            attn_weights = attn_weights.cast(query_dtype)?;
         }
         attn_weights.matmul(value)
     }

--- a/tensor/src/transformer.rs
+++ b/tensor/src/transformer.rs
@@ -149,24 +149,15 @@ impl Tensor {
             .context(SymbolicShapeUnsupportedSnafu { operation: "scaled_dot_product_attention" })?;
         let scale_val = scale.unwrap_or(1.0 / (head_dim as f64).sqrt());
 
-        let query_dtype = self.uop().dtype();
+        let scores_dtype = self.uop().dtype();
 
-        // Pre-scale low-precision Q/K so the unscaled dot product cannot
-        // overflow or discard precision before the usual 1/sqrt(D) factor is
-        // applied. This matches Whisper's explicit D^-1/4 formulation.
-        let low_precision_scores =
-            (query_dtype == DType::Float16 || query_dtype == DType::BFloat16) && key.uop().dtype() == query_dtype;
-        let mut scores = if low_precision_scores {
-            let prescale = Tensor::const_(scale_val.sqrt(), query_dtype.clone());
-            let q = self.try_mul(&prescale)?;
-            let k = key.try_mul(&prescale)?;
-            q.matmul_with().other(&k.try_transpose(-1, -2)?).dtype(DType::Float32).call()?
-        } else {
-            let scores = self.matmul(&key.try_transpose(-1, -2)?)?;
-            let scale_t = Tensor::const_(scale_val, scores.uop().dtype());
-            scores.try_mul(&scale_t)?
-        };
-        let scores_dtype = scores.uop().dtype();
+        // Q @ K^T
+        let kt = key.try_transpose(-1, -2)?;
+        let mut scores = self.matmul(&kt)?;
+
+        // Scale
+        let scale_t = Tensor::const_(scale_val, scores_dtype.clone());
+        scores = scores.try_mul(&scale_t)?;
 
         // Build a boolean "keep" mask that ANDs together the causal constraint,
         // the optional sliding-window band, and the user-supplied `attn_mask`.
@@ -243,14 +234,16 @@ impl Tensor {
         // Softmax + output. Re-zero out-of-band weights so a fully-masked row
         // (whose softmax would otherwise be uniform over the masked keys)
         // produces exact zeros rather than `1/k_len` leakage.
-        let mut attn_weights = scores.softmax(-1isize)?;
+        let low_precision_scores = scores.uop().dtype() == DType::Float16 || scores.uop().dtype() == DType::BFloat16;
+        let mut attn_weights = if low_precision_scores {
+            scores.cast(DType::Float32)?.softmax(-1isize)?.cast(scores_dtype.clone())?
+        } else {
+            scores.softmax(-1isize)?
+        };
         if let Some(keep) = keep_mask.as_ref() {
             let zero = Tensor::const_(ConstValue::zero(scores_dtype.base()), scores_dtype);
             let masked_out = keep.logical_not()?;
             attn_weights = zero.where_(&masked_out, &attn_weights)?;
-        }
-        if low_precision_scores {
-            attn_weights = attn_weights.cast(query_dtype)?;
         }
         attn_weights.matmul(value)
     }

--- a/tk/Cargo.toml
+++ b/tk/Cargo.toml
@@ -43,3 +43,7 @@ harness = false
 [[bench]]
 name = "matmul"
 harness = false
+
+[[bench]]
+name = "sq_attention"
+harness = false

--- a/tk/benches/sq_attention.rs
+++ b/tk/benches/sq_attention.rs
@@ -1,0 +1,65 @@
+//! Whisper single-query attention device-time comparison.
+//!
+//! Run: `SVOD_DEVICE=AMD:0 cargo bench -p svod-tk --bench sq_attention`.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use svod_dtype::DType;
+use svod_tensor::Tensor;
+
+mod common;
+use common::{bench_plan, randn_bf16, requirements_met};
+
+fn randn_f32(shape: &[usize]) -> Tensor {
+    let mut t = randn_bf16(shape).cast(DType::Float32).expect("f32");
+    t.realize().expect("realize");
+    t
+}
+
+fn bench_sq_attention(c: &mut Criterion) {
+    if !requirements_met(svod_tk::kernels::sq_attention::SQ_ATTENTION_SUPPORTED_ARCHS) {
+        eprintln!("svod-tk single-query attention bench: skipped (unsupported target/toolchain)");
+        return;
+    }
+    let (b, h, d) = (5usize, 20usize, 64usize);
+    let mut group = c.benchmark_group("whisper_sq_attention");
+    for &(mode, n) in &[("self", 449usize), ("cross", 1500usize)] {
+        group.throughput(Throughput::Elements((4 * b * h * n * d) as u64));
+        let q = randn_f32(&[b, 1, h, d]);
+        let k = randn_f32(&[b, n, h, d]);
+        let v = randn_f32(&[b, n, h, d]);
+        let lens_values = [444i32, 445, 446, 447, 448];
+        let lens = (mode == "self").then(|| {
+            let mut t = Tensor::from_slice(lens_values);
+            t.realize().expect("realize lens");
+            t
+        });
+
+        let opts = svod_tk::SqAttentionOpts { key_lens: lens.as_ref(), include_last: mode == "self" };
+        let mut tk = svod_tk::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
+        let tk_plan = tk.prepare().expect("prepare tk");
+        group.bench_with_input(BenchmarkId::new("tk", mode), &n, |bencher, _| bench_plan(bencher, &tk_plan));
+
+        let perm = |t: &Tensor| t.try_permute(&[0, 2, 1, 3]).expect("permute");
+        let (qp, kp, vp) = (perm(&q), perm(&k), perm(&v));
+        let mask = (mode == "self").then(|| {
+            let values: Vec<bool> =
+                lens_values.iter().flat_map(|&len| (0..n).map(move |i| i >= len as usize && i + 1 != n)).collect();
+            Tensor::from_slice(values.as_slice()).try_reshape([b, 1, 1, n]).expect("self mask")
+        });
+        let sdpa = qp.scaled_dot_product_attention().key(&kp).value(&vp).is_causal(false);
+        let mut sdpa = match &mask {
+            Some(mask) => sdpa.attn_mask(mask).call().expect("masked sdpa"),
+            None => sdpa.call().expect("sdpa"),
+        };
+        let sdpa_plan = sdpa.prepare().expect("prepare sdpa");
+        group.bench_with_input(BenchmarkId::new("sdpa", mode), &n, |bencher, _| bench_plan(bencher, &sdpa_plan));
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(common::bench_profiler());
+    targets = bench_sq_attention
+}
+criterion_main!(benches);

--- a/tk/benches/sq_attention.rs
+++ b/tk/benches/sq_attention.rs
@@ -22,26 +22,32 @@ fn bench_sq_attention(c: &mut Criterion) {
     }
     let (b, h, d) = (5usize, 20usize, 64usize);
     let mut group = c.benchmark_group("whisper_sq_attention");
-    for &(mode, n) in &[("self", 449usize), ("cross", 1500usize)] {
+    for &(mode, n) in &[("self_short", 449usize), ("self_full", 449usize), ("cross", 1500usize)] {
         group.throughput(Throughput::Elements((4 * b * h * n * d) as u64));
         let q = randn_f32(&[b, 1, h, d]);
         let k = randn_f32(&[b, n, h, d]);
         let v = randn_f32(&[b, n, h, d]);
-        let lens_values = [444i32, 445, 446, 447, 448];
-        let lens = (mode == "self").then(|| {
+        let lens_values = if mode == "self_short" { [8i32, 9, 7, 8, 9] } else { [444i32, 445, 446, 447, 448] };
+        let lens = mode.starts_with("self").then(|| {
             let mut t = Tensor::from_slice(lens_values);
             t.realize().expect("realize lens");
             t
         });
 
-        let opts = svod_tk::SqAttentionOpts { key_lens: lens.as_ref(), include_last: mode == "self" };
-        let mut tk = svod_tk::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
-        let tk_plan = tk.prepare().expect("prepare tk");
-        group.bench_with_input(BenchmarkId::new("tk", mode), &n, |bencher, _| bench_plan(bencher, &tk_plan));
+        let splits: &[usize] = if mode == "cross" { &[1, 2, 4, 5, 10] } else { &[1] };
+        for &split in splits {
+            let opts =
+                svod_tk::SqAttentionOpts { key_lens: lens.as_ref(), include_last: mode.starts_with("self"), split };
+            let mut tk = svod_tk::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
+            let tk_plan = tk.prepare().expect("prepare tk");
+            group.bench_with_input(BenchmarkId::new(format!("tk/{mode}/split_{split}"), n), &n, |bencher, _| {
+                bench_plan(bencher, &tk_plan)
+            });
+        }
 
         let perm = |t: &Tensor| t.try_permute(&[0, 2, 1, 3]).expect("permute");
         let (qp, kp, vp) = (perm(&q), perm(&k), perm(&v));
-        let mask = (mode == "self").then(|| {
+        let mask = mode.starts_with("self").then(|| {
             let values: Vec<bool> =
                 lens_values.iter().flat_map(|&len| (0..n).map(move |i| i >= len as usize && i + 1 != n)).collect();
             Tensor::from_slice(values.as_slice()).try_reshape([b, 1, 1, n]).expect("self mask")
@@ -52,7 +58,9 @@ fn bench_sq_attention(c: &mut Criterion) {
             None => sdpa.call().expect("sdpa"),
         };
         let sdpa_plan = sdpa.prepare().expect("prepare sdpa");
-        group.bench_with_input(BenchmarkId::new("sdpa", mode), &n, |bencher, _| bench_plan(bencher, &sdpa_plan));
+        group.bench_with_input(BenchmarkId::new(format!("sdpa/{mode}"), n), &n, |bencher, _| {
+            bench_plan(bencher, &sdpa_plan)
+        });
     }
     group.finish();
 }

--- a/tk/src/group/shuffle.rs
+++ b/tk/src/group/shuffle.rs
@@ -11,6 +11,41 @@ use crate::tile::RT;
 use svod_ir::UOp;
 
 impl<'k> Group<'k> {
+    /// Butterfly reduction within each fixed-width power-of-two subgroup. XOR
+    /// partners never cross a subgroup boundary, so the result is replicated in
+    /// every lane of that subgroup without LDS or a barrier.
+    pub fn subgroup_reduce_scalar<F>(&self, mut value: Arc<UOp>, width: usize, op: F) -> Arc<UOp>
+    where
+        F: Fn(&Arc<UOp>, &Arc<UOp>) -> Arc<UOp>,
+    {
+        assert_eq!(self.warps, 1, "subgroup_reduce_scalar is a single-warp op");
+        assert!(width.is_power_of_two(), "subgroup width must be a power of two");
+        assert!(width <= self.ker.caps.wave_size, "subgroup width must not exceed wave size");
+        assert!(self.ker.caps.wave_size.is_multiple_of(width), "subgroup width must divide wave size");
+        let mut mask = 1i64;
+        while mask < width as i64 {
+            let partner = self.shuffle_lane(&value, &ixor(&self.laneid(), mask));
+            value = op(&value, &partner);
+            mask *= 2;
+        }
+        value
+    }
+
+    /// Gather one scalar SSA value from `src_lane` into every lane of the wave.
+    pub fn broadcast_scalar(&self, value: &Arc<UOp>, src_lane: i64) -> Arc<UOp> {
+        assert_eq!(self.warps, 1, "broadcast_scalar is a single-warp op");
+        let w = self.ker.caps.wave_size as i64;
+        assert!((0..w).contains(&src_lane), "broadcast source lane {src_lane} must be in 0..{w}");
+        self.shuffle_lane(value, &crate::index::cidx(src_lane))
+    }
+
+    /// Lane index within a fixed-width power-of-two subgroup.
+    pub fn subgroup_laneid(&self, width: usize) -> Arc<UOp> {
+        assert!(width.is_power_of_two(), "subgroup width must be a power of two");
+        assert!(self.ker.caps.wave_size.is_multiple_of(width), "subgroup width must divide wave size");
+        iand(&self.laneid(), width as i64 - 1)
+    }
+
     /// Full-wave butterfly reduction of one scalar SSA value. Each step gathers
     /// from `laneid ^ mask`, so the result is replicated in every lane without
     /// LDS or a barrier. `op` must be associative (normally add or max).

--- a/tk/src/group/shuffle.rs
+++ b/tk/src/group/shuffle.rs
@@ -11,6 +11,23 @@ use crate::tile::RT;
 use svod_ir::UOp;
 
 impl<'k> Group<'k> {
+    /// Full-wave butterfly reduction of one scalar SSA value. Each step gathers
+    /// from `laneid ^ mask`, so the result is replicated in every lane without
+    /// LDS or a barrier. `op` must be associative (normally add or max).
+    pub fn wave_reduce_scalar<F>(&self, mut value: Arc<UOp>, op: F) -> Arc<UOp>
+    where
+        F: Fn(&Arc<UOp>, &Arc<UOp>) -> Arc<UOp>,
+    {
+        assert_eq!(self.warps, 1, "wave_reduce_scalar is a single-warp op");
+        let mut mask = 1i64;
+        while mask < self.ker.caps.wave_size as i64 {
+            let partner = self.shuffle_lane(&value, &ixor(&self.laneid(), mask));
+            value = op(&value, &partner);
+            mask *= 2;
+        }
+        value
+    }
+
     /// Per-element cross-lane gather (the public face of [`Self::shuffle_lane`]): for
     /// each logical element, `dst` receives `src`'s value at the SAME position but
     /// from lane `src_lane(laneid)`. Single-warp; one `ds_bpermute` per element (no

--- a/tk/src/kernels/fa.rs
+++ b/tk/src/kernels/fa.rs
@@ -68,6 +68,12 @@ fn iconst(v: i64) -> Arc<UOp> {
 /// Validated on gfx942 (CDNA3) and gfx1151 (RDNA3.5).
 pub const FA_SUPPORTED_ARCHS: &[svod_dtype::AmdArch] = &[svod_dtype::AmdArch::Gfx942, svod_dtype::AmdArch::Gfx1151];
 
+/// Whether `device` can run the production graph flash-attention kernel.
+/// Uses the same architecture and AMD toolchain gate as [`crate::launch_custom`].
+pub fn flash_attention_supported(device: &svod_dtype::DeviceSpec) -> bool {
+    crate::target::resolve_supported_arch(device, FA_SUPPORTED_ARCHS).is_ok()
+}
+
 /// The **direct-launch** FA wrappers ([`flash_attention_forward`], `_mw`, `_mw_db`,
 /// `_mw_rdb`) hardcode the wave64 block size and the CDNA fragment tiles, so they
 /// stay gfx942-only — gfx1151 reaches the wave32 kernel only through the

--- a/tk/src/kernels/fa.rs
+++ b/tk/src/kernels/fa.rs
@@ -42,6 +42,10 @@ const NUM_WARPS: usize = 8;
 /// waves/block) is opt-in via [`FaConfig`]. `{32,32}`/`{32,64}` stay
 /// opt-in via the explicit-tile [`build_fa_mw_db`] args.
 const Q_BLK: usize = 16;
+/// Sequence-length multiple accepted by the baseline production flash-attention
+/// tile. Callers that explicitly choose to pad can use this without duplicating
+/// the kernel's tiling details.
+pub const FLASH_ATTENTION_SEQUENCE_MULTIPLE: usize = Q_BLK * NUM_WARPS;
 /// Default per-warp KV super-block height. `32` (2·BLK): profiling the small-grid
 /// fallback (the b=1/h=16 inference regime) showed FA is ILP/recurrence-bound, not
 /// occupancy-bound — a taller KV super-block raises per-warp WMMA ILP and halves the

--- a/tk/src/kernels/mod.rs
+++ b/tk/src/kernels/mod.rs
@@ -10,3 +10,4 @@ pub mod fa;
 pub mod kmeans;
 pub mod knn;
 pub mod matmul;
+pub mod sq_attention;

--- a/tk/src/kernels/sq_attention.rs
+++ b/tk/src/kernels/sq_attention.rs
@@ -2,8 +2,9 @@
 //!
 //! One wave owns one `(batch, head)`. Q stays resident in registers while K/V
 //! stream over N; lane `l` owns dimensions `l + j*wave_size`. Dot products use
-//! XOR-shuffle all-reduces and a one-pass stable online softmax. There is no LDS,
-//! MFMA, or split-K.
+//! XOR-shuffle all-reduces and a one-pass stable online softmax. Long unmasked
+//! attention can split K/V into contiguous chunks and associatively merge their
+//! FP32 softmax states. There is no LDS or MFMA.
 
 use std::sync::Arc;
 
@@ -14,20 +15,29 @@ use svod_ir::{ConstValue, UOp};
 use svod_tensor::Tensor;
 
 use crate::Kernel;
-use crate::index::{Idx, flat_index, load_at};
+use crate::index::{Idx, flat_index, flat_offset, index_off_gated, load_at};
 use crate::scaffold::GlSpec;
 
 /// Architectures on which the scalar shuffle implementation is supported.
 pub const SQ_ATTENTION_SUPPORTED_ARCHS: &[AmdArch] = &[AmdArch::Gfx942, AmdArch::Gfx1151];
 
 /// Compile-time masking options for [`single_query_attention`].
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub struct SqAttentionOpts<'a> {
     /// Optional `[B]` i32 valid-key counts. Keys `0..key_lens[b]` are valid.
     pub key_lens: Option<&'a Tensor>,
     /// Also include key `N-1`. Required when `key_lens` is present; this is the
     /// Whisper self-cache layout where the current token occupies the final slot.
     pub include_last: bool,
+    /// Number of contiguous K/V chunks. Values above one are supported only for
+    /// unmasked attention when `N` is divisible by `split`.
+    pub split: usize,
+}
+
+impl Default for SqAttentionOpts<'_> {
+    fn default() -> Self {
+        Self { key_lens: None, include_last: false, split: 1 }
+    }
 }
 
 fn cidx(v: i64) -> Arc<UOp> {
@@ -53,6 +63,7 @@ pub(crate) fn build_single_query_attention(
     let wave = ker.caps.wave_size;
     Kernel::assert_divisible(d, wave, "single-query attention D");
     assert!(n > 0, "single-query attention N must be > 0");
+    assert!(!masked || include_last, "masked single-query attention must include the appended key");
     let ept = d / wave;
     let warp = ker.warp();
     let f32 = DType::Float32;
@@ -96,8 +107,19 @@ pub(crate) fn build_single_query_attention(
     let max_reg = max_reg.after(smallvec![initialized.clone()]);
     let norm_reg = norm_reg.after(smallvec![initialized]);
 
-    let lp = ker.loop_static(n as i64);
-    let key = lp.index().clone();
+    let lp = match &prefix {
+        Some(prefix) => ker.loop_dynamic(prefix.add(&cidx(1))),
+        None => ker.loop_static(n as i64),
+    };
+    let loop_index = lp.index().clone();
+    // Whisper keeps the current token after the fixed cache. A masked launch
+    // streams only the valid prefix, then maps its final iteration to that slot.
+    let key = match &prefix {
+        Some(prefix) => {
+            UOp::try_where(loop_index.lt(prefix), loop_index.clone(), cidx(n as i64 - 1)).expect("select appended key")
+        }
+        None => loop_index,
+    };
     let q_loop = q_reg.after(smallvec![key.clone()]);
     let o_loop = o_reg.after(smallvec![key.clone()]);
     let max_loop = max_reg.after(smallvec![key.clone()]);
@@ -111,33 +133,21 @@ pub(crate) fn build_single_query_attention(
         dot = dot.add(&qv.mul(&kv));
     }
     let score = warp.wave_reduce_scalar(dot, |a, p| a.add(p));
-    let valid = prefix.as_ref().map(|len| {
-        let in_prefix = key.lt(len);
-        if include_last { in_prefix.or_(&key.eq(&cidx(n as i64 - 1))) } else { in_prefix }
-    });
-
     let old_max = load_at(&max_loop, &[1], &[Idx::Const(0)]);
     let old_norm = load_at(&norm_loop, &[1], &[Idx::Const(0)]);
     let next_max = old_max.max(&score);
     let alpha = old_max.sub(&next_max).try_exp2().expect("exp2 alpha");
     let beta = score.sub(&next_max).try_exp2().expect("exp2 beta");
-    let candidate_norm = old_norm.mul(&alpha).add(&beta);
-    let select = |candidate: Arc<UOp>, old: Arc<UOp>| match &valid {
-        Some(pred) => UOp::try_where(pred.clone(), candidate, old).expect("mask select"),
-        None => candidate,
-    };
-    let new_max = select(next_max, old_max);
-    let new_norm = select(candidate_norm, old_norm);
+    let new_norm = old_norm.mul(&alpha).add(&beta);
 
-    let max_store = flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(new_max);
+    let max_store = flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(next_max);
     let norm_store = flat_index(&norm_reg.after(smallvec![max_store.clone()]), &[1], &[Idx::Const(0)]).store(new_norm);
     let mut output_stores = Vec::with_capacity(ept);
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
         let vv = load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
-        let candidate = old_o.mul(&alpha).add(&vv.mul(&beta));
-        let new_o = select(candidate, old_o);
+        let new_o = old_o.mul(&alpha).add(&vv.mul(&beta));
         output_stores.push(
             flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)]).store(new_o),
         );
@@ -153,6 +163,201 @@ pub(crate) fn build_single_query_attention(
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let value = load_at(&final_o, &[ept], &[Idx::Const(j as i64)]).try_div(&denom).expect("normalize");
+        stores.push(
+            flat_index(out.uop(), out.shape(), &[Idx::from(&batch), Idx::Const(0), Idx::from(&head), Idx::from(dim)])
+                .store(value),
+        );
+    }
+    ker.push_store(UOp::group(stores), out.uop().clone());
+}
+
+/// Build one unnormalized online-softmax state per contiguous K/V split.
+///
+/// ABI is `numerator, stats, q, k, v`; outputs are `[B,S,H,D]` and
+/// `[B,S,H,2]`, where the final axis of stats is `(max, norm)`.
+pub(crate) fn build_single_query_attention_partial(
+    ker: &Kernel,
+    b: usize,
+    n: usize,
+    h: usize,
+    d: usize,
+    splits: usize,
+) {
+    let wave = ker.caps.wave_size;
+    Kernel::assert_divisible(d, wave, "single-query attention D");
+    assert!(splits > 1 && n.is_multiple_of(splits), "split attention requires equal non-empty chunks");
+    let ept = d / wave;
+    let chunk = n / splits;
+    let warp = ker.warp();
+    let f32 = DType::Float32;
+
+    let (outs, ins) = ker.bind_abi(
+        &[GlSpec::new(&[b, splits, h, d], f32.clone()), GlSpec::new(&[b, splits, h, 2], f32.clone())],
+        &[
+            GlSpec::new(&[b, 1, h, d], f32.clone()),
+            GlSpec::new(&[b, n, h, d], f32.clone()),
+            GlSpec::new(&[b, n, h, d], f32.clone()),
+        ],
+    );
+    let (numerator, stats) = (outs[0].clone(), outs[1].clone());
+    let (q, k, v) = (ins[0].clone(), ins[1].clone(), ins[2].clone());
+    let head = ker.grid_x();
+    let batch = ker.grid_y();
+    let split = ker.grid_z();
+    let lane = ker.laneid();
+
+    let q_reg = ker.alloc_reg(ept, f32.clone());
+    let o_reg = ker.alloc_reg(ept, f32.clone());
+    let max_reg = ker.alloc_reg(1, f32.clone());
+    let norm_reg = ker.alloc_reg(1, f32.clone());
+    let scale = f32c(std::f64::consts::LOG2_E / (d as f64).sqrt());
+    let mut init = Vec::with_capacity(2 * ept + 2);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let qv = load_at(q.uop(), q.shape(), &[Idx::from(&batch), Idx::Const(0), Idx::from(&head), Idx::from(dim)])
+            .mul(&scale);
+        init.push(flat_index(&q_reg, &[ept], &[Idx::Const(j as i64)]).store(qv));
+        init.push(flat_index(&o_reg, &[ept], &[Idx::Const(j as i64)]).store(f32c(0.0)));
+    }
+    init.push(flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(f32c(f64::NEG_INFINITY)));
+    init.push(flat_index(&norm_reg, &[1], &[Idx::Const(0)]).store(f32c(0.0)));
+    let initialized = UOp::group(init);
+    let q_reg = q_reg.after(smallvec![initialized.clone()]);
+    let o_reg = o_reg.after(smallvec![initialized.clone()]);
+    let max_reg = max_reg.after(smallvec![initialized.clone()]);
+    let norm_reg = norm_reg.after(smallvec![initialized]);
+
+    let lp = ker.loop_static(chunk as i64);
+    let key = split.mul(&cidx(chunk as i64)).add(lp.index());
+    let q_loop = q_reg.after(smallvec![key.clone()]);
+    let o_loop = o_reg.after(smallvec![key.clone()]);
+    let max_loop = max_reg.after(smallvec![key.clone()]);
+    let norm_loop = norm_reg.after(smallvec![key.clone()]);
+    let mut dot = f32c(0.0);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let qv = load_at(&q_loop, &[ept], &[Idx::Const(j as i64)]);
+        let kv = load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        dot = dot.add(&qv.mul(&kv));
+    }
+    let score = warp.wave_reduce_scalar(dot, |a, p| a.add(p));
+    let old_max = load_at(&max_loop, &[1], &[Idx::Const(0)]);
+    let old_norm = load_at(&norm_loop, &[1], &[Idx::Const(0)]);
+    let next_max = old_max.max(&score);
+    let alpha = old_max.sub(&next_max).try_exp2().expect("exp2 alpha");
+    let beta = score.sub(&next_max).try_exp2().expect("exp2 beta");
+    let max_store = flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(next_max);
+    let norm_store = flat_index(&norm_reg.after(smallvec![max_store.clone()]), &[1], &[Idx::Const(0)])
+        .store(old_norm.mul(&alpha).add(&beta));
+    let mut output_stores = Vec::with_capacity(ept);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
+        let vv = load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        output_stores.push(
+            flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)])
+                .store(old_o.mul(&alpha).add(&vv.mul(&beta))),
+        );
+    }
+    ker.push_store(UOp::group(output_stores), o_reg.clone());
+    let ended = lp.close();
+
+    let final_o = o_reg.after(smallvec![ended.clone()]);
+    let final_max = max_reg.after(smallvec![ended.clone()]);
+    let final_norm = norm_reg.after(smallvec![ended]);
+    let mut numerator_stores = Vec::with_capacity(ept);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        numerator_stores.push(
+            flat_index(
+                numerator.uop(),
+                numerator.shape(),
+                &[Idx::from(&batch), Idx::from(&split), Idx::from(&head), Idx::from(dim)],
+            )
+            .store(load_at(&final_o, &[ept], &[Idx::Const(j as i64)])),
+        );
+    }
+    ker.push_store(UOp::group(numerator_stores), numerator.uop().clone());
+
+    let lane_zero = lane.eq(&cidx(0));
+    let max_off = flat_offset(stats.shape(), &[Idx::from(&batch), Idx::from(&split), Idx::from(&head), Idx::Const(0)]);
+    let norm_off = flat_offset(stats.shape(), &[Idx::from(&batch), Idx::from(&split), Idx::from(&head), Idx::Const(1)]);
+    let stats_stores = UOp::group(vec![
+        index_off_gated(stats.uop(), max_off, lane_zero.clone()).store(load_at(&final_max, &[1], &[Idx::Const(0)])),
+        index_off_gated(stats.uop(), norm_off, lane_zero).store(load_at(&final_norm, &[1], &[Idx::Const(0)])),
+    ]);
+    ker.push_store(stats_stores, stats.uop().clone());
+}
+
+/// Merge split online-softmax states without rereading K/V.
+pub(crate) fn build_single_query_attention_merge(ker: &Kernel, b: usize, h: usize, d: usize, splits: usize) {
+    let wave = ker.caps.wave_size;
+    Kernel::assert_divisible(d, wave, "single-query attention D");
+    let ept = d / wave;
+    let f32 = DType::Float32;
+    let (outs, ins) = ker.bind_abi(
+        &[GlSpec::new(&[b, 1, h, d], f32.clone())],
+        &[GlSpec::new(&[b, splits, h, d], f32.clone()), GlSpec::new(&[b, splits, h, 2], f32.clone())],
+    );
+    let (out, numerator, stats) = (outs[0].clone(), ins[0].clone(), ins[1].clone());
+    let head = ker.grid_x();
+    let batch = ker.grid_y();
+    let lane = ker.laneid();
+    let o_reg = ker.alloc_reg(ept, f32.clone());
+    let max_reg = ker.alloc_reg(1, f32.clone());
+    let norm_reg = ker.alloc_reg(1, f32.clone());
+    let mut init = Vec::with_capacity(ept + 2);
+    for j in 0..ept {
+        init.push(flat_index(&o_reg, &[ept], &[Idx::Const(j as i64)]).store(f32c(0.0)));
+    }
+    init.push(flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(f32c(f64::NEG_INFINITY)));
+    init.push(flat_index(&norm_reg, &[1], &[Idx::Const(0)]).store(f32c(0.0)));
+    let initialized = UOp::group(init);
+    let o_reg = o_reg.after(smallvec![initialized.clone()]);
+    let max_reg = max_reg.after(smallvec![initialized.clone()]);
+    let norm_reg = norm_reg.after(smallvec![initialized]);
+
+    let lp = ker.loop_static(splits as i64);
+    let split = lp.index().clone();
+    let o_loop = o_reg.after(smallvec![split.clone()]);
+    let max_loop = max_reg.after(smallvec![split.clone()]);
+    let norm_loop = norm_reg.after(smallvec![split.clone()]);
+    let old_max = load_at(&max_loop, &[1], &[Idx::Const(0)]);
+    let old_norm = load_at(&norm_loop, &[1], &[Idx::Const(0)]);
+    let partial_max =
+        load_at(stats.uop(), stats.shape(), &[Idx::from(&batch), Idx::from(&split), Idx::from(&head), Idx::Const(0)]);
+    let partial_norm =
+        load_at(stats.uop(), stats.shape(), &[Idx::from(&batch), Idx::from(&split), Idx::from(&head), Idx::Const(1)]);
+    let next_max = old_max.max(&partial_max);
+    let alpha = old_max.sub(&next_max).try_exp2().expect("exp2 merge alpha");
+    let beta = partial_max.sub(&next_max).try_exp2().expect("exp2 merge beta");
+    let max_store = flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(next_max);
+    let norm_store = flat_index(&norm_reg.after(smallvec![max_store.clone()]), &[1], &[Idx::Const(0)])
+        .store(old_norm.mul(&alpha).add(&partial_norm.mul(&beta)));
+    let mut output_stores = Vec::with_capacity(ept);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
+        let partial_o = load_at(
+            numerator.uop(),
+            numerator.shape(),
+            &[Idx::from(&batch), Idx::from(&split), Idx::from(&head), Idx::from(dim)],
+        );
+        output_stores.push(
+            flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)])
+                .store(old_o.mul(&alpha).add(&partial_o.mul(&beta))),
+        );
+    }
+    ker.push_store(UOp::group(output_stores), o_reg.clone());
+    let ended = lp.close();
+
+    let final_o = o_reg.after(smallvec![ended.clone()]);
+    let final_norm = norm_reg.after(smallvec![ended]);
+    let denom = load_at(&final_norm, &[1], &[Idx::Const(0)]);
+    let mut stores = Vec::with_capacity(ept);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let value = load_at(&final_o, &[ept], &[Idx::Const(j as i64)]).try_div(&denom).expect("normalize merge");
         stores.push(
             flat_index(out.uop(), out.shape(), &[Idx::from(&batch), Idx::Const(0), Idx::from(&head), Idx::from(dim)])
                 .store(value),
@@ -178,6 +383,7 @@ pub fn single_query_attention(
     let (b, n, h, d) = (qd[0], kd[1], qd[2], qd[3]);
     let dtype = q.uop().dtype();
     let masked = opts.key_lens.is_some();
+    let splits = opts.split;
 
     ensure!(
         qd[1] == 1,
@@ -231,6 +437,15 @@ pub fn single_query_attention(
             multiple: 1usize
         }
     );
+    ensure!(
+        splits > 0 && (!masked || splits == 1) && (masked || n.is_multiple_of(splits)),
+        crate::launch::DimMultipleSnafu {
+            kernel: "single-query attention",
+            dim: "split (unmasked divisor of N; masked requires 1)",
+            value: splits,
+            multiple: 1usize
+        }
+    );
     if let Some(lens) = opts.key_lens {
         let ld = crate::launch::concrete_dims(lens, "single-query attention", "key_lens", 1)?;
         ensure!(
@@ -274,23 +489,53 @@ pub fn single_query_attention(
         true,
         move |arch| {
             let caps = crate::ArchCaps::for_arch(arch);
-            let out = Tensor::empty(&[b, 1, h, d], DType::Float32);
-            let mut inputs = vec![q, k, v];
-            if let Some(lens) = opts.key_lens {
-                inputs.push(lens);
+            if splits == 1 {
+                let out = Tensor::empty(&[b, 1, h, d], DType::Float32);
+                let mut inputs = vec![q, k, v];
+                if let Some(lens) = opts.key_lens {
+                    inputs.push(lens);
+                }
+                crate::graph_launch(
+                    "sq_attention",
+                    [h as i64, b as i64, 1],
+                    caps.wave_size as i64,
+                    out,
+                    &inputs,
+                    caps,
+                    move |ker| {
+                        build_single_query_attention(ker, b, n, h, d, masked, opts.include_last);
+                        ker.finish(1)
+                    },
+                )
+            } else {
+                let partials = crate::graph_launch_multi(
+                    "sq_attention_partial",
+                    [h as i64, b as i64, splits as i64],
+                    caps.wave_size as i64,
+                    vec![
+                        Tensor::empty(&[b, splits, h, d], DType::Float32),
+                        Tensor::empty(&[b, splits, h, 2], DType::Float32),
+                    ],
+                    &[q, k, v],
+                    caps,
+                    move |ker| {
+                        build_single_query_attention_partial(ker, b, n, h, d, splits);
+                        ker.finish(2)
+                    },
+                )?;
+                crate::graph_launch(
+                    "sq_attention_merge",
+                    [h as i64, b as i64, 1],
+                    caps.wave_size as i64,
+                    Tensor::empty(&[b, 1, h, d], DType::Float32),
+                    &[&partials[0], &partials[1]],
+                    caps,
+                    move |ker| {
+                        build_single_query_attention_merge(ker, b, h, d, splits);
+                        ker.finish(1)
+                    },
+                )
             }
-            crate::graph_launch(
-                "sq_attention",
-                [h as i64, b as i64, 1],
-                caps.wave_size as i64,
-                out,
-                &inputs,
-                caps,
-                move |ker| {
-                    build_single_query_attention(ker, b, n, h, d, masked, opts.include_last);
-                    ker.finish(1)
-                },
-            )
         },
     )
 }

--- a/tk/src/kernels/sq_attention.rs
+++ b/tk/src/kernels/sq_attention.rs
@@ -15,7 +15,7 @@ use svod_ir::{ConstValue, UOp};
 use svod_tensor::Tensor;
 
 use crate::Kernel;
-use crate::index::{Idx, flat_index, flat_offset, index_off_gated, load_at};
+use crate::index::{Idx, flat_index, flat_offset, index_off_gated, load_at, load_off_gated};
 use crate::scaffold::GlSpec;
 
 /// Architectures on which the scalar shuffle implementation is supported.
@@ -195,11 +195,16 @@ pub(crate) fn build_single_query_attention_partial(
     d: usize,
     splits: usize,
 ) {
+    const SUBGROUP: usize = 8;
     let wave = ker.caps.wave_size;
     Kernel::assert_divisible(d, wave, "single-query attention D");
+    Kernel::assert_divisible(d, SUBGROUP, "split single-query attention D");
     assert!(splits > 1 && n.is_multiple_of(splits), "split attention requires equal non-empty chunks");
     let ept = d / wave;
+    let dot_ept = d / SUBGROUP;
     let chunk = n / splits;
+    let groups = wave / SUBGROUP;
+    let tiles = chunk.div_ceil(groups);
     let warp = ker.warp();
     let f32 = DType::Float32;
 
@@ -222,17 +227,21 @@ pub(crate) fn build_single_query_attention_partial(
     let split = ker.grid_z();
     let lane = ker.laneid();
 
-    let q_reg = ker.alloc_reg(ept, f32.clone());
+    let q_reg = ker.alloc_reg(dot_ept, f32.clone());
     let o_reg = ker.alloc_reg(ept, f32.clone());
     let max_reg = ker.alloc_reg(1, f32.clone());
     let norm_reg = ker.alloc_reg(1, f32.clone());
     let scale = f32c(std::f64::consts::LOG2_E / (d as f64).sqrt());
-    let mut init = Vec::with_capacity(2 * ept + 2);
-    for j in 0..ept {
-        let dim = lane.add(&cidx((j * wave) as i64));
+    let subgroup_lane = warp.subgroup_laneid(SUBGROUP);
+    let group = lane.idiv(&cidx(SUBGROUP as i64));
+    let mut init = Vec::with_capacity(dot_ept + ept + 2);
+    for j in 0..dot_ept {
+        let dim = subgroup_lane.add(&cidx((j * SUBGROUP) as i64));
         let qv = load_at(q.uop(), q.shape(), &[Idx::from(&batch), Idx::Const(0), Idx::from(&head), Idx::from(dim)])
             .mul(&scale);
-        init.push(flat_index(&q_reg, &[ept], &[Idx::Const(j as i64)]).store(qv));
+        init.push(flat_index(&q_reg, &[dot_ept], &[Idx::Const(j as i64)]).store(qv));
+    }
+    for j in 0..ept {
         init.push(flat_index(&o_reg, &[ept], &[Idx::Const(j as i64)]).store(f32c(0.0)));
     }
     init.push(flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(f32c(f64::NEG_INFINITY)));
@@ -243,38 +252,58 @@ pub(crate) fn build_single_query_attention_partial(
     let max_reg = max_reg.after(smallvec![initialized.clone()]);
     let norm_reg = norm_reg.after(smallvec![initialized]);
 
-    let lp = ker.loop_static(chunk as i64);
-    let key = split.mul(&cidx(chunk as i64)).add(lp.index());
+    let lp = ker.loop_static(tiles as i64);
+    let tile_offset = lp.index().mul(&cidx(groups as i64));
+    let group_offset = tile_offset.add(&group);
+    let valid = group_offset.lt(&cidx(chunk as i64));
+    let key = split.mul(&cidx(chunk as i64)).add(&group_offset);
     let q_loop = q_reg.after(smallvec![key.clone()]);
     let o_loop = o_reg.after(smallvec![key.clone()]);
     let max_loop = max_reg.after(smallvec![key.clone()]);
     let norm_loop = norm_reg.after(smallvec![key.clone()]);
     let mut dot = f32c(0.0);
-    for j in 0..ept {
-        let dim = lane.add(&cidx((j * wave) as i64));
-        let qv = load_at(&q_loop, &[ept], &[Idx::Const(j as i64)]);
-        let kv =
-            load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
+    for j in 0..dot_ept {
+        let dim = subgroup_lane.add(&cidx((j * SUBGROUP) as i64));
+        let qv = load_at(&q_loop, &[dot_ept], &[Idx::Const(j as i64)]);
+        let k_off =
+            flat_offset(k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
+        let kv = load_off_gated(k.uop(), k_off, valid.clone(), f32c(0.0));
         dot = dot.add(&qv.mul(&kv));
     }
-    let score = warp.wave_reduce_scalar(dot, |a, p| a.add(p));
+    let score = warp.subgroup_reduce_scalar(dot, SUBGROUP, |a, p| a.add(p));
+    let score = UOp::try_where(valid.clone(), score, f32c(f64::NEG_INFINITY)).expect("mask tail score");
     let old_max = load_at(&max_loop, &[1], &[Idx::Const(0)]);
     let old_norm = load_at(&norm_loop, &[1], &[Idx::Const(0)]);
-    let next_max = old_max.max(&score);
+    let tile_max = warp.wave_reduce_scalar(score.clone(), |a, p| a.max(p));
+    let next_max = old_max.max(&tile_max);
     let alpha = old_max.sub(&next_max).try_exp2().expect("exp2 alpha");
     let beta = score.sub(&next_max).try_exp2().expect("exp2 beta");
+    let representative = subgroup_lane.eq(&cidx(0));
+    let norm_term = UOp::try_where(representative, beta.clone(), f32c(0.0)).expect("one beta per subgroup");
+    let tile_norm = warp.wave_reduce_scalar(norm_term, |a, p| a.add(p));
     let max_store = flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(next_max);
     let norm_store = flat_index(&norm_reg.after(smallvec![max_store.clone()]), &[1], &[Idx::Const(0)])
-        .store(old_norm.mul(&alpha).add(&beta));
+        .store(old_norm.mul(&alpha).add(&tile_norm));
+    let group_betas: Vec<_> = (0..groups).map(|g| warp.broadcast_scalar(&beta, (g * SUBGROUP) as i64)).collect();
     let mut output_stores = Vec::with_capacity(ept);
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
-        let vv =
-            load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
+        let mut tile_o = f32c(0.0);
+        for (g, group_beta) in group_betas.iter().enumerate() {
+            let group_key_offset = tile_offset.add(&cidx(g as i64));
+            let group_valid = group_key_offset.lt(&cidx(chunk as i64));
+            let group_key = split.mul(&cidx(chunk as i64)).add(&group_key_offset);
+            let v_off = flat_offset(
+                v.shape(),
+                &[Idx::from(&batch), Idx::from(&group_key), Idx::from(&packed_head), Idx::from(dim.clone())],
+            );
+            let vv = load_off_gated(v.uop(), v_off, group_valid, f32c(0.0));
+            tile_o = tile_o.add(&vv.mul(group_beta));
+        }
         output_stores.push(
             flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)])
-                .store(old_o.mul(&alpha).add(&vv.mul(&beta))),
+                .store(old_o.mul(&alpha).add(&tile_o)),
         );
     }
     ker.push_store(UOp::group(output_stores), o_reg.clone());

--- a/tk/src/kernels/sq_attention.rs
+++ b/tk/src/kernels/sq_attention.rs
@@ -1,0 +1,296 @@
+//! FP32 single-query attention for decoder inference.
+//!
+//! One wave owns one `(batch, head)`. Q stays resident in registers while K/V
+//! stream over N; lane `l` owns dimensions `l + j*wave_size`. Dot products use
+//! XOR-shuffle all-reduces and a one-pass stable online softmax. There is no LDS,
+//! MFMA, or split-K.
+
+use std::sync::Arc;
+
+use smallvec::smallvec;
+use snafu::ensure;
+use svod_dtype::{AmdArch, DType};
+use svod_ir::{ConstValue, UOp};
+use svod_tensor::Tensor;
+
+use crate::Kernel;
+use crate::index::{Idx, flat_index, load_at};
+use crate::scaffold::GlSpec;
+
+/// Architectures on which the scalar shuffle implementation is supported.
+pub const SQ_ATTENTION_SUPPORTED_ARCHS: &[AmdArch] = &[AmdArch::Gfx942, AmdArch::Gfx1151];
+
+/// Compile-time masking options for [`single_query_attention`].
+#[derive(Clone, Copy, Default)]
+pub struct SqAttentionOpts<'a> {
+    /// Optional `[B]` i32 valid-key counts. Keys `0..key_lens[b]` are valid.
+    pub key_lens: Option<&'a Tensor>,
+    /// Also include key `N-1`. Required when `key_lens` is present; this is the
+    /// Whisper self-cache layout where the current token occupies the final slot.
+    pub include_last: bool,
+}
+
+fn cidx(v: i64) -> Arc<UOp> {
+    UOp::const_(DType::Index, ConstValue::Int(v))
+}
+
+fn f32c(v: f64) -> Arc<UOp> {
+    UOp::const_(DType::Float32, ConstValue::Float(v))
+}
+
+/// Build the one-wave single-query attention kernel.
+///
+/// ABI is `out, q, k, v, [key_lens]`, with sequence-major `[B,S,H,D]` globals.
+pub(crate) fn build_single_query_attention(
+    ker: &Kernel,
+    b: usize,
+    n: usize,
+    h: usize,
+    d: usize,
+    masked: bool,
+    include_last: bool,
+) {
+    let wave = ker.caps.wave_size;
+    Kernel::assert_divisible(d, wave, "single-query attention D");
+    assert!(n > 0, "single-query attention N must be > 0");
+    let ept = d / wave;
+    let warp = ker.warp();
+    let f32 = DType::Float32;
+
+    let (outs, ins) = ker.bind_abi(
+        &[GlSpec::new(&[b, 1, h, d], f32.clone())],
+        &[
+            GlSpec::new(&[b, 1, h, d], f32.clone()),
+            GlSpec::new(&[b, n, h, d], f32.clone()),
+            GlSpec::new(&[b, n, h, d], f32.clone()),
+        ],
+    );
+    let (out, q, k, v) = (outs[0].clone(), ins[0].clone(), ins[1].clone(), ins[2].clone());
+    let batch = ker.grid_y();
+    let head = ker.grid_x();
+    let lane = ker.laneid();
+    let prefix = masked.then(|| {
+        let lens = ker.gl(&[b], DType::Int32);
+        load_at(lens.uop(), lens.shape(), &[Idx::from(&batch)]).cast(DType::Index)
+    });
+
+    let q_reg = ker.alloc_reg(ept, f32.clone());
+    let o_reg = ker.alloc_reg(ept, f32.clone());
+    let max_reg = ker.alloc_reg(1, f32.clone());
+    let norm_reg = ker.alloc_reg(1, f32.clone());
+    let scale = f32c(std::f64::consts::LOG2_E / (d as f64).sqrt());
+
+    let mut init = Vec::with_capacity(2 * ept + 2);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let qv = load_at(q.uop(), q.shape(), &[Idx::from(&batch), Idx::Const(0), Idx::from(&head), Idx::from(dim)])
+            .mul(&scale);
+        init.push(flat_index(&q_reg, &[ept], &[Idx::Const(j as i64)]).store(qv));
+        init.push(flat_index(&o_reg, &[ept], &[Idx::Const(j as i64)]).store(f32c(0.0)));
+    }
+    init.push(flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(f32c(f64::NEG_INFINITY)));
+    init.push(flat_index(&norm_reg, &[1], &[Idx::Const(0)]).store(f32c(0.0)));
+    let initialized = UOp::group(init);
+    let q_reg = q_reg.after(smallvec![initialized.clone()]);
+    let o_reg = o_reg.after(smallvec![initialized.clone()]);
+    let max_reg = max_reg.after(smallvec![initialized.clone()]);
+    let norm_reg = norm_reg.after(smallvec![initialized]);
+
+    let lp = ker.loop_static(n as i64);
+    let key = lp.index().clone();
+    let q_loop = q_reg.after(smallvec![key.clone()]);
+    let o_loop = o_reg.after(smallvec![key.clone()]);
+    let max_loop = max_reg.after(smallvec![key.clone()]);
+    let norm_loop = norm_reg.after(smallvec![key.clone()]);
+
+    let mut dot = f32c(0.0);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let qv = load_at(&q_loop, &[ept], &[Idx::Const(j as i64)]);
+        let kv = load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        dot = dot.add(&qv.mul(&kv));
+    }
+    let score = warp.wave_reduce_scalar(dot, |a, p| a.add(p));
+    let valid = prefix.as_ref().map(|len| {
+        let in_prefix = key.lt(len);
+        if include_last { in_prefix.or_(&key.eq(&cidx(n as i64 - 1))) } else { in_prefix }
+    });
+
+    let old_max = load_at(&max_loop, &[1], &[Idx::Const(0)]);
+    let old_norm = load_at(&norm_loop, &[1], &[Idx::Const(0)]);
+    let next_max = old_max.max(&score);
+    let alpha = old_max.sub(&next_max).try_exp2().expect("exp2 alpha");
+    let beta = score.sub(&next_max).try_exp2().expect("exp2 beta");
+    let candidate_norm = old_norm.mul(&alpha).add(&beta);
+    let select = |candidate: Arc<UOp>, old: Arc<UOp>| match &valid {
+        Some(pred) => UOp::try_where(pred.clone(), candidate, old).expect("mask select"),
+        None => candidate,
+    };
+    let new_max = select(next_max, old_max);
+    let new_norm = select(candidate_norm, old_norm);
+
+    let max_store = flat_index(&max_reg, &[1], &[Idx::Const(0)]).store(new_max);
+    let norm_store = flat_index(&norm_reg.after(smallvec![max_store.clone()]), &[1], &[Idx::Const(0)]).store(new_norm);
+    let mut output_stores = Vec::with_capacity(ept);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
+        let vv = load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        let candidate = old_o.mul(&alpha).add(&vv.mul(&beta));
+        let new_o = select(candidate, old_o);
+        output_stores.push(
+            flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)]).store(new_o),
+        );
+    }
+    let output_group = UOp::group(output_stores);
+    ker.push_store(output_group, o_reg.clone());
+    let ended = lp.close();
+
+    let final_o = o_reg.after(smallvec![ended.clone()]);
+    let final_norm = norm_reg.after(smallvec![ended]);
+    let denom = load_at(&final_norm, &[1], &[Idx::Const(0)]);
+    let mut stores = Vec::with_capacity(ept);
+    for j in 0..ept {
+        let dim = lane.add(&cidx((j * wave) as i64));
+        let value = load_at(&final_o, &[ept], &[Idx::Const(j as i64)]).try_div(&denom).expect("normalize");
+        stores.push(
+            flat_index(out.uop(), out.shape(), &[Idx::from(&batch), Idx::Const(0), Idx::from(&head), Idx::from(dim)])
+                .store(value),
+        );
+    }
+    ker.push_store(UOp::group(stores), out.uop().clone());
+}
+
+/// Graph-native FP32 single-query attention.
+///
+/// Q is `[B,1,H,D]`, K/V are `[B,N,H,D]`, and output is `[B,1,H,D]`.
+/// Returns `Ok(None)` when the target is not gfx942/gfx1151. No generic SDPA
+/// fallback is performed here.
+pub fn single_query_attention(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    opts: SqAttentionOpts<'_>,
+) -> crate::LaunchResult<Option<Tensor>> {
+    let qd = crate::launch::concrete_dims(q, "single-query attention", "q", 4)?;
+    let kd = crate::launch::concrete_dims(k, "single-query attention", "k", 4)?;
+    let vd = crate::launch::concrete_dims(v, "single-query attention", "v", 4)?;
+    let (b, n, h, d) = (qd[0], kd[1], qd[2], qd[3]);
+    let dtype = q.uop().dtype();
+    let masked = opts.key_lens.is_some();
+
+    ensure!(
+        qd[1] == 1,
+        crate::launch::DimMultipleSnafu {
+            kernel: "single-query attention",
+            dim: "Q sequence",
+            value: qd[1],
+            multiple: 1usize
+        }
+    );
+    ensure!(
+        kd[0] == b,
+        crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim: "K batch B", a: kd[0], b }
+    );
+    ensure!(
+        kd[2] == h,
+        crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim: "K heads H", a: kd[2], b: h }
+    );
+    ensure!(
+        kd[3] == d,
+        crate::launch::OperandDimMismatchSnafu {
+            kernel: "single-query attention",
+            dim: "K head dim D",
+            a: kd[3],
+            b: d
+        }
+    );
+    for (dim, a, expected) in
+        [("V batch B", vd[0], b), ("V sequence N", vd[1], n), ("V heads H", vd[2], h), ("V head dim D", vd[3], d)]
+    {
+        ensure!(
+            a == expected,
+            crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim, a, b: expected }
+        );
+    }
+    ensure!(
+        n > 0,
+        crate::launch::DimMultipleSnafu {
+            kernel: "single-query attention",
+            dim: "N (> 0)",
+            value: n,
+            multiple: 1usize
+        }
+    );
+    ensure!(
+        !masked || opts.include_last,
+        crate::launch::DimMultipleSnafu {
+            kernel: "single-query attention",
+            dim: "include_last (required with key_lens)",
+            value: opts.include_last as usize,
+            multiple: 1usize
+        }
+    );
+    if let Some(lens) = opts.key_lens {
+        let ld = crate::launch::concrete_dims(lens, "single-query attention", "key_lens", 1)?;
+        ensure!(
+            ld == [b],
+            crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim: "key_lens B", a: ld[0], b }
+        );
+        ensure!(
+            lens.uop().dtype() == DType::Int32,
+            crate::launch::DtypeSnafu { kernel: "single-query attention", got: lens.uop().dtype(), expected: "i32" }
+        );
+    }
+
+    crate::launch_custom(
+        &q.device(),
+        SQ_ATTENTION_SUPPORTED_ARCHS,
+        move |arch| {
+            let wave = arch.wave_size() as usize;
+            ensure!(
+                dtype == DType::Float32,
+                crate::launch::DtypeSnafu { kernel: "single-query attention", got: dtype.clone(), expected: "f32" }
+            );
+            ensure!(
+                k.uop().dtype() == DType::Float32,
+                crate::launch::DtypeSnafu { kernel: "single-query attention", got: k.uop().dtype(), expected: "f32" }
+            );
+            ensure!(
+                v.uop().dtype() == DType::Float32,
+                crate::launch::DtypeSnafu { kernel: "single-query attention", got: v.uop().dtype(), expected: "f32" }
+            );
+            ensure!(
+                d.is_multiple_of(wave),
+                crate::launch::DimMultipleSnafu {
+                    kernel: "single-query attention",
+                    dim: "D",
+                    value: d,
+                    multiple: wave
+                }
+            );
+            Ok(())
+        },
+        true,
+        move |arch| {
+            let caps = crate::ArchCaps::for_arch(arch);
+            let out = Tensor::empty(&[b, 1, h, d], DType::Float32);
+            let mut inputs = vec![q, k, v];
+            if let Some(lens) = opts.key_lens {
+                inputs.push(lens);
+            }
+            crate::graph_launch(
+                "sq_attention",
+                [h as i64, b as i64, 1],
+                caps.wave_size as i64,
+                out,
+                &inputs,
+                caps,
+                move |ker| {
+                    build_single_query_attention(ker, b, n, h, d, masked, opts.include_last);
+                    ker.finish(1)
+                },
+            )
+        },
+    )
+}

--- a/tk/src/kernels/sq_attention.rs
+++ b/tk/src/kernels/sq_attention.rs
@@ -48,14 +48,22 @@ fn f32c(v: f64) -> Arc<UOp> {
     UOp::const_(DType::Float32, ConstValue::Float(v))
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct HeadSelection {
+    pub(crate) count: usize,
+    pub(crate) total: usize,
+    pub(crate) offset: usize,
+}
+
 /// Build the one-wave single-query attention kernel.
 ///
-/// ABI is `out, q, k, v, [key_lens]`, with sequence-major `[B,S,H,D]` globals.
+/// ABI is `out, q, k, v, [key_lens]`, with sequence-major `[B,S,H,D]` Q/output
+/// and `[B,S,H_total,D]` K/V globals.
 pub(crate) fn build_single_query_attention(
     ker: &Kernel,
     b: usize,
     n: usize,
-    h: usize,
+    heads: HeadSelection,
     d: usize,
     masked: bool,
     include_last: bool,
@@ -69,16 +77,17 @@ pub(crate) fn build_single_query_attention(
     let f32 = DType::Float32;
 
     let (outs, ins) = ker.bind_abi(
-        &[GlSpec::new(&[b, 1, h, d], f32.clone())],
+        &[GlSpec::new(&[b, 1, heads.count, d], f32.clone())],
         &[
-            GlSpec::new(&[b, 1, h, d], f32.clone()),
-            GlSpec::new(&[b, n, h, d], f32.clone()),
-            GlSpec::new(&[b, n, h, d], f32.clone()),
+            GlSpec::new(&[b, 1, heads.count, d], f32.clone()),
+            GlSpec::new(&[b, n, heads.total, d], f32.clone()),
+            GlSpec::new(&[b, n, heads.total, d], f32.clone()),
         ],
     );
     let (out, q, k, v) = (outs[0].clone(), ins[0].clone(), ins[1].clone(), ins[2].clone());
     let batch = ker.grid_y();
     let head = ker.grid_x();
+    let packed_head = head.add(&cidx(heads.offset as i64));
     let lane = ker.laneid();
     let prefix = masked.then(|| {
         let lens = ker.gl(&[b], DType::Int32);
@@ -129,7 +138,8 @@ pub(crate) fn build_single_query_attention(
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let qv = load_at(&q_loop, &[ept], &[Idx::Const(j as i64)]);
-        let kv = load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        let kv =
+            load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
         dot = dot.add(&qv.mul(&kv));
     }
     let score = warp.wave_reduce_scalar(dot, |a, p| a.add(p));
@@ -146,7 +156,8 @@ pub(crate) fn build_single_query_attention(
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
-        let vv = load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        let vv =
+            load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
         let new_o = old_o.mul(&alpha).add(&vv.mul(&beta));
         output_stores.push(
             flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)]).store(new_o),
@@ -173,13 +184,14 @@ pub(crate) fn build_single_query_attention(
 
 /// Build one unnormalized online-softmax state per contiguous K/V split.
 ///
-/// ABI is `numerator, stats, q, k, v`; outputs are `[B,S,H,D]` and
-/// `[B,S,H,2]`, where the final axis of stats is `(max, norm)`.
+/// ABI is `numerator, stats, q, k, v`; K/V use `[B,N,H_total,D]`, while
+/// outputs are `[B,S,H,D]` and `[B,S,H,2]`, where the final axis of stats is
+/// `(max, norm)`.
 pub(crate) fn build_single_query_attention_partial(
     ker: &Kernel,
     b: usize,
     n: usize,
-    h: usize,
+    heads: HeadSelection,
     d: usize,
     splits: usize,
 ) {
@@ -192,16 +204,20 @@ pub(crate) fn build_single_query_attention_partial(
     let f32 = DType::Float32;
 
     let (outs, ins) = ker.bind_abi(
-        &[GlSpec::new(&[b, splits, h, d], f32.clone()), GlSpec::new(&[b, splits, h, 2], f32.clone())],
         &[
-            GlSpec::new(&[b, 1, h, d], f32.clone()),
-            GlSpec::new(&[b, n, h, d], f32.clone()),
-            GlSpec::new(&[b, n, h, d], f32.clone()),
+            GlSpec::new(&[b, splits, heads.count, d], f32.clone()),
+            GlSpec::new(&[b, splits, heads.count, 2], f32.clone()),
+        ],
+        &[
+            GlSpec::new(&[b, 1, heads.count, d], f32.clone()),
+            GlSpec::new(&[b, n, heads.total, d], f32.clone()),
+            GlSpec::new(&[b, n, heads.total, d], f32.clone()),
         ],
     );
     let (numerator, stats) = (outs[0].clone(), outs[1].clone());
     let (q, k, v) = (ins[0].clone(), ins[1].clone(), ins[2].clone());
     let head = ker.grid_x();
+    let packed_head = head.add(&cidx(heads.offset as i64));
     let batch = ker.grid_y();
     let split = ker.grid_z();
     let lane = ker.laneid();
@@ -237,7 +253,8 @@ pub(crate) fn build_single_query_attention_partial(
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let qv = load_at(&q_loop, &[ept], &[Idx::Const(j as i64)]);
-        let kv = load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        let kv =
+            load_at(k.uop(), k.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
         dot = dot.add(&qv.mul(&kv));
     }
     let score = warp.wave_reduce_scalar(dot, |a, p| a.add(p));
@@ -253,7 +270,8 @@ pub(crate) fn build_single_query_attention_partial(
     for j in 0..ept {
         let dim = lane.add(&cidx((j * wave) as i64));
         let old_o = load_at(&o_loop, &[ept], &[Idx::Const(j as i64)]);
-        let vv = load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&head), Idx::from(dim)]);
+        let vv =
+            load_at(v.uop(), v.shape(), &[Idx::from(&batch), Idx::from(&key), Idx::from(&packed_head), Idx::from(dim)]);
         output_stores.push(
             flat_index(&o_reg.after(smallvec![norm_store.clone()]), &[ept], &[Idx::Const(j as i64)])
                 .store(old_o.mul(&alpha).add(&vv.mul(&beta))),
@@ -368,7 +386,8 @@ pub(crate) fn build_single_query_attention_merge(ker: &Kernel, b: usize, h: usiz
 
 /// Graph-native FP32 single-query attention.
 ///
-/// Q is `[B,1,H,D]`, K/V are `[B,N,H,D]`, and output is `[B,1,H,D]`.
+/// Q is `[B,1,H,D]`, K/V are `[B,N,H_total,D]`, and output is `[B,1,H,D]`.
+/// The first `H` K/V heads are selected.
 /// Returns `Ok(None)` when the target is not gfx942/gfx1151. No generic SDPA
 /// fallback is performed here.
 pub fn single_query_attention(
@@ -377,13 +396,28 @@ pub fn single_query_attention(
     v: &Tensor,
     opts: SqAttentionOpts<'_>,
 ) -> crate::LaunchResult<Option<Tensor>> {
+    single_query_attention_packed(q, k, v, 0, opts)
+}
+
+/// Graph-native FP32 single-query attention over selected heads in packed K/V.
+///
+/// Q is `[B,1,H,D]`, K/V are `[B,N,H_total,D]`, and heads
+/// `head_offset..head_offset+H` are selected without materializing a slice.
+pub fn single_query_attention_packed(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    head_offset: usize,
+    opts: SqAttentionOpts<'_>,
+) -> crate::LaunchResult<Option<Tensor>> {
     let qd = crate::launch::concrete_dims(q, "single-query attention", "q", 4)?;
     let kd = crate::launch::concrete_dims(k, "single-query attention", "k", 4)?;
     let vd = crate::launch::concrete_dims(v, "single-query attention", "v", 4)?;
-    let (b, n, h, d) = (qd[0], kd[1], qd[2], qd[3]);
+    let (b, n, h, h_total, d) = (qd[0], kd[1], qd[2], kd[2], qd[3]);
     let dtype = q.uop().dtype();
     let masked = opts.key_lens.is_some();
     let splits = opts.split;
+    let heads = HeadSelection { count: h, total: h_total, offset: head_offset };
 
     ensure!(
         qd[1] == 1,
@@ -399,8 +433,13 @@ pub fn single_query_attention(
         crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim: "K batch B", a: kd[0], b }
     );
     ensure!(
-        kd[2] == h,
-        crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim: "K heads H", a: kd[2], b: h }
+        head_offset <= h_total && h <= h_total - head_offset,
+        crate::launch::OperandDimMismatchSnafu {
+            kernel: "single-query attention",
+            dim: "selected K heads (offset + H <= H_total)",
+            a: head_offset.saturating_add(h),
+            b: h_total
+        }
     );
     ensure!(
         kd[3] == d,
@@ -411,9 +450,12 @@ pub fn single_query_attention(
             b: d
         }
     );
-    for (dim, a, expected) in
-        [("V batch B", vd[0], b), ("V sequence N", vd[1], n), ("V heads H", vd[2], h), ("V head dim D", vd[3], d)]
-    {
+    for (dim, a, expected) in [
+        ("V batch B", vd[0], b),
+        ("V sequence N", vd[1], n),
+        ("V total heads H_total", vd[2], h_total),
+        ("V head dim D", vd[3], d),
+    ] {
         ensure!(
             a == expected,
             crate::launch::OperandDimMismatchSnafu { kernel: "single-query attention", dim, a, b: expected }
@@ -503,7 +545,7 @@ pub fn single_query_attention(
                     &inputs,
                     caps,
                     move |ker| {
-                        build_single_query_attention(ker, b, n, h, d, masked, opts.include_last);
+                        build_single_query_attention(ker, b, n, heads, d, masked, opts.include_last);
                         ker.finish(1)
                     },
                 )
@@ -519,7 +561,7 @@ pub fn single_query_attention(
                     &[q, k, v],
                     caps,
                     move |ker| {
-                        build_single_query_attention_partial(ker, b, n, h, d, splits);
+                        build_single_query_attention_partial(ker, b, n, heads, d, splits);
                         ker.finish(2)
                     },
                 )?;

--- a/tk/src/lib.rs
+++ b/tk/src/lib.rs
@@ -72,6 +72,7 @@ pub use kernels::fa::{
 pub use kernels::kmeans::{kmeans_assign, kmeans_update};
 pub use kernels::knn::knn;
 pub use kernels::matmul::matmul;
+pub use kernels::sq_attention::{SqAttentionOpts, single_query_attention};
 pub use launch::{Error as LaunchError, Result as LaunchResult};
 
 // ── Author your own kernel (the tile DSL) ───────────────────────────────────

--- a/tk/src/lib.rs
+++ b/tk/src/lib.rs
@@ -66,7 +66,7 @@ pub const WARP_THREADS: usize = 64;
 const _: () = assert!(WARP_THREADS == svod_dtype::AmdArch::Gfx942.wave_size() as usize);
 
 // ── Use the built-in kernels (Tensor in → Tensor out) ───────────────────────
-pub use kernels::fa::{FaOpts, flash_attention, flash_attention_with};
+pub use kernels::fa::{FLASH_ATTENTION_SEQUENCE_MULTIPLE, FaOpts, flash_attention, flash_attention_with};
 pub use kernels::kmeans::{kmeans_assign, kmeans_update};
 pub use kernels::knn::knn;
 pub use kernels::matmul::matmul;

--- a/tk/src/lib.rs
+++ b/tk/src/lib.rs
@@ -72,7 +72,7 @@ pub use kernels::fa::{
 pub use kernels::kmeans::{kmeans_assign, kmeans_update};
 pub use kernels::knn::knn;
 pub use kernels::matmul::matmul;
-pub use kernels::sq_attention::{SqAttentionOpts, single_query_attention};
+pub use kernels::sq_attention::{SqAttentionOpts, single_query_attention, single_query_attention_packed};
 pub use launch::{Error as LaunchError, Result as LaunchResult};
 
 // ── Author your own kernel (the tile DSL) ───────────────────────────────────

--- a/tk/src/lib.rs
+++ b/tk/src/lib.rs
@@ -66,7 +66,9 @@ pub const WARP_THREADS: usize = 64;
 const _: () = assert!(WARP_THREADS == svod_dtype::AmdArch::Gfx942.wave_size() as usize);
 
 // ── Use the built-in kernels (Tensor in → Tensor out) ───────────────────────
-pub use kernels::fa::{FLASH_ATTENTION_SEQUENCE_MULTIPLE, FaOpts, flash_attention, flash_attention_with};
+pub use kernels::fa::{
+    FLASH_ATTENTION_SEQUENCE_MULTIPLE, FaOpts, flash_attention, flash_attention_supported, flash_attention_with,
+};
 pub use kernels::kmeans::{kmeans_assign, kmeans_update};
 pub use kernels::knn::knn;
 pub use kernels::matmul::matmul;

--- a/tk/src/test/unit/fa.rs
+++ b/tk/src/test/unit/fa.rs
@@ -43,6 +43,7 @@ fn dummy_fa_buffers(b: usize, n: usize, h: usize, h_kv: usize, d: usize) -> Vec<
 #[test]
 fn test_target_gate_rejects_non_gfx942() {
     use crate::kernels::fa::FA_SUPPORTED_ARCHS;
+    assert!(!crate::flash_attention_supported(&DeviceSpec::Cpu));
     let err = crate::target::check_target(&DeviceSpec::Cpu, FA_SUPPORTED_ARCHS);
     assert!(
         matches!(err, Err(crate::launch::Error::UnsupportedArch { .. })),

--- a/tk/src/test/unit/mod.rs
+++ b/tk/src/test/unit/mod.rs
@@ -16,4 +16,5 @@ mod proptests;
 mod reductions;
 mod scaffold;
 mod shuffle;
+mod sq_attention;
 mod swizzle;

--- a/tk/src/test/unit/sq_attention.rs
+++ b/tk/src/test/unit/sq_attention.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use svod_dtype::{AmdArch, DType, DeviceSpec};
+use svod_ir::{Op, UOp};
+use svod_tensor::Tensor;
+
+use crate::kernels::sq_attention::{SQ_ATTENTION_SUPPORTED_ARCHS, SqAttentionOpts, build_single_query_attention};
+use crate::{ArchCaps, Kernel};
+
+fn buffers(b: usize, n: usize, h: usize, d: usize, masked: bool) -> Vec<Arc<UOp>> {
+    let mut bufs = vec![
+        UOp::new_buffer(DeviceSpec::Cpu, b * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * n * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * n * h * d, DType::Float32),
+    ];
+    if masked {
+        bufs.push(UOp::new_buffer(DeviceSpec::Cpu, b, DType::Int32));
+    }
+    bufs
+}
+
+fn sink(caps: ArchCaps, masked: bool) -> Arc<UOp> {
+    let (b, n, h, d) = (2, 5, 3, 64);
+    let ker =
+        Kernel::new("sq_attention", [h as i64, b as i64, 1], caps.wave_size as i64, buffers(b, n, h, d, masked), caps);
+    build_single_query_attention(&ker, b, n, h, d, masked, masked);
+    ker.finish(1)
+}
+
+#[test]
+fn sq_attention_graph_shape_both_arches() {
+    for caps in [ArchCaps::GFX942, ArchCaps::for_arch(AmdArch::Gfx1151)] {
+        for masked in [false, true] {
+            let topo = sink(caps, masked).toposort();
+            let shuffles = topo.iter().filter(|u| matches!(u.op(), Op::Custom { .. })).count();
+            assert_eq!(shuffles, caps.wave_size.ilog2() as usize, "{:?}: one XOR reduction", caps.arch);
+            assert!(
+                topo.iter().any(|u| matches!(u.op(), Op::Unary(svod_ir::UnaryOp::Exp2, ..))),
+                "{:?}: exp2",
+                caps.arch
+            );
+            assert!(topo.iter().any(|u| matches!(u.op(), Op::Range { .. })), "{:?}: streamed N loop", caps.arch);
+            assert!(!topo.iter().any(|u| matches!(u.op(), Op::DefineLocal(_))), "{:?}: no LDS", caps.arch);
+            assert!(!topo.iter().any(|u| matches!(u.op(), Op::Wmma { .. })), "{:?}: no MFMA/WMMA", caps.arch);
+            assert!(!topo.iter().any(|u| matches!(u.op(), Op::Barrier { .. })), "{:?}: no barrier", caps.arch);
+        }
+    }
+}
+
+#[test]
+fn sq_attention_renders_both_arches() {
+    for arch in [AmdArch::Gfx942, AmdArch::Gfx1151] {
+        let lowered = svod_schedule::graph_rewrite(
+            &svod_schedule::symbolic::pm_lower_index_dtype(),
+            sink(ArchCaps::for_arch(arch), true),
+            &mut (),
+        );
+        let program = svod_codegen::program_pipeline::program_from_sink(lowered, DeviceSpec::Cpu);
+        let linearized = svod_codegen::program_pipeline::do_linearize(&program).expect("linearize");
+        let linear = linearized.toposort().into_iter().find(|u| matches!(u.op(), Op::Linear { .. })).expect("LINEAR");
+        let renderer = svod_codegen::llvm::LlvmTextRenderer::amd(arch);
+        let code =
+            svod_codegen::traits::Renderer::render(&renderer, &linear, Some("sq_attention")).expect("render").code;
+        assert!(code.contains("llvm.amdgcn.ds.bpermute"), "{arch:?}: shuffle rendered");
+        assert!(!code.contains("@local"), "{arch:?}: no LDS allocation");
+    }
+}
+
+fn supported_device() -> bool {
+    crate::target::check_target(&Tensor::empty(&[1], DType::Float32).device(), SQ_ATTENTION_SUPPORTED_ARCHS).is_ok()
+}
+
+fn cpu_reference(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    dims: (usize, usize, usize, usize),
+    lens: Option<&[i32]>,
+) -> Vec<f32> {
+    let (b, n, h, d) = dims;
+    let mut out = vec![0.0; b * h * d];
+    for bi in 0..b {
+        for hi in 0..h {
+            let valid = |ni: usize| lens.is_none_or(|ls| ni < ls[bi] as usize || ni + 1 == n);
+            let mut scores = vec![f32::NEG_INFINITY; n];
+            for (ni, score) in scores.iter_mut().enumerate().filter(|(ni, _)| valid(*ni)) {
+                let mut dot = 0.0;
+                for di in 0..d {
+                    dot += q[(bi * h + hi) * d + di] * k[((bi * n + ni) * h + hi) * d + di];
+                }
+                *score = dot / (d as f32).sqrt();
+            }
+            let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let weights: Vec<f32> = scores.iter().map(|x| (*x - max).exp()).collect();
+            let norm: f32 = weights.iter().sum();
+            for di in 0..d {
+                for ni in 0..n {
+                    out[(bi * h + hi) * d + di] += weights[ni] * v[((bi * n + ni) * h + hi) * d + di] / norm;
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+#[ignore]
+fn sq_attention_numerical_amd() {
+    if !supported_device() {
+        eprintln!("skip sq_attention_numerical_amd: unsupported device/toolchain");
+        return;
+    }
+    let (b, n, h, d) = (2, 17, 3, 64);
+    let mut q = Tensor::randn(&[b, 1, h, d]).expect("q");
+    let mut k = Tensor::randn(&[b, n, h, d]).expect("k");
+    let mut v = Tensor::randn(&[b, n, h, d]).expect("v");
+    q.realize().expect("realize q");
+    k.realize().expect("realize k");
+    v.realize().expect("realize v");
+    let qv = q.as_vec::<f32>().expect("q vec");
+    let kv = k.as_vec::<f32>().expect("k vec");
+    let vv = v.as_vec::<f32>().expect("v vec");
+
+    for lens in [None, Some(vec![7i32, 13])] {
+        let mut lens_t = lens.as_ref().map(|x| Tensor::from_slice(x.as_slice()));
+        if let Some(t) = &mut lens_t {
+            t.realize().expect("realize lens");
+        }
+        let opts = SqAttentionOpts { key_lens: lens_t.as_ref(), include_last: lens.is_some() };
+        let mut got = crate::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
+        got.realize().expect("realize output");
+        let got = got.as_vec::<f32>().expect("output vec");
+        let expected = cpu_reference(&qv, &kv, &vv, (b, n, h, d), lens.as_deref());
+        let max_abs = got.iter().zip(&expected).map(|(a, e)| (a - e).abs()).fold(0.0f32, f32::max);
+        assert!(max_abs < 2e-4, "max abs error {max_abs}");
+    }
+}

--- a/tk/src/test/unit/sq_attention.rs
+++ b/tk/src/test/unit/sq_attention.rs
@@ -4,7 +4,10 @@ use svod_dtype::{AmdArch, DType, DeviceSpec};
 use svod_ir::{Op, UOp};
 use svod_tensor::Tensor;
 
-use crate::kernels::sq_attention::{SQ_ATTENTION_SUPPORTED_ARCHS, SqAttentionOpts, build_single_query_attention};
+use crate::kernels::sq_attention::{
+    SQ_ATTENTION_SUPPORTED_ARCHS, SqAttentionOpts, build_single_query_attention, build_single_query_attention_merge,
+    build_single_query_attention_partial,
+};
 use crate::{ArchCaps, Kernel};
 
 fn buffers(b: usize, n: usize, h: usize, d: usize, masked: bool) -> Vec<Arc<UOp>> {
@@ -28,6 +31,35 @@ fn sink(caps: ArchCaps, masked: bool) -> Arc<UOp> {
     ker.finish(1)
 }
 
+fn split_sinks(caps: ArchCaps, splits: usize) -> (Arc<UOp>, Arc<UOp>) {
+    let (b, n, h, d) = (2, 20, 3, 64);
+    let partial_buffers = vec![
+        UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * 2, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * n * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * n * h * d, DType::Float32),
+    ];
+    let partial = Kernel::new(
+        "sq_attention_partial",
+        [h as i64, b as i64, splits as i64],
+        caps.wave_size as i64,
+        partial_buffers,
+        caps,
+    );
+    build_single_query_attention_partial(&partial, b, n, h, d, splits);
+    let partial = partial.finish(2);
+
+    let merge_buffers = vec![
+        UOp::new_buffer(DeviceSpec::Cpu, b * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * 2, DType::Float32),
+    ];
+    let merge = Kernel::new("sq_attention_merge", [h as i64, b as i64, 1], caps.wave_size as i64, merge_buffers, caps);
+    build_single_query_attention_merge(&merge, b, h, d, splits);
+    (partial, merge.finish(1))
+}
+
 #[test]
 fn sq_attention_graph_shape_both_arches() {
     for caps in [ArchCaps::GFX942, ArchCaps::for_arch(AmdArch::Gfx1151)] {
@@ -45,25 +77,46 @@ fn sq_attention_graph_shape_both_arches() {
             assert!(!topo.iter().any(|u| matches!(u.op(), Op::Wmma { .. })), "{:?}: no MFMA/WMMA", caps.arch);
             assert!(!topo.iter().any(|u| matches!(u.op(), Op::Barrier { .. })), "{:?}: no barrier", caps.arch);
         }
+        let (partial, merge) = split_sinks(caps, 4);
+        for (name, graph) in [("partial", partial), ("merge", merge)] {
+            let topo = graph.toposort();
+            assert!(topo.iter().any(|u| matches!(u.op(), Op::Range { .. })), "{:?}: split {name} loop", caps.arch);
+            assert!(!topo.iter().any(|u| matches!(u.op(), Op::DefineLocal(_))), "{:?}: split {name} no LDS", caps.arch);
+            assert!(
+                !topo.iter().any(|u| matches!(u.op(), Op::Wmma { .. })),
+                "{:?}: split {name} no MFMA/WMMA",
+                caps.arch
+            );
+            assert!(
+                !topo.iter().any(|u| matches!(u.op(), Op::Barrier { .. })),
+                "{:?}: split {name} no barrier",
+                caps.arch
+            );
+        }
     }
 }
 
 #[test]
 fn sq_attention_renders_both_arches() {
     for arch in [AmdArch::Gfx942, AmdArch::Gfx1151] {
-        let lowered = svod_schedule::graph_rewrite(
-            &svod_schedule::symbolic::pm_lower_index_dtype(),
-            sink(ArchCaps::for_arch(arch), true),
-            &mut (),
-        );
-        let program = svod_codegen::program_pipeline::program_from_sink(lowered, DeviceSpec::Cpu);
-        let linearized = svod_codegen::program_pipeline::do_linearize(&program).expect("linearize");
-        let linear = linearized.toposort().into_iter().find(|u| matches!(u.op(), Op::Linear { .. })).expect("LINEAR");
-        let renderer = svod_codegen::llvm::LlvmTextRenderer::amd(arch);
-        let code =
-            svod_codegen::traits::Renderer::render(&renderer, &linear, Some("sq_attention")).expect("render").code;
-        assert!(code.contains("llvm.amdgcn.ds.bpermute"), "{arch:?}: shuffle rendered");
-        assert!(!code.contains("@local"), "{arch:?}: no LDS allocation");
+        let caps = ArchCaps::for_arch(arch);
+        let (partial, merge) = split_sinks(caps, 4);
+        for (name, graph, shuffle) in [
+            ("sq_attention", sink(caps, true), true),
+            ("sq_attention_partial", partial, true),
+            ("sq_attention_merge", merge, false),
+        ] {
+            let lowered =
+                svod_schedule::graph_rewrite(&svod_schedule::symbolic::pm_lower_index_dtype(), graph, &mut ());
+            let program = svod_codegen::program_pipeline::program_from_sink(lowered, DeviceSpec::Cpu);
+            let linearized = svod_codegen::program_pipeline::do_linearize(&program).expect("linearize");
+            let linear =
+                linearized.toposort().into_iter().find(|u| matches!(u.op(), Op::Linear { .. })).expect("LINEAR");
+            let renderer = svod_codegen::llvm::LlvmTextRenderer::amd(arch);
+            let code = svod_codegen::traits::Renderer::render(&renderer, &linear, Some(name)).expect("render").code;
+            assert_eq!(code.contains("llvm.amdgcn.ds.bpermute"), shuffle, "{arch:?}: {name} shuffle rendering");
+            assert!(!code.contains("@local"), "{arch:?}: {name} no LDS allocation");
+        }
     }
 }
 
@@ -111,7 +164,7 @@ fn sq_attention_numerical_amd() {
         eprintln!("skip sq_attention_numerical_amd: unsupported device/toolchain");
         return;
     }
-    let (b, n, h, d) = (2, 17, 3, 64);
+    let (b, n, h, d) = (2, 20, 3, 64);
     let mut q = Tensor::randn(&[b, 1, h, d]).expect("q");
     let mut k = Tensor::randn(&[b, n, h, d]).expect("k");
     let mut v = Tensor::randn(&[b, n, h, d]).expect("v");
@@ -122,17 +175,19 @@ fn sq_attention_numerical_amd() {
     let kv = k.as_vec::<f32>().expect("k vec");
     let vv = v.as_vec::<f32>().expect("v vec");
 
-    for lens in [None, Some(vec![7i32, 13])] {
-        let mut lens_t = lens.as_ref().map(|x| Tensor::from_slice(x.as_slice()));
-        if let Some(t) = &mut lens_t {
-            t.realize().expect("realize lens");
+    for (lens, splits) in [(None, vec![1, 2, 4]), (Some(vec![7i32, 13]), vec![1])] {
+        for split in splits {
+            let mut lens_t = lens.as_ref().map(|x| Tensor::from_slice(x.as_slice()));
+            if let Some(t) = &mut lens_t {
+                t.realize().expect("realize lens");
+            }
+            let opts = SqAttentionOpts { key_lens: lens_t.as_ref(), include_last: lens.is_some(), split };
+            let mut got = crate::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
+            got.realize().expect("realize output");
+            let got = got.as_vec::<f32>().expect("output vec");
+            let expected = cpu_reference(&qv, &kv, &vv, (b, n, h, d), lens.as_deref());
+            let max_abs = got.iter().zip(&expected).map(|(a, e)| (a - e).abs()).fold(0.0f32, f32::max);
+            assert!(max_abs < 2e-4, "split {split} max abs error {max_abs}");
         }
-        let opts = SqAttentionOpts { key_lens: lens_t.as_ref(), include_last: lens.is_some() };
-        let mut got = crate::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
-        got.realize().expect("realize output");
-        let got = got.as_vec::<f32>().expect("output vec");
-        let expected = cpu_reference(&qv, &kv, &vv, (b, n, h, d), lens.as_deref());
-        let max_abs = got.iter().zip(&expected).map(|(a, e)| (a - e).abs()).fold(0.0f32, f32::max);
-        assert!(max_abs < 2e-4, "max abs error {max_abs}");
     }
 }

--- a/tk/src/test/unit/sq_attention.rs
+++ b/tk/src/test/unit/sq_attention.rs
@@ -5,8 +5,8 @@ use svod_ir::{Op, UOp};
 use svod_tensor::Tensor;
 
 use crate::kernels::sq_attention::{
-    SQ_ATTENTION_SUPPORTED_ARCHS, SqAttentionOpts, build_single_query_attention, build_single_query_attention_merge,
-    build_single_query_attention_partial,
+    HeadSelection, SQ_ATTENTION_SUPPORTED_ARCHS, SqAttentionOpts, build_single_query_attention,
+    build_single_query_attention_merge, build_single_query_attention_partial,
 };
 use crate::{ArchCaps, Kernel};
 
@@ -24,21 +24,27 @@ fn buffers(b: usize, n: usize, h: usize, d: usize, masked: bool) -> Vec<Arc<UOp>
 }
 
 fn sink(caps: ArchCaps, masked: bool) -> Arc<UOp> {
-    let (b, n, h, d) = (2, 5, 3, 64);
-    let ker =
-        Kernel::new("sq_attention", [h as i64, b as i64, 1], caps.wave_size as i64, buffers(b, n, h, d, masked), caps);
-    build_single_query_attention(&ker, b, n, h, d, masked, masked);
+    let (b, n, h, h_total, d, head_offset) = (2, 5, 3, 7, 64, 2);
+    let ker = Kernel::new(
+        "sq_attention",
+        [h as i64, b as i64, 1],
+        caps.wave_size as i64,
+        buffers(b, n, h_total, d, masked),
+        caps,
+    );
+    let heads = HeadSelection { count: h, total: h_total, offset: head_offset };
+    build_single_query_attention(&ker, b, n, heads, d, masked, masked);
     ker.finish(1)
 }
 
 fn split_sinks(caps: ArchCaps, splits: usize) -> (Arc<UOp>, Arc<UOp>) {
-    let (b, n, h, d) = (2, 20, 3, 64);
+    let (b, n, h, h_total, d, head_offset) = (2, 20, 3, 7, 64, 2);
     let partial_buffers = vec![
         UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * d, DType::Float32),
         UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * 2, DType::Float32),
         UOp::new_buffer(DeviceSpec::Cpu, b * h * d, DType::Float32),
-        UOp::new_buffer(DeviceSpec::Cpu, b * n * h * d, DType::Float32),
-        UOp::new_buffer(DeviceSpec::Cpu, b * n * h * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * n * h_total * d, DType::Float32),
+        UOp::new_buffer(DeviceSpec::Cpu, b * n * h_total * d, DType::Float32),
     ];
     let partial = Kernel::new(
         "sq_attention_partial",
@@ -47,7 +53,8 @@ fn split_sinks(caps: ArchCaps, splits: usize) -> (Arc<UOp>, Arc<UOp>) {
         partial_buffers,
         caps,
     );
-    build_single_query_attention_partial(&partial, b, n, h, d, splits);
+    let heads = HeadSelection { count: h, total: h_total, offset: head_offset };
+    build_single_query_attention_partial(&partial, b, n, heads, d, splits);
     let partial = partial.finish(2);
 
     let merge_buffers = vec![
@@ -124,14 +131,32 @@ fn supported_device() -> bool {
     crate::target::check_target(&Tensor::empty(&[1], DType::Float32).device(), SQ_ATTENTION_SUPPORTED_ARCHS).is_ok()
 }
 
+#[test]
+fn sq_attention_packed_validates_head_geometry() {
+    let q = Tensor::empty(&[1, 1, 3, 64], DType::Float32);
+    let k = Tensor::empty(&[1, 5, 4, 64], DType::Float32);
+    let v = Tensor::empty(&[1, 5, 4, 64], DType::Float32);
+    let err = crate::single_query_attention_packed(&q, &k, &v, 2, SqAttentionOpts::default())
+        .err()
+        .expect("out-of-range heads");
+    assert!(matches!(err, crate::LaunchError::OperandDimMismatch { .. }));
+
+    let bad_v = Tensor::empty(&[1, 5, 5, 64], DType::Float32);
+    let err = crate::single_query_attention_packed(&q, &k, &bad_v, 1, SqAttentionOpts::default())
+        .err()
+        .expect("mismatched total heads");
+    assert!(matches!(err, crate::LaunchError::OperandDimMismatch { .. }));
+}
+
 fn cpu_reference(
     q: &[f32],
     k: &[f32],
     v: &[f32],
-    dims: (usize, usize, usize, usize),
+    dims: (usize, usize, usize, usize, usize),
+    head_offset: usize,
     lens: Option<&[i32]>,
 ) -> Vec<f32> {
-    let (b, n, h, d) = dims;
+    let (b, n, h, h_total, d) = dims;
     let mut out = vec![0.0; b * h * d];
     for bi in 0..b {
         for hi in 0..h {
@@ -140,7 +165,7 @@ fn cpu_reference(
             for (ni, score) in scores.iter_mut().enumerate().filter(|(ni, _)| valid(*ni)) {
                 let mut dot = 0.0;
                 for di in 0..d {
-                    dot += q[(bi * h + hi) * d + di] * k[((bi * n + ni) * h + hi) * d + di];
+                    dot += q[(bi * h + hi) * d + di] * k[((bi * n + ni) * h_total + hi + head_offset) * d + di];
                 }
                 *score = dot / (d as f32).sqrt();
             }
@@ -149,7 +174,8 @@ fn cpu_reference(
             let norm: f32 = weights.iter().sum();
             for di in 0..d {
                 for ni in 0..n {
-                    out[(bi * h + hi) * d + di] += weights[ni] * v[((bi * n + ni) * h + hi) * d + di] / norm;
+                    out[(bi * h + hi) * d + di] +=
+                        weights[ni] * v[((bi * n + ni) * h_total + hi + head_offset) * d + di] / norm;
                 }
             }
         }
@@ -164,10 +190,10 @@ fn sq_attention_numerical_amd() {
         eprintln!("skip sq_attention_numerical_amd: unsupported device/toolchain");
         return;
     }
-    let (b, n, h, d) = (2, 20, 3, 64);
+    let (b, n, h, h_total, d, head_offset) = (2, 20, 3, 7, 64, 2);
     let mut q = Tensor::randn(&[b, 1, h, d]).expect("q");
-    let mut k = Tensor::randn(&[b, n, h, d]).expect("k");
-    let mut v = Tensor::randn(&[b, n, h, d]).expect("v");
+    let mut k = Tensor::randn(&[b, n, h_total, d]).expect("k");
+    let mut v = Tensor::randn(&[b, n, h_total, d]).expect("v");
     q.realize().expect("realize q");
     k.realize().expect("realize k");
     v.realize().expect("realize v");
@@ -182,10 +208,12 @@ fn sq_attention_numerical_amd() {
                 t.realize().expect("realize lens");
             }
             let opts = SqAttentionOpts { key_lens: lens_t.as_ref(), include_last: lens.is_some(), split };
-            let mut got = crate::single_query_attention(&q, &k, &v, opts).expect("sq attention").expect("supported");
+            let mut got = crate::single_query_attention_packed(&q, &k, &v, head_offset, opts)
+                .expect("sq attention")
+                .expect("supported");
             got.realize().expect("realize output");
             let got = got.as_vec::<f32>().expect("output vec");
-            let expected = cpu_reference(&qv, &kv, &vv, (b, n, h, d), lens.as_deref());
+            let expected = cpu_reference(&qv, &kv, &vv, (b, n, h, h_total, d), head_offset, lens.as_deref());
             let max_abs = got.iter().zip(&expected).map(|(a, e)| (a - e).abs()).fold(0.0f32, f32::max);
             assert!(max_abs < 2e-4, "split {split} max abs error {max_abs}");
         }

--- a/tk/src/test/unit/sq_attention.rs
+++ b/tk/src/test/unit/sq_attention.rs
@@ -37,8 +37,8 @@ fn sink(caps: ArchCaps, masked: bool) -> Arc<UOp> {
     ker.finish(1)
 }
 
-fn split_sinks(caps: ArchCaps, splits: usize) -> (Arc<UOp>, Arc<UOp>) {
-    let (b, n, h, h_total, d, head_offset) = (2, 20, 3, 7, 64, 2);
+fn split_sinks(caps: ArchCaps, splits: usize, d: usize) -> (Arc<UOp>, Arc<UOp>) {
+    let (b, n, h, h_total, head_offset) = (2, 20, 3, 7, 2);
     let partial_buffers = vec![
         UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * d, DType::Float32),
         UOp::new_buffer(DeviceSpec::Cpu, b * splits * h * 2, DType::Float32),
@@ -84,21 +84,36 @@ fn sq_attention_graph_shape_both_arches() {
             assert!(!topo.iter().any(|u| matches!(u.op(), Op::Wmma { .. })), "{:?}: no MFMA/WMMA", caps.arch);
             assert!(!topo.iter().any(|u| matches!(u.op(), Op::Barrier { .. })), "{:?}: no barrier", caps.arch);
         }
-        let (partial, merge) = split_sinks(caps, 4);
-        for (name, graph) in [("partial", partial), ("merge", merge)] {
-            let topo = graph.toposort();
-            assert!(topo.iter().any(|u| matches!(u.op(), Op::Range { .. })), "{:?}: split {name} loop", caps.arch);
-            assert!(!topo.iter().any(|u| matches!(u.op(), Op::DefineLocal(_))), "{:?}: split {name} no LDS", caps.arch);
-            assert!(
-                !topo.iter().any(|u| matches!(u.op(), Op::Wmma { .. })),
-                "{:?}: split {name} no MFMA/WMMA",
+        for d in [64, 128] {
+            let (partial, merge) = split_sinks(caps, 4, d);
+            let partial_topo = partial.toposort();
+            let partial_shuffles = partial_topo.iter().filter(|u| matches!(u.op(), Op::Custom { .. })).count();
+            let groups = caps.wave_size / 8;
+            let expected = 3 + 2 * caps.wave_size.ilog2() as usize + groups;
+            assert_eq!(
+                partial_shuffles, expected,
+                "{:?} D={d}: width-8 dot, tile reductions, and beta broadcasts",
                 caps.arch
             );
-            assert!(
-                !topo.iter().any(|u| matches!(u.op(), Op::Barrier { .. })),
-                "{:?}: split {name} no barrier",
-                caps.arch
-            );
+            for (name, graph) in [("partial", partial), ("merge", merge)] {
+                let topo = graph.toposort();
+                assert!(topo.iter().any(|u| matches!(u.op(), Op::Range { .. })), "{:?}: split {name} loop", caps.arch);
+                assert!(
+                    !topo.iter().any(|u| matches!(u.op(), Op::DefineLocal(_))),
+                    "{:?}: split {name} no LDS",
+                    caps.arch
+                );
+                assert!(
+                    !topo.iter().any(|u| matches!(u.op(), Op::Wmma { .. })),
+                    "{:?}: split {name} no MFMA/WMMA",
+                    caps.arch
+                );
+                assert!(
+                    !topo.iter().any(|u| matches!(u.op(), Op::Barrier { .. })),
+                    "{:?}: split {name} no barrier",
+                    caps.arch
+                );
+            }
         }
     }
 }
@@ -107,7 +122,7 @@ fn sq_attention_graph_shape_both_arches() {
 fn sq_attention_renders_both_arches() {
     for arch in [AmdArch::Gfx942, AmdArch::Gfx1151] {
         let caps = ArchCaps::for_arch(arch);
-        let (partial, merge) = split_sinks(caps, 4);
+        let (partial, merge) = split_sinks(caps, 4, 64);
         for (name, graph, shuffle) in [
             ("sq_attention", sink(caps, true), true),
             ("sq_attention_partial", partial, true),
@@ -218,4 +233,35 @@ fn sq_attention_numerical_amd() {
             assert!(max_abs < 2e-4, "split {split} max abs error {max_abs}");
         }
     }
+
+    // Production cross-cache geometry. A 150-key chunk leaves a ragged width-8
+    // tile on both wave64 (8 groups) and wave32 (4 groups).
+    let (b, n, h, h_total, d, head_offset) = (5, 1500, 20, 24, 64, 2);
+    let mut q = Tensor::randn(&[b, 1, h, d]).expect("production q");
+    let mut k = Tensor::randn(&[b, n, h_total, d]).expect("production k");
+    let mut v = Tensor::randn(&[b, n, h_total, d]).expect("production v");
+    q.realize().expect("realize production q");
+    k.realize().expect("realize production k");
+    v.realize().expect("realize production v");
+    let expected = cpu_reference(
+        &q.as_vec::<f32>().expect("production q vec"),
+        &k.as_vec::<f32>().expect("production k vec"),
+        &v.as_vec::<f32>().expect("production v vec"),
+        (b, n, h, h_total, d),
+        head_offset,
+        None,
+    );
+    let mut got = crate::single_query_attention_packed(
+        &q,
+        &k,
+        &v,
+        head_offset,
+        SqAttentionOpts { split: 10, ..Default::default() },
+    )
+    .expect("production sq attention")
+    .expect("production supported");
+    got.realize().expect("realize production output");
+    let got = got.as_vec::<f32>().expect("production output vec");
+    let max_abs = got.iter().zip(&expected).map(|(a, e)| (a - e).abs()).fold(0.0f32, f32::max);
+    assert!(max_abs < 2e-4, "production split 10 max abs error {max_abs}");
 }


### PR DESCRIPTION
Two additions to the Whisper model: a continuous-batching decode path and an fp16 compute switch.

## Continuous-batching decoder (`ef7dd095`)

Decode N audio windows in a step-locked loop — one JIT dispatch per token step across all active lanes, lanes drop out on EOT. Greedy-only; beam search and temperature fallback stay on the existing single-stream path.

Core primitive is `forward_step_batched` — identical math to `forward_step`, but with batch as a JIT `Variable` (`b`) instead of a constant. One plan compiled at `max_lanes` serves any `b ∈ [1, max_lanes]` via `execute_with_vars` — no recompilation per lane count.

| Component | Role |
|---|---|
| `WhisperDecoderStepBatchedJit` | Step JIT with batch dim as variable (`b: (1, 8)`) |
| `DecodeLane` | Per-window decode state (KV caches + loop state) |
| `run_batched_decode` | Step-locked loop: seed → dispatch → SDMA append → pick token |
| `transcribe_windows_batched` | End-to-end batched transcription |

## fp16 compute + device-resident KV cache (`ba55d6d0`)

Switch from fp32 to fp16, matching the OpenAI reference mixed-precision pattern.

The blocker was the host-mirrored KV cache (`Vec<f32>` round-trip each step) which pinned the device buffer to fp32. Making the cache device-resident unblocks low-precision compute.

| Change | Detail |
|---|---|
| Device-resident cache | Cache inputs are `device_local()`, seeded once via `copyin_at`, grown via SDMA append. Lane compaction relocates grown caches via `Buffer::copy_within` (new on-device same-buffer SDMA primitive). Host touches only integer offsets + logits. |
| Configurable dtype | `ModelDimensions.dtype` defaults to Float16 (settable to Float32 for CPU parity). Loader casts weights to `dims.dtype`. |
| fp32 upcast points | Softmax in the manual QKV/DTW path; logits output. LayerNorm relies on `Tensor::layernorm`'s internal fp32 upcast. K/V cache outputs cast to fp32 at prefill + step boundaries (cache buffers stay fp32 since the host round-trips them as `Vec<f32>`). |

## New device primitives

- `Buffer::copy_within(dst_off, src_off, len)` — on-device same-buffer SDMA copy for lane compaction.
- `Buffer::copyin_at(dst_off, src)` — partial-write seeding of device-local buffers via the copy engine.